### PR TITLE
Add prefix requirement flag for Telegram pages

### DIFF
--- a/app/Filament/Resources/Pages/Schemas/PageForm.php
+++ b/app/Filament/Resources/Pages/Schemas/PageForm.php
@@ -110,6 +110,11 @@ class PageForm
                             ->label('إرسال رابط الصفحة مع الرد')
                             ->default(true),
 
+                        Toggle::make('quick_response_require_prefix')
+                            ->label('يتطلب كتابة "دليل" قبل العنوان')
+                            ->helperText('عند التفعيل، يجب كتابة كلمة "دليل" قبل اسم الصفحة في بوت التيليجرام')
+                            ->default(true),
+
                         Toggle::make('quick_response_customize_message')
                             ->label('تخصيص نص الرد')
                             ->reactive()

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -85,6 +85,7 @@ class Page extends Model implements Sortable
         'quick_response_customize_buttons',
         'quick_response_customize_attachments',
         'quick_response_send_link',
+        'quick_response_require_prefix',
         'quick_response_message',
         'quick_response_buttons',
         'quick_response_attachments',
@@ -101,6 +102,7 @@ class Page extends Model implements Sortable
         'quick_response_customize_buttons' => 'boolean',
         'quick_response_customize_attachments' => 'boolean',
         'quick_response_send_link' => 'boolean',
+        'quick_response_require_prefix' => 'boolean',
         'quick_response_buttons' => 'array',
         'quick_response_attachments' => 'array',
     ];

--- a/app/Services/MarkdownMigrationService.php
+++ b/app/Services/MarkdownMigrationService.php
@@ -93,6 +93,7 @@ class MarkdownMigrationService
             'extension' => pathinfo($filePath, PATHINFO_EXTENSION),
             'quick_response_enabled' => $frontmatter['quickResponseEnabled'] ?? false,
             'quick_response_send_link' => $frontmatter['quickResponseSendLink'] ?? true,
+            'quick_response_require_prefix' => $frontmatter['quickResponseRequirePrefix'] ?? true,
             'quick_response_message' => $frontmatter['quickResponseMessage'] ?? null,
             'quick_response_buttons' => $frontmatter['quickResponseButtons'] ?? [],
             'quick_response_attachments' => $frontmatter['quickResponseAttachments'] ?? [],

--- a/app/Services/QuickResponseService.php
+++ b/app/Services/QuickResponseService.php
@@ -28,6 +28,7 @@ class QuickResponseService
                     'quick_response_customize_buttons',
                     'quick_response_customize_attachments',
                     'quick_response_send_link',
+                    'quick_response_require_prefix',
                     'quick_response_message',
                     'quick_response_buttons',
                     'quick_response_attachments',
@@ -35,6 +36,36 @@ class QuickResponseService
                 ->orderBy('order')
                 ->get()
         );
