### PR TITLE
Add truth table generator tool

### DIFF
--- a/app/Services/Logic/TruthTableGenerator.php
+++ b/app/Services/Logic/TruthTableGenerator.php
@@ -1,0 +1,325 @@
+<?php
+
+namespace App\Services\Logic;
+
+use InvalidArgumentException;
+use function collect;
+
+class TruthTableGenerator
+{
+    private const OPERATOR_PRECEDENCE = [
+        'NOT' => 5,
+        'AND' => 4,
+        'OR' => 3,
+        'XOR' => 2,
+        'IMPLIES' => 2,
+        'IFF' => 1,
+    ];
+
+    private const BINARY_OPERATORS = ['AND', 'OR', 'XOR', 'IMPLIES', 'IFF'];
+
+    /**
+     * @return array{variables: string[], columns: array<int, array{label: string, node: array}>, rows: array<int, array<string, bool>>, normalized: string}
+     */
+    public function generate(string $rawExpression): array
+    {
+        $tokens = $this->tokenize($rawExpression);
+        if (empty($tokens)) {
+            throw new InvalidArgumentException('الرجاء إدخال صيغة منطقية.');
+        }
+
+        $ast = $this->parse($tokens);
+
+        $variables = $this->extractVariables($ast);
+        sort($variables, SORT_STRING);
+
+        $expressions = $this->collectExpressions($ast);
+        $columns = [
+            ...array_map(fn ($var) => ['label' => $var, 'node' => ['type' => 'VAR', 'name' => $var]], $variables),
+            ...$expressions,
+        ];
+
+        $normalized = $this->formatNode($ast);
+        if (! collect($columns)->contains(fn ($column) => $column['label'] === $normalized)) {
+            $columns[] = ['label' => $normalized, 'node' => $ast];
+        }
+
+        $rowCount = max(1, 2 ** count($variables));
+        $rows = [];
+
+        for ($i = 0; $i < $rowCount; $i++) {
+            $assignment = [];
+            foreach ($variables as $index => $variable) {
+                $bit = (($rowCount - 1 - $i) >> (count($variables) - $index - 1)) & 1;
+                $assignment[$variable] = (bool) $bit;
+            }
+
+            $row = [];
+            foreach ($columns as $column) {
+                $row[$column['label']] = $column['node']['type'] === 'VAR'
+                    ? $assignment[$column['label']]
+                    : $this->evaluate($column['node'], $assignment);
+            }
+            $rows[] = $row;
+        }
+
+        return [
+            'variables' => $variables,
+            'columns' => $columns,
+            'rows' => $rows,
+            'normalized' => $normalized,
+        ];
+    }
+
+    /**
+     * @return array<int, array{type: string, value?: bool|string}>
+     */
+    private function tokenize(string $input): array
+    {
+        $tokens = [];
+        $remaining = trim($input);
+
+        while ($remaining !== '') {
+            if (preg_match('/^\s+/u', $remaining, $match)) {
+                $remaining = mb_substr($remaining, mb_strlen($match[0]));
+                continue;
+            }
+
+            $patterns = [
+                ['/^<=>|^<->|^↔|^⟷/u', ['type' => 'IFF']],
+                ['/^->|^=>|^→/u', ['type' => 'IMPLIES']],
+                ['/^\/\\\\|^&&|^&|^∧/u', ['type' => 'AND']],
+                ['/^\\\\\/|^\|\||^∨/u', ['type' => 'OR']],
+                ['/^xor(?![A-Za-z0-9_])|^⊕|^\^/iu', ['type' => 'XOR']],
+                ['/^!|^~|^¬/u', ['type' => 'NOT']],
+                ['/^and(?![A-Za-z0-9_])/iu', ['type' => 'AND']],
+                ['/^or(?![A-Za-z0-9_])/iu', ['type' => 'OR']],
+                ['/^not(?![A-Za-z0-9_])/iu', ['type' => 'NOT']],
+                ['/^xor(?![A-Za-z0-9_])/iu', ['type' => 'XOR']],
+                ['/^\(/u', ['type' => 'LPAREN']],
+                ['/^\)/u', ['type' => 'RPAREN']],
+                ['/^⊤(?![A-Za-z0-9_])|^T(?![A-Za-z0-9_])/u', ['type' => 'CONST', 'value' => true]],
+                ['/^⊥(?![A-Za-z0-9_])|^F(?![A-Za-z0-9_])/u', ['type' => 'CONST', 'value' => false]],
+            ];
+
+            $matched = false;
+            foreach ($patterns as [$pattern, $token]) {
+                if (preg_match($pattern, $remaining, $match)) {
+                    $tokens[] = $token;
+                    $remaining = mb_substr($remaining, mb_strlen($match[0]));
+                    $matched = true;
+                    break;
+                }
+            }
+
+            if ($matched) {
+                continue;
+            }
+
+            if (preg_match('/^[A-Za-z][A-Za-z0-9_]*/u', $remaining, $match)) {
+                $tokens[] = ['type' => 'VAR', 'value' => $match[0]];
+                $remaining = mb_substr($remaining, mb_strlen($match[0]));
+                continue;
+            }
+
+            throw new InvalidArgumentException('رمز غير معروف بالقرب من: "'.mb_substr($remaining, 0, 10).'"');
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * @param array<int, array{type: string, value?: bool|string}> $tokens
+     */
+    private function parse(array $tokens): array
+    {
+        $position = 0;
+        $length = count($tokens);
+
+        $peek = fn () => $tokens[$position] ?? null;
+        $consume = fn () => $tokens[$position++] ?? null;
+
+        $parsePrimary = function () use (&$peek, &$consume, &$parseExpression): array {
+            $token = $peek();
+            if ($token === null) {
+                throw new InvalidArgumentException('صيغة غير مكتملة.');
+            }
+
+            if ($token['type'] === 'LPAREN') {
+                $consume();
+                $expr = $parseExpression();
+                if (($peek()['type'] ?? null) !== 'RPAREN') {
+                    throw new InvalidArgumentException('القوس الأيمن مفقود.');
+                }
+                $consume();
+                return $expr;
+            }
+
+            if ($token['type'] === 'VAR') {
+                $consume();
+                return ['type' => 'VAR', 'name' => $token['value']];
+            }
+
+            if ($token['type'] === 'CONST') {
+                $consume();
+                return ['type' => 'CONST', 'value' => (bool) $token['value']];
+            }
+
+            if ($token['type'] === 'NOT') {
+                $consume();
+                return ['type' => 'NOT', 'value' => $parsePrimary()];
+            }
+
+            throw new InvalidArgumentException('تعبير غير صالح، يرجى التحقق من الصيغة.');
+        };
+
+        $parseWithPrecedence = function (int $minPrecedence) use (&$parsePrimary, &$peek, &$consume, &$parseWithPrecedence): array {
+            $left = $parsePrimary();
+
+            while (true) {
+                $token = $peek();
+                if ($token === null || ! $this->isBinaryOperator($token['type'])) {
+                    break;
+                }
+
+                $precedence = self::OPERATOR_PRECEDENCE[$token['type']];
+                if ($precedence < $minPrecedence) {
+                    break;
+                }
+
+                $consume();
+                $nextMin = in_array($token['type'], ['IMPLIES', 'IFF'], true) ? $precedence : $precedence + 1;
+                $right = $parseWithPrecedence($nextMin);
+                $left = ['type' => $token['type'], 'left' => $left, 'right' => $right];
+            }
+
+            return $left;
+        };
+
+        $parseExpression = fn () => $parseWithPrecedence(1);
+
+        $ast = $parseExpression();
+        if ($position !== $length) {
+            throw new InvalidArgumentException('لم يتم استهلاك كامل الصيغة، تحقق من الأقواس أو المشغلين.');
+        }
+
+        return $ast;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, bool>  $assignment
+     */
+    private function evaluate(array $node, array $assignment): bool
+    {
+        return match ($node['type']) {
+            'VAR' => $assignment[$node['name']] ?? throw new InvalidArgumentException("لم يتم تعريف المتغير {$node['name']}."),
+            'CONST' => (bool) $node['value'],
+            'NOT' => ! $this->evaluate($node['value'], $assignment),
+            'AND' => $this->evaluate($node['left'], $assignment) && $this->evaluate($node['right'], $assignment),
+            'OR' => $this->evaluate($node['left'], $assignment) || $this->evaluate($node['right'], $assignment),
+            'XOR' => $this->evaluate($node['left'], $assignment) xor $this->evaluate($node['right'], $assignment),
+            'IMPLIES' => ! $this->evaluate($node['left'], $assignment) || $this->evaluate($node['right'], $assignment),
+            'IFF' => $this->evaluate($node['left'], $assignment) === $this->evaluate($node['right'], $assignment),
+            default => throw new InvalidArgumentException('نوع عقدة غير معروف.'),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private function formatNode(array $node): string
+    {
+        $precedence = fn (string $operator) => self::OPERATOR_PRECEDENCE[$operator];
+        $wrap = function (array $child, ?string $parentOp = null) use (&$wrap, $precedence): string {
+            if ($child['type'] === 'VAR') {
+                return (string) $child['name'];
+            }
+            if ($child['type'] === 'CONST') {
+                return $child['value'] ? '⊤' : '⊥';
+            }
+            if ($child['type'] === 'NOT') {
+                return '¬'.$wrap($child['value'], 'NOT');
+            }
+
+            $op = $child['type'];
+            $needsParens = $parentOp !== null && $precedence($op) < $precedence($parentOp);
+            $text = $wrap($child['left'], $op).' '.$this->operatorSymbol($op).' '.$wrap($child['right'], $op);
+
+            return $needsParens ? "({$text})" : $text;
+        };
+
+        if (in_array($node['type'], ['VAR', 'CONST', 'NOT'], true)) {
+            return $wrap($node);
+        }
+
+        return $wrap($node);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, true>  $seen
+     * @return array<int, array{label: string, node: array}>
+     */
+    private function collectExpressions(array $node, array &$seen = []): array
+    {
+        if (in_array($node['type'], ['VAR', 'CONST'], true)) {
+            return [];
+        }
+
+        $expressions = [];
+        if ($node['type'] === 'NOT') {
+            $expressions = [...$expressions, ...$this->collectExpressions($node['value'], $seen)];
+        } else {
+            $expressions = [
+                ...$expressions,
+                ...$this->collectExpressions($node['left'], $seen),
+                ...$this->collectExpressions($node['right'], $seen),
+            ];
+        }
+
+        $label = $this->formatNode($node);
+        if (! isset($seen[$label])) {
+            $seen[$label] = true;
+            $expressions[] = ['label' => $label, 'node' => $node];
+        }
+
+        return $expressions;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     * @param array<string, true>  $vars
+     * @return string[]
+     */
+    private function extractVariables(array $node, array &$vars = []): array
+    {
+        if ($node['type'] === 'VAR') {
+            $vars[$node['name']] = true;
+        } elseif ($node['type'] === 'NOT') {
+            $this->extractVariables($node['value'], $vars);
+        } elseif ($node['type'] !== 'CONST') {
+            $this->extractVariables($node['left'], $vars);
+            $this->extractVariables($node['right'], $vars);
+        }
+
+        return array_keys($vars);
+    }
+
+    private function isBinaryOperator(string $type): bool
+    {
+        return in_array($type, self::BINARY_OPERATORS, true);
+    }
+
+    private function operatorSymbol(string $operator): string
+    {
+        return match ($operator) {
+            'AND' => '∧',
+            'OR' => '∨',
+            'XOR' => '⊕',
+            'IMPLIES' => '→',
+            'IFF' => '↔',
+            default => $operator,
+        };
+    }
+}

--- a/app/Services/Telegram/Handlers/TruthTableHandler.php
+++ b/app/Services/Telegram/Handlers/TruthTableHandler.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Services\Telegram\Handlers;
+
+use App\Services\Logic\TruthTableGenerator;
+use InvalidArgumentException;
+use Telegram\Bot\Api;
+use Telegram\Bot\Objects\Message;
+
+class TruthTableHandler extends BaseHandler
+{
+    public function __construct(Api $telegram, private readonly TruthTableGenerator $generator)
+    {
+        parent::__construct($telegram);
+    }
+
+    public function handle(Message $message): void
+    {
+        $text = $message->getText();
+        $content = is_string($text) ? trim($text) : '';
+
+        if (! preg_match('/^\/truth(?:@[\w_]+)?\s+(.+)/us', $content, $matches)) {
+            return;
+        }
+
+        $expression = trim($matches[1] ?? '');
+        if ($expression === '') {
+            $this->reply($message, '⚠️ الرجاء إدخال صيغة منطقية بعد الأمر.');
+            return;
+        }
+
+        try {
+            $result = $this->generator->generate($expression);
+            $table = $this->renderTable($result);
+
+            $this->replyMarkdown($message, "```\n{$table}\n```");
+        } catch (InvalidArgumentException $e) {
+            $this->reply($message, '⚠️ '.$e->getMessage());
+        } catch (\Throwable $e) {
+            $this->reply($message, '❌ حدث خطأ أثناء إنشاء جدول الحقيقة.');
+        }
+    }
+
+    /**
+     * @param array{variables: string[], columns: array<int, array{label: string, node: array}>, rows: array<int, array<string, bool>>, normalized: string} $result
+     */
+    private function renderTable(array $result): string
+    {
+        $columns = array_map(fn ($column) => $column['label'], $result['columns']);
+        $widths = [];
+
+        foreach ($columns as $column) {
+            $widths[$column] = mb_strlen($column);
+        }
+
+        foreach ($result['rows'] as $row) {
+            foreach ($columns as $column) {
+                $widths[$column] = max($widths[$column], 1);
+            }
+        }
+
+        $renderLine = function (array $values) use ($columns, $widths): string {
+            $parts = [];
+            foreach ($columns as $column) {
+                $parts[] = $this->padText($values[$column], $widths[$column]);
+            }
+
+            return implode(' | ', $parts);
+        };
+
+        $lines = [
+            'Expression: '.$result['normalized'],
+            $renderLine(array_combine($columns, $columns)),
+            implode('-+-', array_map(fn ($column) => str_repeat('-', $widths[$column]), $columns)),
+        ];
+
+        foreach ($result['rows'] as $row) {
+            $values = [];
+            foreach ($columns as $column) {
+                $values[$column] = $row[$column] ? 'T' : 'F';
+            }
+            $lines[] = $renderLine($values);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function padText(string $text, int $width): string
+    {
+        $length = mb_strlen($text);
+        if ($length >= $width) {
+            return $text;
+        }
+
+        $total = $width - $length;
+        $left = intdiv($total, 2);
+        $right = $total - $left;
+
+        return str_repeat(' ', $left).$text.str_repeat(' ', $right);
+    }
+}

--- a/app/Services/TelegramBotService.php
+++ b/app/Services/TelegramBotService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Services\Logic\TruthTableGenerator;
 use App\Services\Telegram\ContentParser;
 use App\Services\Telegram\Handlers\DeepSeekChatHandler;
 use App\Services\Telegram\Handlers\InfoHandler;
@@ -11,6 +12,7 @@ use App\Services\Telegram\Handlers\LoginHandler;
 use App\Services\Telegram\Handlers\PageManagementHandler;
 use App\Services\Telegram\Handlers\PrivateForwardHandler;
 use App\Services\Telegram\Handlers\PythonExecutionHandler;
+use App\Services\Telegram\Handlers\TruthTableHandler;
 use App\Services\Telegram\Handlers\UquccListHandler;
 use App\Services\Telegram\Handlers\UquccSearchHandler;
 use Telegram\Bot\Api;
@@ -43,6 +45,7 @@ class TelegramBotService
             new InfoHandler($this->telegram),
             new PrivateForwardHandler($this->telegram),
             new InviteLinkHandler($this->telegram),
+            new TruthTableHandler($this->telegram, app(TruthTableGenerator::class)),
         ];
     }
 

--- a/resources/js/components/tools/TruthTableGenerator.vue
+++ b/resources/js/components/tools/TruthTableGenerator.vue
@@ -1,0 +1,168 @@
+<template>
+  <div class="space-y-6">
+    <Card>
+      <CardHeader>
+        <CardTitle>أدخل الصيغة المنطقية</CardTitle>
+        <p class="text-sm text-muted-foreground">
+          يدعم المحلل عدة صيغ للمُعاملات كما في أداة ستانفورد. جرّب كتابة القيم باستخدام أي من الصيغ
+          التالية.
+        </p>
+      </CardHeader>
+      <CardContent class="space-y-3">
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="sample in samples"
+            :key="sample"
+            type="button"
+            class="rounded-md border px-3 py-1 text-sm transition hover:border-primary hover:text-primary"
+            @click="() => (expression = sample)"
+          >
+            {{ sample }}
+          </button>
+        </div>
+
+        <Input
+          v-model="expression"
+          dir="ltr"
+          placeholder="مثال: p /\\ q -> ~r"
+          class="font-mono text-base"
+        />
+
+        <Alert v-if="error" variant="destructive">
+          <AlertDescription>{{ error }}</AlertDescription>
+        </Alert>
+
+        <div class="grid gap-3 md:grid-cols-2">
+          <div>
+            <h3 class="mb-2 text-sm font-semibold text-foreground/80">المعاملات (AND / OR / NOT)</h3>
+            <div class="flex flex-wrap gap-2">
+              <OperatorPill
+                v-for="operator in basicOperators"
+                :key="operator.label"
+                :label="operator.label"
+                :symbols="operator.symbols"
+              />
+            </div>
+          </div>
+          <div>
+            <h3 class="mb-2 text-sm font-semibold text-foreground/80">المحتمِلات الإضافية</h3>
+            <div class="flex flex-wrap gap-2">
+              <OperatorPill label="الاستلزام (IMPLIES)" :symbols="['->', '=>', '→']" />
+              <OperatorPill label="التكافؤ (IFF)" :symbols="['<->', '<=>', '↔']" />
+              <OperatorPill label="XOR" :symbols="['xor', '^', '⊕']" />
+              <OperatorPill label="الثوابت" :symbols="['T / ⊤', 'F / ⊥']" />
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader>
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <CardTitle>جدول الحقيقة</CardTitle>
+            <p v-if="tableData" class="text-sm text-muted-foreground">
+              الصيغة بعد التطبيع: <span class="font-mono text-foreground">{{ tableData.normalized }}</span>
+            </p>
+          </div>
+          <div v-if="tableData" class="rounded-md bg-muted px-3 py-1 text-sm font-mono text-muted-foreground">
+            {{ tableData.rows.length }} صفوف
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p v-if="!expression.trim()" class="text-muted-foreground">
+          اكتب صيغة منطقية لعرض جدول الحقيقة.
+        </p>
+        <p v-else-if="!tableData && !error" class="text-muted-foreground">يتم التحليل...</p>
+
+        <div v-if="tableData" class="overflow-x-auto">
+          <table class="min-w-full border-collapse text-center">
+            <thead>
+              <tr>
+                <th
+                  v-for="column in tableData.columns"
+                  :key="column.label"
+                  class="border border-border bg-muted/40 px-3 py-2 font-semibold text-foreground"
+                >
+                  <span class="font-mono">{{ column.label }}</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(row, index) in tableData.rows" :key="index">
+                <td
+                  v-for="column in tableData.columns"
+                  :key="column.label"
+                  class="border border-border px-3 py-2 font-mono"
+                  :class="column.label === tableData.columns.at(-1)?.label ? 'bg-muted/60 font-semibold' : ''"
+                >
+                  {{ row[column.label] ? 'T' : 'F' }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { defineComponent, h, ref, watchEffect, type PropType } from 'vue'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { generateTruthTable, type TruthTableResult } from '@/lib/truth-table'
+
+const samples = [
+  'p /\\ q -> ~r',
+  '(p or q) <-> (q or p)',
+  'not (p and q) -> (not p or not q)',
+  '(p xor q) => (p or q)'
+]
+
+const basicOperators = [
+  { label: 'AND', symbols: ['/\\', '&&', '∧', 'and'] },
+  { label: 'OR', symbols: ['\\/', '||', '∨', 'or'] },
+  { label: 'NOT', symbols: ['~', '!', '¬', 'not'] }
+]
+
+const expression = ref(samples[0])
+const error = ref<string | null>(null)
+const tableData = ref<TruthTableResult | null>(null)
+
+watchEffect(() => {
+  if (!expression.value.trim()) {
+    error.value = null
+    tableData.value = null
+    return
+  }
+
+  try {
+    tableData.value = generateTruthTable(expression.value)
+    error.value = null
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'حدث خطأ غير متوقع.'
+    tableData.value = null
+  }
+})
+defineOptions({ name: 'TruthTableGenerator' })
+
+const OperatorPill = defineComponent({
+  name: 'OperatorPill',
+  props: {
+    label: { type: String, required: true },
+    symbols: { type: Array as PropType<string[]>, required: true }
+  },
+  setup(props) {
+    return () =>
+      h('div', { class: 'flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs' }, [
+        h('span', { class: 'font-semibold text-foreground' }, props.label),
+        h('span', { class: 'text-muted-foreground' }, '•'),
+        h('span', { class: 'font-mono text-muted-foreground' }, props.symbols.join(' / '))
+      ])
+  }
+})
+</script>

--- a/resources/js/lib/truth-table.ts
+++ b/resources/js/lib/truth-table.ts
@@ -1,0 +1,300 @@
+export type Operator = 'NOT' | 'AND' | 'OR' | 'IMPLIES' | 'IFF' | 'XOR'
+
+export type Node =
+    | { type: 'VAR'; name: string }
+    | { type: 'CONST'; value: boolean }
+    | { type: 'NOT'; value: Node }
+    | { type: Exclude<Operator, 'NOT'>; left: Node; right: Node }
+
+export interface TruthTableResult {
+    variables: string[]
+    columns: { label: string; node: Node }[]
+    rows: Record<string, boolean>[]
+    normalized: string
+}
+
+type Token =
+    | { type: 'LPAREN' | 'RPAREN' }
+    | { type: 'CONST'; value: boolean }
+    | { type: 'VAR'; value: string }
+    | { type: Operator }
+
+const OPERATOR_PRECEDENCE: Record<Operator, number> = {
+    NOT: 5,
+    AND: 4,
+    OR: 3,
+    XOR: 2.5,
+    IMPLIES: 2,
+    IFF: 1
+}
+
+const BINARY_OPERATORS: Operator[] = ['AND', 'OR', 'XOR', 'IMPLIES', 'IFF']
+
+const KEYWORD_PATTERN = (word: string) => new RegExp(`^${word}(?![A-Za-z0-9_])`, 'i')
+
+export function tokenize(input: string): Token[] {
+    const tokens: Token[] = []
+    let remaining = input.trim()
+
+    while (remaining.length > 0) {
+        // Skip whitespace
+        const whitespaceMatch = remaining.match(/^\s+/)
+        if (whitespaceMatch) {
+            remaining = remaining.slice(whitespaceMatch[0].length)
+            continue
+        }
+
+        const checks: Array<[RegExp, () => Token]> = [
+            [/^(<=>|<->|↔|⟷)/, () => ({ type: 'IFF' })],
+            [/^(->|=>|→)/, () => ({ type: 'IMPLIES' })],
+            [/^(\/\\|&&|&|∧)/, () => ({ type: 'AND' })],
+            [/^(\\\/|\|\||∨)/, () => ({ type: 'OR' })],
+            [/^(xor|⊕|\^)/i, () => ({ type: 'XOR' })],
+            [/^(!|~|¬)/, () => ({ type: 'NOT' })],
+            [KEYWORD_PATTERN('and'), () => ({ type: 'AND' })],
+            [KEYWORD_PATTERN('or'), () => ({ type: 'OR' })],
+            [KEYWORD_PATTERN('xor'), () => ({ type: 'XOR' })],
+            [KEYWORD_PATTERN('not'), () => ({ type: 'NOT' })],
+            [/^[\(]/, () => ({ type: 'LPAREN' })],
+            [/^[\)]/, () => ({ type: 'RPAREN' })],
+            [/^(⊤|T)(?![A-Za-z0-9_])/, () => ({ type: 'CONST', value: true })],
+            [/^(⊥|F)(?![A-Za-z0-9_])/, () => ({ type: 'CONST', value: false })],
+            [/^[A-Za-z][A-Za-z0-9_]*/, () => {
+                const [match] = remaining.match(/^[A-Za-z][A-Za-z0-9_]*/) as RegExpMatchArray
+                return { type: 'VAR', value: match }
+            }]
+        ]
+
+        let matched = false
+        for (const [pattern, factory] of checks) {
+            const match = remaining.match(pattern)
+            if (match) {
+                tokens.push(factory())
+                remaining = remaining.slice(match[0].length)
+                matched = true
+                break
+            }
+        }
+
+        if (!matched) {
+            throw new Error(`رمز غير معروف بالقرب من: "${remaining.slice(0, 10)}"`)
+        }
+    }
+
+    return tokens
+}
+
+export function parse(tokens: Token[]): Node {
+    let position = 0
+
+    const peek = () => tokens[position]
+    const consume = () => tokens[position++]
+
+    const parsePrimary = (): Node => {
+        const token = peek()
+        if (!token) {
+            throw new Error('صيغة غير مكتملة.')
+        }
+
+        if (token.type === 'LPAREN') {
+            consume()
+            const expr = parseExpression()
+            if (!peek() || peek()?.type !== 'RPAREN') {
+                throw new Error('القوس الأيمن مفقود.')
+            }
+            consume()
+            return expr
+        }
+
+        if (token.type === 'VAR') {
+            consume()
+            return { type: 'VAR', name: token.value }
+        }
+
+        if (token.type === 'CONST') {
+            consume()
+            return { type: 'CONST', value: token.value }
+        }
+
+        if (token.type === 'NOT') {
+            consume()
+            return { type: 'NOT', value: parsePrimary() }
+        }
+
+        throw new Error('تعبير غير صالح، يرجى التحقق من الصيغة.')
+    }
+
+    const parseWithPrecedence = (minPrecedence: number): Node => {
+        let left = parsePrimary()
+
+        while (true) {
+            const token = peek()
+            if (!token || !isBinaryOperator(token)) {
+                break
+            }
+
+            const precedence = OPERATOR_PRECEDENCE[token.type]
+            if (precedence < minPrecedence) {
+                break
+            }
+
+            consume()
+            const right = parseWithPrecedence(precedence + (token.type === 'IMPLIES' || token.type === 'IFF' ? 0 : 1))
+            left = { type: token.type, left, right } as Node
+        }
+
+        return left
+    }
+
+    const parseExpression = (): Node => parseWithPrecedence(1)
+
+    const ast = parseExpression()
+    if (position !== tokens.length) {
+        throw new Error('لم يتم استهلاك كامل الصيغة، تحقق من الأقواس أو المشغلين.')
+    }
+
+    return ast
+}
+
+export function evaluate(node: Node, assignment: Record<string, boolean>): boolean {
+    switch (node.type) {
+        case 'VAR':
+            if (!(node.name in assignment)) {
+                throw new Error(`لم يتم تعريف المتغير ${node.name}.`)
+            }
+            return assignment[node.name]
+        case 'CONST':
+            return node.value
+        case 'NOT':
+            return !evaluate(node.value, assignment)
+        case 'AND':
+            return evaluate(node.left, assignment) && evaluate(node.right, assignment)
+        case 'OR':
+            return evaluate(node.left, assignment) || evaluate(node.right, assignment)
+        case 'XOR':
+            return evaluate(node.left, assignment) !== evaluate(node.right, assignment)
+        case 'IMPLIES':
+            return !evaluate(node.left, assignment) || evaluate(node.right, assignment)
+        case 'IFF':
+            return evaluate(node.left, assignment) === evaluate(node.right, assignment)
+    }
+}
+
+export function formatNode(node: Node): string {
+    const precedence = (operator: Operator) => OPERATOR_PRECEDENCE[operator]
+
+    const wrap = (child: Node, parentOp?: Operator) => {
+        if (child.type === 'VAR') return child.name
+        if (child.type === 'CONST') return child.value ? '⊤' : '⊥'
+        if (child.type === 'NOT') return `¬${wrap(child.value, 'NOT')}`
+        const needsParens = parentOp !== undefined && precedence(getOperator(child)) < precedence(parentOp)
+        const text = `${wrap(child.left, getOperator(child))} ${operatorSymbol(child.type)} ${wrap(child.right, getOperator(child))}`
+        return needsParens ? `(${text})` : text
+    }
+
+    if (node.type === 'VAR') return node.name
+    if (node.type === 'CONST') return node.value ? '⊤' : '⊥'
+    if (node.type === 'NOT') return `¬${wrap(node.value, 'NOT')}`
+    return wrap(node)
+}
+
+const operatorSymbol = (operator: Operator): string => {
+    switch (operator) {
+        case 'AND':
+            return '∧'
+        case 'OR':
+            return '∨'
+        case 'XOR':
+            return '⊕'
+        case 'IMPLIES':
+            return '→'
+        case 'IFF':
+            return '↔'
+        case 'NOT':
+            return '¬'
+    }
+}
+
+const getOperator = (node: Node): Operator => {
+    if (node.type === 'NOT') return 'NOT'
+    if (node.type === 'VAR' || node.type === 'CONST') {
+        throw new Error('Leaf nodes do not have operators.')
+    }
+    return node.type
+}
+
+const isBinaryOperator = (token: Token): token is { type: Exclude<Operator, 'NOT'> } =>
+    BINARY_OPERATORS.includes(token.type as Operator)
+
+const extractVariables = (node: Node, vars = new Set<string>()): Set<string> => {
+    if (node.type === 'VAR') {
+        vars.add(node.name)
+    } else if (node.type === 'NOT') {
+        extractVariables(node.value, vars)
+    } else if (node.type !== 'CONST') {
+        extractVariables(node.left, vars)
+        extractVariables(node.right, vars)
+    }
+    return vars
+}
+
+const collectExpressions = (node: Node, seen = new Set<string>()): { label: string; node: Node }[] => {
+    if (node.type === 'VAR' || node.type === 'CONST') return []
+
+    const expressions: { label: string; node: Node }[] = []
+    if (node.type === 'NOT') {
+        expressions.push(...collectExpressions(node.value, seen))
+    } else {
+        expressions.push(...collectExpressions(node.left, seen))
+        expressions.push(...collectExpressions(node.right, seen))
+    }
+
+    const label = formatNode(node)
+    if (!seen.has(label)) {
+        seen.add(label)
+        expressions.push({ label, node })
+    }
+
+    return expressions
+}
+
+export function generateTruthTable(rawExpression: string): TruthTableResult {
+    const tokens = tokenize(rawExpression)
+    if (tokens.length === 0) {
+        throw new Error('الرجاء إدخال صيغة منطقية.')
+    }
+
+    const ast = parse(tokens)
+    const variables = Array.from(extractVariables(ast)).sort((a, b) => a.localeCompare(b))
+    const expressions = collectExpressions(ast)
+    const columns = [...variables.map((v) => ({ label: v, node: { type: 'VAR', name: v } as Node })), ...expressions]
+
+    const finalLabel = formatNode(ast)
+    if (!columns.some((column) => column.label === finalLabel)) {
+        columns.push({ label: finalLabel, node: ast })
+    }
+
+    const rowCount = Math.max(1, 2 ** variables.length)
+    const rows: Record<string, boolean>[] = []
+
+    for (let i = 0; i < rowCount; i++) {
+        const assignment: Record<string, boolean> = {}
+        variables.forEach((variable, index) => {
+            const bit = (rowCount - 1 - i) >> (variables.length - index - 1)
+            assignment[variable] = (bit & 1) === 1
+        })
+
+        const row: Record<string, boolean> = {}
+        columns.forEach(({ label, node }) => {
+            row[label] = node.type === 'VAR' ? assignment[label] : evaluate(node, assignment)
+        })
+        rows.push(row)
+    }
+
+    return {
+        variables,
+        columns,
+        rows,
+        normalized: formatNode(ast)
+    }
+}

--- a/resources/js/pages/tools/TruthTablePage.vue
+++ b/resources/js/pages/tools/TruthTablePage.vue
@@ -1,0 +1,24 @@
+<template>
+  <DocsLayout>
+    <PageHeader title="مولد جدول الحقيقة" icon="solar:table-bold-duotone" />
+
+    <div class="typography space-y-6">
+      <p class="text-muted-foreground">
+        أدخل صيغة منطقية واحصل على جدول الحقيقة الخاص بها مع دعم لمعظم صيغ المعاملات
+        الشائعة كما في أداة ستانفورد.
+      </p>
+
+      <TruthTableGenerator />
+    </div>
+  </DocsLayout>
+</template>
+
+<script setup lang="ts">
+import DocsLayout from '@/components/layout/DocsLayout.vue'
+import PageHeader from '@/components/page/PageHeader.vue'
+import TruthTableGenerator from '@/components/tools/TruthTableGenerator.vue'
+
+defineOptions({
+  layout: false
+})
+</script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ Route::get('/', [PageController::class, 'home'])->name('home');
 Route::inertia('/adoat/almkafa', 'tools/NextRewardPage')->name('tools.next-reward');
 Route::inertia('/adoat/hasb-alhrman', 'tools/DeprivationCalculatorPage')->name('tools.deprivation-calculator');
 Route::inertia('/adoat/hasb-almaadl', 'tools/GpaCalculatorPage')->name('tools.gpa-calculator');
+Route::inertia('/adoat/jadwal-alhaqiqa', 'tools/TruthTablePage')->name('tools.truth-table');
 
 // Catch-all route for content pages (must be last!)
 Route::get('/{slug}', [PageController::class, 'show'])


### PR DESCRIPTION
## Summary
- add reusable truth table tokenizer, parser, and evaluator utilities for web and Telegram
- introduce a Truth Table Generator page with operator cheatsheets and an interactive table output
- add a /truth Telegram command that returns formatted truth tables using the shared logic service

## Testing
- npm run lint *(fails: existing lint errors in legacy components unrelated to this change)*
- php -l app/Services/Logic/TruthTableGenerator.php
- php -l app/Services/Telegram/Handlers/TruthTableHandler.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb302e178832db9a5585547221658)