### PR TITLE
Screenshot sending issue

### DIFF
--- a/app/Services/Telegram/Handlers/UquccSearchHandler.php
+++ b/app/Services/Telegram/Handlers/UquccSearchHandler.php
@@ -155,7 +155,7 @@ class UquccSearchHandler extends BaseHandler
             // Send attachments with text as caption (shorter limit)
             $captionContent = $this->buildTextContent($page, $resolvedContent, isCaption: true);
             $this->sendQuickResponseAttachments($message, $page, $captionContent, $replyMarkup, $attachments);
-        } elseif ($page->quick_response_send_screenshot && ! $page->hidden && ($resolvedContent['message'] || $replyMarkup)) {
+        } elseif ($page->quick_response_send_screenshot && ! $page->hidden) {
             // Send screenshot with custom content as caption (only if page is not hidden from website)
             $captionContent = $this->buildTextContent($page, $resolvedContent, isCaption: true);
             $this->sendScreenshotWithText($message, $page, $captionContent, $replyMarkup);


### PR DESCRIPTION
Remove the requirement for a message or buttons when sending a screenshot to ensure screenshots are sent when `quick_response_send_screenshot` is enabled.

Previously, the condition `$page->quick_response_send_screenshot && ! $page->hidden && ($resolvedContent['message'] || $replyMarkup)` meant that if `quick_response_send_screenshot` was true but there was no custom message or buttons, the screenshot would not be sent. This change allows the screenshot to be sent as the primary content when the option is enabled.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c7b30db-e2eb-4a2c-8c58-15b62e34982f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7c7b30db-e2eb-4a2c-8c58-15b62e34982f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

