### PR TITLE
feat(ai): weekly scheduled corpus re-ingest

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -22,3 +22,8 @@ Schedule::command('ai:prune-conversations')
     ->daily()
     ->withoutOverlapping()
     ->runInBackground();
+
+Schedule::command('ai:ingest-pages')
+    ->weekly()
+    ->withoutOverlapping()
+    ->runInBackground();


### PR DESCRIPTION
Safety-net schedule beside the event-driven observer ingestion: a weekly `ai:ingest-pages` backfills anything missed and heals rate-limited image extractions (failed rows retry each ingest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)