### PR TITLE
Use Inertia links for internal prose anchors

### DIFF
--- a/resources/js/components/prose/ProseA.vue
+++ b/resources/js/components/prose/ProseA.vue
@@ -1,10 +1,14 @@
 <template>
-    <a :href="props.href" :target="target">
+    <Link v-if="shouldUseInertiaLink" :href="props.href" :target="linkTarget">
+        <slot />
+    </Link>
+    <a v-else :href="props.href" :target="linkTarget">
         <slot />
     </a>
 </template>
 
 <script setup lang="ts">
+import { Link } from '@inertiajs/vue3';
 import { computed } from 'vue';
 import type { PropType } from 'vue';
 
@@ -20,11 +24,35 @@ const props = defineProps({
     },
 });
 
-const target = computed(() => {
-    if (props.href.startsWith('/documents') || props.href.startsWith('http')) {
+const normalizedHref = computed(() => props.href || '');
+const linkTarget = computed(() => {
+    if (normalizedHref.value.startsWith('/documents') || normalizedHref.value.startsWith('http')) {
         return '_blank';
     }
 
     return props.target || '_self';
+});
+
+const isHttpUrl = computed(() => normalizedHref.value.startsWith('http://') || normalizedHref.value.startsWith('https://'));
+const isHashLink = computed(() => normalizedHref.value.startsWith('#'));
+const isRelativePath = computed(
+    () => normalizedHref.value.startsWith('/') || normalizedHref.value.startsWith('./') || normalizedHref.value.startsWith('../')
+);
+const isMailOrTel = computed(() => normalizedHref.value.startsWith('mailto:') || normalizedHref.value.startsWith('tel:'));
+const isSameHost = computed(() => {
+    if (!isHttpUrl.value || typeof window === 'undefined') return false;
+
+    try {
+        return new URL(normalizedHref.value).host === window.location.host;
+    } catch {
+        return false;
+    }
+});
+
+const shouldUseInertiaLink = computed(() => {
+    if (!normalizedHref.value || isMailOrTel.value) return false;
+    if (isHashLink.value || isRelativePath.value) return true;
+
+    return isHttpUrl.value && isSameHost.value;
 });
 </script>

--- a/resources/js/components/prose/ProseH2.vue
+++ b/resources/js/components/prose/ProseH2.vue
@@ -1,13 +1,14 @@
 <template>
     <h2 :id="props.id ? slugifiedId : undefined">
-        <a v-if="props.id" class="text-foreground font-normal" :href="`#${slugifiedId}`">
+        <Link v-if="props.id" class="text-foreground font-normal" :href="`#${slugifiedId}`">
             <slot />
-        </a>
+        </Link>
         <slot v-else />
     </h2>
 </template>
 
 <script setup lang="ts">
+import { Link } from '@inertiajs/vue3';
 import { computed } from 'vue';
 
 const props = defineProps<{ id?: string }>();

--- a/resources/js/components/prose/ProseH3.vue
+++ b/resources/js/components/prose/ProseH3.vue
@@ -1,13 +1,14 @@
 <template>
     <h3 :id="props.id ? slugifiedId : undefined">
-        <a v-if="props.id" class="text-foreground font-normal" :href="`#${slugifiedId}`">
+        <Link v-if="props.id" class="text-foreground font-normal" :href="`#${slugifiedId}`">
             <slot />
-        </a>
+        </Link>
         <slot v-else />
     </h3>
 </template>
 
 <script setup lang="ts">
+import { Link } from '@inertiajs/vue3';
 import { computed } from 'vue';
 
 const props = defineProps<{ id?: string }>();

--- a/resources/js/components/prose/ProseH4.vue
+++ b/resources/js/components/prose/ProseH4.vue
@@ -1,13 +1,14 @@
 <template>
     <h4 :id="props.id ? slugifiedId : undefined">
-        <a v-if="props.id" class="text-foreground font-normal" :href="`#${slugifiedId}`">
+        <Link v-if="props.id" class="text-foreground font-normal" :href="`#${slugifiedId}`">
             <slot />
-        </a>
+        </Link>
         <slot v-else />
     </h4>
 </template>
 
 <script setup lang="ts">
+import { Link } from '@inertiajs/vue3';
 import { computed } from 'vue';
 
 const props = defineProps<{ id?: string }>();

--- a/resources/js/components/prose/ProseH5.vue
+++ b/resources/js/components/prose/ProseH5.vue
@@ -1,13 +1,14 @@
 <template>
     <h5 :id="props.id ? slugifiedId : undefined">
-        <a v-if="props.id" class="text-foreground font-normal" :href="`#${slugifiedId}`">
+        <Link v-if="props.id" class="text-foreground font-normal" :href="`#${slugifiedId}`">
             <slot />
-        </a>
+        </Link>
         <slot v-else />
     </h5>
 </template>
 
 <script setup lang="ts">
+import { Link } from '@inertiajs/vue3';
 import { computed } from 'vue';
 
 const props = defineProps<{ id?: string }>();

--- a/resources/js/components/prose/ProseH6.vue
+++ b/resources/js/components/prose/ProseH6.vue
@@ -1,13 +1,14 @@
 <template>
     <h6 :id="props.id ? slugifiedId : undefined">
-        <a v-if="props.id" class="text-foreground font-normal" :href="`#${slugifiedId}`">
+        <Link v-if="props.id" class="text-foreground font-normal" :href="`#${slugifiedId}`">
             <slot />
-        </a>
+        </Link>
         <slot v-else />
     </h6>
 </template>
 
 <script setup lang="ts">
+import { Link } from '@inertiajs/vue3';
 import { computed } from 'vue';
 
 const props = defineProps<{ id?: string }>();


### PR DESCRIPTION
## Summary
- route internal and same-host links in prose content through the Inertia Link component
- ensure heading anchors use Inertia links for on-page navigation
- maintain target handling while differentiating external links from internal ones

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb330257c832dafe66156f350d454)