### PR TITLE
Add copy controls for rendered pre/code blocks

### DIFF
--- a/resources/css/typography.css
+++ b/resources/css/typography.css
@@ -2,31 +2,31 @@
 
 @layer components {
     .typography * {
-        @apply my-2 break-words whitespace-normal transition-all text-foreground;
+        @apply my-2 break-words whitespace-normal text-foreground transition-all;
     }
 
     .typography h1 {
-        @apply mb-4 text-3xl tracking-tight scroll-m-20;
+        @apply mb-4 scroll-m-20 text-3xl tracking-tight;
     }
 
     .typography h2 {
-        @apply pb-2 my-4 text-[1.7rem] font-semibold tracking-tight transition-colors border-b scroll-m-20 first:mt-0;
+        @apply my-4 scroll-m-20 border-b pb-2 text-[1.7rem] font-semibold tracking-tight transition-colors first:mt-0;
     }
 
     .typography h3 {
-        @apply my-4 text-2xl font-semibold tracking-tight scroll-m-20;
+        @apply my-4 scroll-m-20 text-2xl font-semibold tracking-tight;
     }
 
     .typography h4 {
-        @apply my-4 text-xl font-semibold tracking-tight scroll-m-20;
+        @apply my-4 scroll-m-20 text-xl font-semibold tracking-tight;
     }
 
     .typography h5 {
-        @apply text-lg font-semibold tracking-tight scroll-m-20;
+        @apply scroll-m-20 text-lg font-semibold tracking-tight;
     }
 
     .typography h6 {
-        @apply text-base font-semibold tracking-tight scroll-m-20;
+        @apply scroll-m-20 text-base font-semibold tracking-tight;
     }
 
     .typography p {
@@ -34,7 +34,7 @@
     }
 
     .typography blockquote {
-        @apply mt-6 italic border-l-2 ps-6;
+        @apply mt-6 border-l-2 ps-6 italic;
     }
 
     .typography hr {
@@ -64,12 +64,28 @@
     }
 
     .typography pre {
-        @apply p-4 my-6 overflow-x-auto rounded-lg bg-muted whitespace-pre;
+        @apply relative my-6 overflow-x-auto rounded-lg bg-muted p-4 pt-10 whitespace-pre;
         direction: ltr;
     }
 
+    .typography .code-copy-button {
+        @apply absolute end-3 top-3 inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-background/80 text-sm leading-none text-muted-foreground transition-colors;
+    }
+
+    .typography .code-copy-button:hover {
+        @apply bg-background text-foreground;
+    }
+
+    .typography .code-copy-button[data-state='success'] {
+        @apply text-green-600 dark:text-green-400;
+    }
+
+    .typography .code-copy-button[data-state='error'] {
+        @apply text-red-600 dark:text-red-400;
+    }
+
     .typography pre code {
-        @apply px-0 py-0 bg-transparent rounded-none whitespace-pre;
+        @apply rounded-none bg-transparent px-0 py-0 whitespace-pre;
     }
 
     .typography ul {
@@ -81,7 +97,7 @@
     }
 
     .typography img {
-        @apply max-w-full my-6 rounded-lg;
+        @apply my-6 max-w-full rounded-lg;
     }
 
     .typography ul ul,
@@ -100,7 +116,7 @@
     }
 
     .typography small {
-        @apply text-sm font-medium leading-none;
+        @apply text-sm leading-none font-medium;
     }
 
     .typography p.muted {
@@ -108,7 +124,7 @@
     }
 
     /* Table wrapper - matches old project's Table component wrapper */
