### PR TITLE
feat: Add screenshot with custom content toggle (#11)

### DIFF
--- a/app/Filament/Resources/Pages/Schemas/PageForm.php
+++ b/app/Filament/Resources/Pages/Schemas/PageForm.php
@@ -115,6 +115,12 @@ class PageForm
                             ->label('إرسال رابط الصفحة مع الرد')
                             ->default(true),
 
+                        Toggle::make('quick_response_send_screenshot')
+                            ->label('إرسال لقطة شاشة للصفحة')
+                            ->reactive()
+                            ->helperText('عند التفعيل، سيتم إرسال لقطة شاشة من الصفحة مع المحتوى المخصص')
+                            ->default(false),
+
                         Toggle::make('quick_response_customize_message')
                             ->label('تخصيص نص الرد')
                             ->reactive()

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -86,6 +86,7 @@ class Page extends Model implements Sortable
         'quick_response_customize_buttons',
         'quick_response_customize_attachments',
         'quick_response_send_link',
+        'quick_response_send_screenshot',
         'quick_response_message',
         'quick_response_buttons',
         'quick_response_attachments',
@@ -103,6 +104,7 @@ class Page extends Model implements Sortable
         'quick_response_customize_buttons' => 'boolean',
         'quick_response_customize_attachments' => 'boolean',
         'quick_response_send_link' => 'boolean',
+        'quick_response_send_screenshot' => 'boolean',
         'quick_response_buttons' => 'array',
         'quick_response_attachments' => 'array',
     ];

--- a/app/Services/Telegram/Handlers/UquccSearchHandler.php
+++ b/app/Services/Telegram/Handlers/UquccSearchHandler.php
@@ -189,6 +189,10 @@ class UquccSearchHandler extends BaseHandler
             // Send attachments with text as caption (shorter limit)
             $captionContent = $this->buildTextContent($page, $resolvedContent, isCaption: true);
             $this->sendQuickResponseAttachments($message, $page, $captionContent, $replyMarkup, $attachments);
+        } elseif ($page->quick_response_send_screenshot && ($resolvedContent['message'] || $replyMarkup)) {
+            // Send screenshot with custom content as caption
+            $captionContent = $this->buildTextContent($page, $resolvedContent, isCaption: true);
+            $this->sendScreenshotWithText($message, $page, $captionContent, $replyMarkup);
         } elseif ($resolvedContent['message'] || $replyMarkup) {
             // Send text message with optional buttons (full message limit)
             $textContent = $this->buildTextContent($page, $resolvedContent, isCaption: false);

--- a/database/migrations/2025_12_26_180659_add_quick_response_send_screenshot_to_pages_table.php
+++ b/database/migrations/2025_12_26_180659_add_quick_response_send_screenshot_to_pages_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            $table->boolean('quick_response_send_screenshot')->default(false)->after('quick_response_send_link');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            $table->dropColumn('quick_response_send_screenshot');
+        });
+    }
+};


### PR DESCRIPTION
- Added quick_response_send_screenshot field to Page model
- Added migration to add the new column (default false)
- Added toggle to Filament admin form in quick response section
- Updated UquccSearchHandler to send screenshot with custom content when enabled

When enabled, pages with custom quick response content (message or buttons) will send a screenshot of the page along with the custom content as caption, instead of just sending the text message.

This allows combining the visual preview of screenshots with the flexibility of custom messages and buttons.