### PR TITLE
Add screenshot option to quick responses

### DIFF
--- a/app/Filament/Resources/Pages/Schemas/PageForm.php
+++ b/app/Filament/Resources/Pages/Schemas/PageForm.php
@@ -110,6 +110,11 @@ class PageForm
                             ->label('إرسال رابط الصفحة مع الرد')
                             ->default(true),
 
+                        Toggle::make('quick_response_send_screenshot')
+                            ->label('إرسال لقطة شاشة للصفحة')
+                            ->helperText('يرسل الرد مع لقطة شاشة للصفحة بدل النص فقط')
+                            ->default(false),
+
                         Toggle::make('quick_response_customize_message')
                             ->label('تخصيص نص الرد')
                             ->reactive()

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -73,6 +73,7 @@ class PageController extends Controller
                 'quick_response' => [
                     'enabled' => $page->quick_response_enabled,
                     'send_link' => $page->quick_response_send_link,
+                    'send_screenshot' => $page->quick_response_send_screenshot,
                     'message' => $page->quick_response_message,
                     'buttons' => collect($page->quick_response_buttons ?? [])
                         ->filter(fn ($btn) => filled($btn['text'] ?? null) && filled($btn['url'] ?? null))

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -85,6 +85,7 @@ class Page extends Model implements Sortable
         'quick_response_customize_buttons',
         'quick_response_customize_attachments',
         'quick_response_send_link',
+        'quick_response_send_screenshot',
         'quick_response_message',
         'quick_response_buttons',
         'quick_response_attachments',
@@ -101,6 +102,7 @@ class Page extends Model implements Sortable
         'quick_response_customize_buttons' => 'boolean',
         'quick_response_customize_attachments' => 'boolean',
         'quick_response_send_link' => 'boolean',
+        'quick_response_send_screenshot' => 'boolean',
         'quick_response_buttons' => 'array',
         'quick_response_attachments' => 'array',
     ];

--- a/app/Services/MarkdownMigrationService.php
+++ b/app/Services/MarkdownMigrationService.php
@@ -93,6 +93,7 @@ class MarkdownMigrationService
             'extension' => pathinfo($filePath, PATHINFO_EXTENSION),
             'quick_response_enabled' => $frontmatter['quickResponseEnabled'] ?? false,
             'quick_response_send_link' => $frontmatter['quickResponseSendLink'] ?? true,
+            'quick_response_send_screenshot' => $frontmatter['quickResponseSendScreenshot'] ?? false,
             'quick_response_message' => $frontmatter['quickResponseMessage'] ?? null,
             'quick_response_buttons' => $frontmatter['quickResponseButtons'] ?? [],
             'quick_response_attachments' => $frontmatter['quickResponseAttachments'] ?? [],

--- a/app/Services/QuickResponseService.php
+++ b/app/Services/QuickResponseService.php
@@ -28,6 +28,7 @@ class QuickResponseService
                     'quick_response_customize_buttons',
                     'quick_response_customize_attachments',
                     'quick_response_send_link',
+                    'quick_response_send_screenshot',
                     'quick_response_message',
                     'quick_response_buttons',
                     'quick_response_attachments',

--- a/app/Services/Telegram/Handlers/UquccSearchHandler.php
+++ b/app/Services/Telegram/Handlers/UquccSearchHandler.php
@@ -105,6 +105,7 @@ class UquccSearchHandler extends BaseHandler
         // Get the resolved content (auto-extracted or custom)
         $resolvedContent = $this->resolveQuickResponseContent($page);
         $replyMarkup = $this->buildReplyMarkup($page, $resolvedContent['buttons']);
+        $shouldSendScreenshot = ($page->quick_response_send_screenshot ?? false);
 
         // Check if there are attachments
         $attachments = collect($resolvedContent['attachments'])
@@ -115,6 +116,10 @@ class UquccSearchHandler extends BaseHandler
             // Send attachments with text as caption (shorter limit)
             $captionContent = $this->buildTextContent($page, $resolvedContent, isCaption: true);
             $this->sendQuickResponseAttachments($message, $page, $captionContent, $replyMarkup, $attachments);
+        } elseif ($shouldSendScreenshot) {
+            // Send screenshot with caption and optional buttons
+            $captionContent = $this->buildTextContent($page, $resolvedContent, isCaption: true);
+            $this->sendScreenshotWithText($message, $page, $captionContent, $replyMarkup);
         } elseif ($resolvedContent['message'] || $replyMarkup) {
             // Send text message with optional buttons (full message limit)
             $textContent = $this->buildTextContent($page, $resolvedContent, isCaption: false);

--- a/database/migrations/2026_02_01_000000_add_send_screenshot_to_pages_table.php
+++ b/database/migrations/2026_02_01_000000_add_send_screenshot_to_pages_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            if (! Schema::hasColumn('pages', 'quick_response_send_screenshot')) {
+                $table->boolean('quick_response_send_screenshot')->default(false)->after('quick_response_send_link');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            if (Schema::hasColumn('pages', 'quick_response_send_screenshot')) {
+                $table->dropColumn('quick_response_send_screenshot');
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- keep existing model, controller, and handler support for screenshot quick responses
- move database schema change into a new migration instead of altering existing ones

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb32ae0e0832db62f1b7fe7a07c6f)