-    .typography > div[class*="overflow-auto"] {
+    .typography > div[class*='overflow-auto'] {
         @apply my-6;
     }
 
@@ -126,11 +142,11 @@
     }
 
     .typography tr {
-        @apply hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors;
+        @apply border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted;
     }
 
     .typography th {
-        @apply text-muted-foreground h-10 px-2 text-start align-middle font-medium whitespace-nowrap;
+        @apply h-10 px-2 text-start align-middle font-medium whitespace-nowrap text-muted-foreground;
     }
 
     .typography td {

--- a/resources/js/components/RichContentRenderer.vue
+++ b/resources/js/components/RichContentRenderer.vue
@@ -1,17 +1,18 @@
 <script setup lang="ts">
-import { EditorContent, useEditor } from '@tiptap/vue-3';
-import { generateHTML } from '@tiptap/html';
-import Link from '@tiptap/extension-link';
-import StarterKit from '@tiptap/starter-kit';
-import TextAlign from '@tiptap/extension-text-align';
-import Underline from '@tiptap/extension-underline';
-import Image from '@tiptap/extension-image';
 import CustomTable from '@/tiptap/extensions/table';
-import TableRow from '@tiptap/extension-table-row';
+import Image from '@tiptap/extension-image';
+import Link from '@tiptap/extension-link';
 import TableCell from '@tiptap/extension-table-cell';
 import TableHeader from '@tiptap/extension-table-header';
+import TableRow from '@tiptap/extension-table-row';
+import TextAlign from '@tiptap/extension-text-align';
+import Underline from '@tiptap/extension-underline';
+import { generateHTML } from '@tiptap/html';
+import StarterKit from '@tiptap/starter-kit';
+import { EditorContent, useEditor } from '@tiptap/vue-3';
 import DOMPurify from 'isomorphic-dompurify';
-import { computed, watch, ref, onMounted } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { toast } from 'vue-sonner';
 
 import AlertBlock from '@/tiptap/extensions/alertBlock';
 import CollapsibleBlock from '@/tiptap/extensions/collapsibleBlock';
@@ -22,13 +23,88 @@ const props = defineProps<{
 
 // Track if we're on the client side
 const isMounted = ref(false);
+const rootElement = ref<HTMLElement | null>(null);
+let codeBlocksObserver: MutationObserver | null = null;
+
+const COPY_ICON = '⧉';
+const SUCCESS_ICON = '✓';
+const ERROR_ICON = '✕';
+
+const updateCopyButtonState = (button: HTMLButtonElement, state: 'default' | 'success' | 'error', timeoutMs = 1800) => {
+    button.dataset.state = state;
+    button.textContent = state === 'success' ? SUCCESS_ICON : state === 'error' ? ERROR_ICON : COPY_ICON;
+
+    if (state !== 'default') {
+        window.setTimeout(() => {
+            button.dataset.state = 'default';
+            button.textContent = COPY_ICON;
+        }, timeoutMs);
+    }
+};
+
+const addCopyButtons = () => {
+    if (!rootElement.value) return;
+
+    const codeBlocks = rootElement.value.querySelectorAll('pre > code');
+    for (const codeBlock of codeBlocks) {
+        const pre = codeBlock.closest('pre');
+        if (!(pre instanceof HTMLPreElement)) continue;
+        if (pre.querySelector('.code-copy-button')) continue;
+
+        const copyButton = document.createElement('button');
+        copyButton.type = 'button';
+        copyButton.className = 'code-copy-button';
+        copyButton.dataset.state = 'default';
+        copyButton.textContent = COPY_ICON;
+        copyButton.setAttribute('aria-label', 'Copy code');
+        copyButton.title = 'Copy code';
+
+        copyButton.addEventListener('click', async () => {
+            const fullCode = codeBlock.textContent ?? '';
+
+            try {
+                await navigator.clipboard.writeText(fullCode);
+                updateCopyButtonState(copyButton, 'success');
+            } catch {
+                updateCopyButtonState(copyButton, 'error');
+                toast.error('Failed to copy code block');
+            }
+        });
+
+        pre.appendChild(copyButton);
+    }
+};
+
+const initCodeBlockObserver = () => {
+    if (!rootElement.value || codeBlocksObserver) return;
+
+    codeBlocksObserver = new MutationObserver(() => {
+        addCopyButtons();
+    });
+
+    codeBlocksObserver.observe(rootElement.value, {
+        childList: true,
+        subtree: true,
+    });
+};
+
 onMounted(() => {
     isMounted.value = true;
+
+    nextTick(() => {
+        addCopyButtons();
+        initCodeBlockObserver();
+    });
 });
 
-const isJsonContent = computed(
-    () => props.content != null && typeof props.content === 'object' && !Array.isArray(props.content),
-);
+onBeforeUnmount(() => {
+    if (codeBlocksObserver) {
+        codeBlocksObserver.disconnect();
+        codeBlocksObserver = null;
+    }
+});
+
+const isJsonContent = computed(() => props.content != null && typeof props.content === 'object' && !Array.isArray(props.content));
 
 const transformCustomBlocks = (node: any): any => {
     if (!node || typeof node !== 'object') return node;
@@ -59,7 +135,33 @@ const transformedContent = computed(() => {
 const cleanHtml = computed(() =>
     typeof props.content === 'string' && props.content
         ? DOMPurify.sanitize(props.content, {
-              ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'u', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'li', 'blockquote', 'code', 'pre', 'a', 'img', 'table', 'thead', 'tbody', 'tr', 'th', 'td'],
+              ALLOWED_TAGS: [
+                  'p',
+                  'br',
+                  'strong',
+                  'em',
+                  'u',
+                  'h1',
+                  'h2',
+                  'h3',
+                  'h4',
+                  'h5',
+                  'h6',
+                  'ul',
+                  'ol',
+                  'li',
+                  'blockquote',
+                  'code',
+                  'pre',
+                  'a',
+                  'img',
+                  'table',
+                  'thead',
+                  'tbody',
+                  'tr',
+                  'th',
+                  'td',
+              ],
               ALLOWED_ATTR: ['href', 'target', 'rel', 'src', 'alt', 'width', 'height', 'class', 'colspan', 'rowspan', 'scope'],
               ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|data):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
           })
@@ -128,18 +230,22 @@ watch(
         } else {
             editor.value.commands.clearContent(true);
         }
+
+        nextTick(() => addCopyButtons());
     },
 );
 </script>
 
 <template>
-    <!-- For JSON content: use SSR HTML during SSR, then hydrate with TipTap editor -->
-    <template v-if="isJsonContent">
-        <!-- Client-side: use the interactive TipTap editor -->
-        <EditorContent v-if="isMounted" :editor="editor" />
-        <!-- SSR: render static HTML that matches the editor output -->
-        <div v-else class="typography" v-html="ssrHtml" />
-    </template>
-    <!-- For HTML string content -->
-    <div v-else class="typography" v-html="cleanHtml" />
+    <div ref="rootElement">
+        <!-- For JSON content: use SSR HTML during SSR, then hydrate with TipTap editor -->
+        <template v-if="isJsonContent">
+            <!-- Client-side: use the interactive TipTap editor -->
+            <EditorContent v-if="isMounted" :editor="editor" />
+            <!-- SSR: render static HTML that matches the editor output -->
+            <div v-else class="typography" v-html="ssrHtml" />
+        </template>
+        <!-- For HTML string content -->
+        <div v-else class="typography" v-html="cleanHtml" />
+    </div>
 </template>


### PR DESCRIPTION
### Motivation

- Improve reader UX for large code blocks by adding a persistent copy control so users can easily copy the entire code snippet and receive clear success/error feedback.

### Description

- Inject a copy button into each `pre > code` block from `RichContentRenderer.vue` by scanning the rendered DOM and appending a `.code-copy-button` element with icons for default/success/error and `navigator.clipboard.writeText` as the copy implementation.
- Provide visual feedback via `updateCopyButtonState` (copy → check or X) and display an error toast on failure using `vue-sonner`, while cleaning up the `MutationObserver` in `onBeforeUnmount` and re-applying buttons for dynamic updates with a `MutationObserver` and `nextTick`.
- Wrap rendered content in a `ref` (`rootElement`) so the DOM can be observed and updated, and call `addCopyButtons()` from the existing `watch` on `props.content` to handle hydration/updates.
- Update `resources/css/typography.css` to reserve top padding for the control, add styling for `.code-copy-button`, and define color states for success and error.

### Testing

- Formatted files with `npx prettier --write resources/js/components/RichContentRenderer.vue resources/css/typography.css` which completed successfully.
- Verified formatting with `npx prettier --check resources/js/components/RichContentRenderer.vue resources/css/typography.css` which passed.
- Attempted full build with `npm run build` which failed in this environment due to missing PHP `vendor/autoload.php` required by `php artisan wayfinder:generate --with-form`, so the Vite build step could not complete here.
- Captured a browser screenshot to validate the UI change using Playwright; the script succeeded and produced a screenshot artifact (`artifacts/code-copy-button.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994b83c3760832da288bcfd3a43018a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds DOM mutation observation and clipboard interactions in `RichContentRenderer`, which could introduce client-only edge cases (hydration timing, clipboard permissions) but does not change server-side data handling.
> 
> **Overview**
> Adds a persistent **copy-to-clipboard control** to rendered `pre > code` blocks in `RichContentRenderer.vue`, including success/error visual states and an error toast when clipboard writes fail.
> 
> Implements DOM scanning plus a `MutationObserver` to inject buttons on initial render and after content updates/hydration, with proper observer cleanup on unmount. Updates `typography.css` to reserve space in `pre` blocks and style the new `.code-copy-button` (hover + success/error colors).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1524484bcd9c4621de57c8e514aab6a1abae94a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->