### PR TITLE
fix(ai): stream image downloads; ingest memory headroom

### DIFF
--- a/app/Ai/Corpus/PageImageExtractor.php
+++ b/app/Ai/Corpus/PageImageExtractor.php
@@ -144,34 +144,45 @@ class PageImageExtractor
      */
     private function download(string $src, string $urlHash): ?string
     {
+        $temporaryPath = null;
+
         try {
+            $temporaryPath = tempnam(sys_get_temp_dir(), 'corpus-img-');
+
+            if ($temporaryPath === false) {
+                return null;
+            }
+
+            // Stream straight to disk: buffering bodies in memory exhausted
+            // the 128M CLI limit over a long ai:ingest-pages run in prod.
             $response = Http::timeout(15)
                 ->withHeaders(['Accept' => 'image/*'])
                 ->maxRedirects(3)
+                ->sink($temporaryPath)
                 ->get($src);
 
             $contentType = strtolower(strtok((string) $response->header('Content-Type'), ';'));
 
+            clearstatcache(true, $temporaryPath);
+            $size = (int) @filesize($temporaryPath);
+
             if (! $response->successful()
                 || ! str_starts_with($contentType, 'image/')
-                || strlen($response->body()) === 0
-                || strlen($response->body()) > self::MAX_DOWNLOAD_BYTES) {
+                || $size === 0
+                || $size > self::MAX_DOWNLOAD_BYTES) {
                 throw new RuntimeException(sprintf(
                     'Unusable image response (status %d, type "%s", %d bytes).',
                     $response->status(),
                     $contentType,
-                    strlen($response->body()),
+                    $size,
                 ));
-            }
-
-            $temporaryPath = tempnam(sys_get_temp_dir(), 'corpus-img-');
-
-            if ($temporaryPath === false || file_put_contents($temporaryPath, $response->body()) === false) {
-                return null;
             }
 
             return $temporaryPath;
         } catch (Throwable $exception) {
+            if (is_string($temporaryPath)) {
+                @unlink($temporaryPath);
+            }
             report($exception);
 
             CorpusImageExtraction::query()->updateOrCreate(

--- a/app/Console/Commands/IngestPages.php
+++ b/app/Console/Commands/IngestPages.php
@@ -23,6 +23,11 @@ class IngestPages extends Command
 
     public function handle(IngestPage $ingest): int
     {
+        // A full inline run touches every page, image download, and vision
+        // response in one process — the default 128M CLI limit was exhausted
+        // in production partway through the site.
+        ini_set('memory_limit', '512M');
+
         if (! $ingest->isEnabled()) {
             $this->warn('AI search ingestion is disabled: enable ai_enabled + search_enabled in AI settings and configure an embedding driver.');
 


### PR DESCRIPTION
Production `ai:ingest-pages` died at 28/100 pages: PHP's 128M CLI limit was exhausted because external image downloads buffered response bodies in memory. Downloads now stream straight to the temp file (`Http::sink`) with the 10MB cap enforced on the file size, and the ingest command raises its own limit to 512M for the long single-process run.

Verified: image-extraction suite green (fakes honor sink); the interrupted production run resumed idempotently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)