### PR TITLE
fix(ssr): guard window read in PageSettingsTab urlPreview computed

### DIFF
--- a/resources/js/components/manage/pages/PageSettingsTab.vue
+++ b/resources/js/components/manage/pages/PageSettingsTab.vue
@@ -7,7 +7,7 @@ import { Switch } from '@/components/ui/switch';
 import { Icon } from '@iconify/vue';
 import { useForm } from '@inertiajs/vue3';
 import { Loader2 } from 'lucide-vue-next';
-import { computed } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import ParentPicker from './ParentPicker.vue';
 import type { PageWorkspace, ParentOption } from './types';
 
@@ -42,7 +42,14 @@ defineExpose({ isDirty });
 
 const excludedParentIds = computed(() => [props.page.id, ...props.descendantIds]);
 
-const urlPreview = computed(() => `${window.location.origin}${form.slug}`);
+/** Read in onMounted so SSR (no `window`) renders just the slug without crashing. */
+const origin = ref('');
+
+onMounted(() => {
+    origin.value = window.location.origin;
+});
+
+const urlPreview = computed(() => `${origin.value}${form.slug}`);
 
 const toggles: { field: 'hidden' | 'hidden_from_bot' | 'smart_search' | 'requires_prefix'; label: string; description: string }[] = [
     { field: 'hidden', label: 'مخفي', description: 'إخفاء الصفحة من الموقع الإلكتروني.' },


### PR DESCRIPTION
## Problem

Production Inertia SSR crashes repeatedly with:

```
ReferenceError: window is not defined
    at ComputedRefImpl.fn (file:///app/bootstrap/ssr/assets/Edit-Dr1tET5I.js:3332:39)
```

The culprit is `resources/js/components/manage/pages/PageSettingsTab.vue` (bundled into the `Edit-*.js` chunk via `pages/manage/pages/Edit.vue`):

```ts
const urlPreview = computed(() => `${window.location.origin}${form.slug}`);
```

The computed evaluates during SSR render, where `window` does not exist.

## Fix

Read `window.location.origin` in `onMounted` into a ref that defaults to `''`:

- SSR renders just the slug (e.g. `/test-page`) — no crash.
- The initial client render also shows just the slug, so there is no hydration mismatch; the full origin fills in right after mount.
- Browser behavior after mount is unchanged.

A sweep of `resources/js` for other render-time `window` / `document` / `navigator` / `localStorage` / `matchMedia` reads found no other unguarded cases — the rest live in `onMounted`, event handlers, existing `typeof window` guards (GPA/Transfer calculators, wayfinder), or try/catch (`manage/pages/Index.vue`).

## Verification

- `npm run build` and `npm run build:ssr` succeed; the rebuilt SSR `Edit-*.js` chunk only references `window.location.origin` inside the mount callback.
- `npx vitest run` — 134 tests pass.
- SSR smoke test: started `node bootstrap/ssr/ssr.js` and POSTed a render request for `manage/pages/Edit` with `?tab=settings` — HTTP 200, full HTML body, URL preview rendered server-side without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)