+    }
+
+    /**
+     * Look up a page without requiring the "دليل" prefix.
+     */
+    public function searchWithoutPrefix(string $query): ?Page
+    {
+        $needle = mb_strtolower($query);
+
+        return $this->getCachedResponses()->first(function (Page $page) use ($needle) {
+            $requiresPrefix = $page->quick_response_require_prefix ?? true;
+
+            if ($requiresPrefix) {
+                return false;
+            }
+
+            $title = mb_strtolower($page->title);
+
+            // Exact match
+            if ($title === $needle) {
+                return true;
+            }
+
+            // Smart search: substring match if enabled
+            if ($page->smart_search && str_contains($needle, $title)) {
+                return true;
+            }
+
+            return false;
+        });
     }
 
     /**

--- a/app/Services/Telegram/Handlers/PageManagementHandler.php
+++ b/app/Services/Telegram/Handlers/PageManagementHandler.php
@@ -84,6 +84,7 @@ class PageManagementHandler extends BaseHandler
             'toggle_smart' => 'smart_search',
             'toggle_update_content' => 'update_main_content',
             'toggle_send_link' => 'send_link',
+            'toggle_require_prefix' => 'require_prefix',
         ];
 
         foreach ($toggleMap as $prefix => $stateKey) {
@@ -108,6 +109,7 @@ class PageManagementHandler extends BaseHandler
                     'smart_search' => ['تم تفعيل البحث الذكي', 'تم تعطيل البحث الذكي'],
                     'update_main_content' => ['سيتم تحديث محتوى الصفحة', 'لن يتم تحديث محتوى الصفحة'],
                     'send_link' => ['سيتم إرسال رابط الصفحة', 'لن يتم إرسال رابط الصفحة'],
+                    'require_prefix' => ['سيتطلب كتابة "دليل"', 'لن يتطلب كتابة "دليل"'],
                 ];
 
                 $this->telegram->answerCallbackQuery([
@@ -138,6 +140,7 @@ class PageManagementHandler extends BaseHandler
             'smart_search' => false,
             'update_main_content' => false,
             'send_link' => false,
+            'require_prefix' => false,
         ];
 
         $this->setState($userId, $state);
@@ -276,6 +279,7 @@ class PageManagementHandler extends BaseHandler
         if ($existingPage) {
             $state['smart_search'] = $existingPage->smart_search ?? false;
             $state['send_link'] = $existingPage->quick_response_send_link ?? false;
+            $state['require_prefix'] = $existingPage->quick_response_require_prefix ?? true;
             // update_main_content stays as user set it (default false)
         }
 
@@ -350,6 +354,7 @@ class PageManagementHandler extends BaseHandler
         $smartSearch = $state['smart_search'] ?? false;
         $updateMainContent = $state['update_main_content'] ?? false;
         $sendLink = $state['send_link'] ?? false;
+        $requirePrefix = $state['require_prefix'] ?? true;
 
         try {
             if ($state['existing_page_id']) {
@@ -363,6 +368,7 @@ class PageManagementHandler extends BaseHandler
                     'quick_response_message' => $formattedMessage,
                     'quick_response_buttons' => $buttons,
                     'quick_response_send_link' => $sendLink,
+                    'quick_response_require_prefix' => $requirePrefix,
                 ];
 
                 // Only update main content if toggle is ON
@@ -405,6 +411,7 @@ class PageManagementHandler extends BaseHandler
                     'quick_response_buttons' => $buttons,
                     'quick_response_attachments' => $attachments,
                     'quick_response_send_link' => $sendLink,
+                    'quick_response_require_prefix' => $requirePrefix,
                 ];
 
                 $page = Page::create($pageData);
@@ -588,10 +595,12 @@ class PageManagementHandler extends BaseHandler
         $smartSearch = $state['smart_search'] ?? false;
         $updateContent = $state['update_main_content'] ?? false;
         $sendLink = $state['send_link'] ?? false;
+        $requirePrefix = $state['require_prefix'] ?? true;
 
         $smartIcon = $smartSearch ? '✅' : '❌';
         $updateIcon = $updateContent ? '✅' : '❌';
         $linkIcon = $sendLink ? '✅' : '❌';
+        $prefixIcon = $requirePrefix ? '✅' : '❌';
 
         return Keyboard::make()
             ->inline()
@@ -611,6 +620,12 @@ class PageManagementHandler extends BaseHandler
                 Keyboard::inlineButton([
                     'text' => "إرسال رابط الصفحة مع الرد {$linkIcon}",
                     'callback_data' => 'toggle_send_link_'.($sendLink ? '1' : '0'),
+                ]),
+            ])
+            ->row([
+                Keyboard::inlineButton([
+                    'text' => "يتطلب كتابة \"دليل\" {$prefixIcon}",
+                    'callback_data' => 'toggle_require_prefix_'.($requirePrefix ? '1' : '0'),
                 ]),
             ]);
     }

--- a/app/Services/Telegram/Handlers/UquccSearchHandler.php
+++ b/app/Services/Telegram/Handlers/UquccSearchHandler.php
@@ -59,7 +59,15 @@ class UquccSearchHandler extends BaseHandler
             return;
         }
 
-        // Check for smart search pages - ANY message that contains a smart page title
+        $directMatch = $this->quickResponses->searchWithoutPrefix($content);
+
+        if ($directMatch) {
+            $this->sendPageResult($message, $directMatch);
+
+            return;
+        }
+
+        // Check for smart search pages - ANY message that contains a smart page title and doesn't require the prefix
         $this->checkSmartSearch($message, $content);
     }
 
@@ -72,7 +80,9 @@ class UquccSearchHandler extends BaseHandler
 
         // Search through all cached responses for smart search pages
         $page = $this->quickResponses->getCachedResponses()->first(function (Page $page) use ($needle) {
-            if (! $page->smart_search) {
+            $requiresPrefix = $page->quick_response_require_prefix ?? true;
+
+            if ($requiresPrefix || ! $page->smart_search) {
                 return false;
             }
 

--- a/database/migrations/2026_02_20_000001_add_quick_response_require_prefix_to_pages_table.php
+++ b/database/migrations/2026_02_20_000001_add_quick_response_require_prefix_to_pages_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            if (! Schema::hasColumn('pages', 'quick_response_require_prefix')) {
+                $table->boolean('quick_response_require_prefix')
+                    ->default(true)
+                    ->after('quick_response_send_link');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            if (Schema::hasColumn('pages', 'quick_response_require_prefix')) {
+                $table->dropColumn('quick_response_require_prefix');
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a per-page flag to control whether the Telegram bot requires the "دليل" prefix and expose it in the admin form
- update Telegram page management options so editors can toggle the prefix requirement, keeping existing pages enabled while new bot-created pages default to off
- respect the prefix requirement in bot lookups so pages only respond without the prefix when allowed

## Testing
- `./vendor/bin/phpunit` *(fails: binary not available in repo)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb313e3d0832d9d0dc2f9f4ede76b)