### PR TITLE
feat(ai): GFM table rendering + SSE production timeouts

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -245,7 +245,10 @@ clear_env = no
 
 ; Useful production tweaks
 php_admin_value[memory_limit] = 512M
-php_admin_value[max_execution_time] = 60
+; Long enough for a streamed AI turn (SSE): reasoning models plus tool
+; calls can run well past a minute before the reply completes. nginx's
+; fastcgi_read_timeout is raised to match.
+php_admin_value[max_execution_time] = 300
 php_admin_value[max_input_time] = 60
 php_admin_value[post_max_size] = 256M
 php_admin_value[upload_max_filesize] = 64M
@@ -334,6 +337,14 @@ http {
 
             # Inertia-specific buffer tweak
             fastcgi_buffer_size 8k;
+
+            # AI chat replies stream as SSE: the controllers send
+            # "X-Accel-Buffering: no" so nginx flushes each token frame
+            # instead of buffering the whole response. The long read timeout
+            # lets a slow turn (reasoning model thinking before the first
+            # token, or a multi-step tool call) finish without nginx killing
+            # the connection at the default 60s and truncating the reply.
+            fastcgi_read_timeout 300;
         }
 
         location ~ /\.(?!well-known).* {

--- a/resources/js/lib/markdown.test.ts
+++ b/resources/js/lib/markdown.test.ts
@@ -44,4 +44,26 @@ describe('renderMarkdown', () => {
     it('renders blockquotes', () => {
         expect(renderMarkdown('> اقتباس')).toBe('<blockquote><p>اقتباس</p></blockquote>');
     });
+
+    it('renders GFM tables with a head and body', () => {
+        const table = '| المادة | الدرجة |\n| --- | --- |\n| رياضيات | 95 |\n| فيزياء | 88 |';
+
+        expect(renderMarkdown(table)).toBe(
+            '<table><thead><tr><th>المادة</th><th>الدرجة</th></tr></thead>' +
+                '<tbody><tr><td>رياضيات</td><td>95</td></tr><tr><td>فيزياء</td><td>88</td></tr></tbody></table>',
+        );
+    });
+
+    it('applies logical alignment from delimiter colons', () => {
+        const table = '| اسم | قيمة |\n| :--- | ---: |\n| أ | 1 |';
+        const html = renderMarkdown(table);
+
+        expect(html).toContain('<th style="text-align: start">اسم</th>');
+        expect(html).toContain('<th style="text-align: end">قيمة</th>');
+        expect(html).toContain('<td style="text-align: end">1</td>');
+    });
+
+    it('does not treat a plain paragraph with a pipe as a table', () => {
+        expect(renderMarkdown('الخيار أ | الخيار ب')).toBe('<p>الخيار أ | الخيار ب</p>');
+    });
 });

--- a/resources/js/lib/markdown.ts
+++ b/resources/js/lib/markdown.ts
@@ -8,7 +8,29 @@ import DOMPurify from 'isomorphic-dompurify';
  * through DOMPurify, so model output can never inject markup.
  */
 
-const ALLOWED_TAGS = ['p', 'br', 'strong', 'em', 'code', 'pre', 'a', 'ul', 'ol', 'li', 'h2', 'h3', 'h4', 'blockquote', 'hr'];
+const ALLOWED_TAGS = [
+    'p',
+    'br',
+    'strong',
+    'em',
+    'code',
+    'pre',
+    'a',
+    'ul',
+    'ol',
+    'li',
+    'h2',
+    'h3',
+    'h4',
+    'blockquote',
+    'hr',
+    'table',
+    'thead',
+    'tbody',
+    'tr',
+    'th',
+    'td',
+];
 
 /** Placeholder sentinel for extracted code spans; a control character never survives user text. */
 const CODE_SENTINEL = String.fromCharCode(1);
@@ -40,6 +62,63 @@ const renderInline = (text: string): string => {
     return html.replace(CODE_RESTORE_PATTERN, (_match, index: string) => codeSpans[Number(index)] ?? '');
 };
 
+/** Split one GFM table row into trimmed cells, tolerating optional outer pipes. */
+const splitTableRow = (row: string): string[] =>
+    row
+        .trim()
+        .replace(/^\|/, '')
+        .replace(/\|$/, '')
+        .split('|')
+        .map((cell) => cell.trim());
+
+/** A GFM delimiter row: every cell is dashes with optional alignment colons. */
+const isTableDelimiter = (line: string): boolean => {
+    const cells = splitTableRow(line);
+
+    return cells.length > 0 && cells.every((cell) => /^:?-+:?$/.test(cell));
+};
+
+/** Logical text-align for one delimiter cell (start/center/end), honouring RTL. */
+const cellAlignment = (spec: string): string => {
+    const startColon = spec.startsWith(':');
+    const endColon = spec.endsWith(':');
+
+    if (startColon && endColon) {
+        return ' style="text-align: center"';
+    }
+
+    if (endColon) {
+        return ' style="text-align: end"';
+    }
+
+    if (startColon) {
+        return ' style="text-align: start"';
+    }
+
+    return '';
+};
+
+const renderTable = (lines: string[]): string => {
+    const alignments = splitTableRow(lines[1]).map(cellAlignment);
+
+    const head = splitTableRow(lines[0])
+        .map((cell, index) => `<th${alignments[index] ?? ''}>${renderInline(cell)}</th>`)
+        .join('');
+
+    const body = lines
+        .slice(2)
+        .map((line) => {
+            const cells = splitTableRow(line)
+                .map((cell, index) => `<td${alignments[index] ?? ''}>${renderInline(cell)}</td>`)
+                .join('');
+
+            return `<tr>${cells}</tr>`;
+        })
+        .join('');
+
+    return `<table><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table>`;
+};
+
 const renderBlock = (block: string): string => {
     const lines = block.split('\n');
 
@@ -47,6 +126,10 @@ const renderBlock = (block: string): string => {
     if (heading && lines.length === 1) {
         const level = Math.min(Math.max(heading[1].length, 2), 4);
         return `<h${level}>${renderInline(heading[2].trim())}</h${level}>`;
+    }
+
+    if (lines.length >= 2 && lines[0].includes('|') && isTableDelimiter(lines[1])) {
+        return renderTable(lines);
     }
 
     if (/^([-*_])\s*\1\s*\1[\s\-*_]*$/.test(block.trim())) {
@@ -93,6 +176,6 @@ export const renderMarkdown = (markdown: string): string => {
 
     return DOMPurify.sanitize(html, {
         ALLOWED_TAGS,
-        ALLOWED_ATTR: ['href', 'target', 'rel'],
+        ALLOWED_ATTR: ['href', 'target', 'rel', 'style'],
     });
 };

--- a/resources/js/pages/AssistantPage.vue
+++ b/resources/js/pages/AssistantPage.vue
@@ -754,4 +754,29 @@ onBeforeUnmount(() => abortController?.abort());
     padding-inline-start: 0.75rem;
     color: var(--muted-foreground);
 }
+
+/* Tables scroll inside the bubble on narrow screens instead of overflowing it. */
+.assistant-markdown :deep(table) {
+    display: block;
+    width: max-content;
+    max-width: 100%;
+    overflow-x: auto;
+    margin-block: 0.5rem;
+    border-collapse: collapse;
+    font-size: 0.8125rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.assistant-markdown :deep(th),
+.assistant-markdown :deep(td) {
+    border: 1px solid var(--border);
+    padding: 0.375rem 0.625rem;
+    text-align: start;
+    vertical-align: top;
+}
+
+.assistant-markdown :deep(th) {
+    background: color-mix(in oklab, var(--foreground) 5%, transparent);
+    font-weight: 600;
+}
 </style>

--- a/resources/js/pages/manage/assistant/Index.vue
+++ b/resources/js/pages/manage/assistant/Index.vue
@@ -514,4 +514,29 @@ onBeforeUnmount(() => abortController?.abort());
     padding-inline-start: 0.75rem;
     color: var(--muted-foreground);
 }
+
+/* Tables scroll inside the bubble on narrow screens instead of overflowing it. */
+.assistant-markdown :deep(table) {
+    display: block;
+    width: max-content;
+    max-width: 100%;
+    overflow-x: auto;
+    margin-block: 0.5rem;
+    border-collapse: collapse;
+    font-size: 0.8125rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.assistant-markdown :deep(th),
+.assistant-markdown :deep(td) {
+    border: 1px solid var(--border);
+    padding: 0.375rem 0.625rem;
+    text-align: start;
+    vertical-align: top;
+}
+
+.assistant-markdown :deep(th) {
+    background: var(--background);
+    font-weight: 600;
+}
 </style>

--- a/resources/js/pages/manage/corpus/ProposalReview.vue
+++ b/resources/js/pages/manage/corpus/ProposalReview.vue
@@ -275,4 +275,28 @@ function runConfirmedAction(): void {
     padding-inline-start: 0.75rem;
     color: var(--muted-foreground);
 }
+
+.proposal-markdown :deep(table) {
+    display: block;
+    width: max-content;
+    max-width: 100%;
+    overflow-x: auto;
+    margin-block: 0.5rem;
+    border-collapse: collapse;
+    font-size: 0.8125rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.proposal-markdown :deep(th),
+.proposal-markdown :deep(td) {
+    border: 1px solid var(--border);
+    padding: 0.375rem 0.625rem;
+    text-align: start;
+    vertical-align: top;
+}
+
+.proposal-markdown :deep(th) {
+    background: color-mix(in oklab, var(--foreground) 5%, transparent);
+    font-weight: 600;
+}
 </style>


### PR DESCRIPTION
Render markdown tables in AI chat replies: the shared renderer handled bold/lists/headings/code/blockquotes but dropped GFM tables, so a model's `| … |` table surfaced as a paragraph of pipes. Adds head/body parsing (optional outer pipes, logical start/center/end alignment from delimiter colons) across the public assistant, admin assistant, and corpus proposal review, with tables that scroll inside the bubble on narrow screens.

Harden SSE for production in nixpacks: raise nginx fastcgi_read_timeout and php-fpm max_execution_time to 300 so a slow streamed turn (reasoning model thinking before the first token, or a multi-step tool call) is not cut off with a 504 mid-reply at the default 60s.