### PR TITLE
fix(ai): stop image-download failures paging the error notifier

### DIFF
--- a/app/Ai/Corpus/PageImageExtractor.php
+++ b/app/Ai/Corpus/PageImageExtractor.php
@@ -10,6 +10,7 @@ use App\Support\LocalFile;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Sleep;
 use Laravel\Ai\Files\Image;
@@ -198,7 +199,14 @@ class PageImageExtractor
             if (is_string($temporaryPath)) {
                 @unlink($temporaryPath);
             }
-            report($exception);
+
+            // A warning, not report(): an unreachable/rate-limited external
+            // image is routine and self-healing (cached as failed, retried on
+            // a later ingest) — it must not page the error notifier.
+            Log::warning('Corpus image download failed', [
+                'url' => $src,
+                'reason' => $exception->getMessage(),
+            ]);
 
             CorpusImageExtraction::query()->updateOrCreate(
                 ['content_hash' => $urlHash],


### PR DESCRIPTION
Each 429'd external image download hit report() and was forwarded to the production Telegram error notifier. It's a routine, self-healing condition (cached as failed, retried next ingest) — now a structured Log::warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)