### PR TITLE
fix(corpus): route rubbish PDF text layers to vision extraction

### DIFF
--- a/app/Ai/Corpus/DocumentVisionExtractor.php
+++ b/app/Ai/Corpus/DocumentVisionExtractor.php
@@ -46,7 +46,7 @@ class DocumentVisionExtractor
             [$this->attachment($document, $file->path)],
             provider: (string) config('ai.default', 'openrouter'),
             model: $this->model(),
-            timeout: (int) config('ai.vision.timeout', 45),
+            timeout: (int) config('ai.vision.document_timeout', 180),
         );
 
         return trim((string) $response->text);

--- a/app/Ai/Corpus/UploadedTextExtractor.php
+++ b/app/Ai/Corpus/UploadedTextExtractor.php
@@ -28,11 +28,31 @@ use Throwable;
 class UploadedTextExtractor
 {
     /**
-     * A PDF text layer shorter than this (in non-whitespace characters) is
-     * treated as a scan artifact — page numbers or stray glyphs — and the
-     * document is routed to the vision model instead.
+     * A PDF text layer with fewer LETTERS AND DIGITS than this is treated as
+     * unusable — page numbers, stray punctuation, or a font with broken
+     * ToUnicode maps that extracts as whitespace/soft-hyphen soup — and the
+     * document is routed to the vision model instead. Counting only \p{L}\p{N}
+     * matters: a 14-page Arabic PDF with no usable maps yields tens of
+     * thousands of junk characters and zero letters.
      */
     public const MIN_TEXT_LAYER_CHARS = 120;
+
+    /**
+     * Letters and digits must make up at least this fraction of the layer's
+     * non-whitespace characters. A real document's text is mostly letters;
+     * broken ToUnicode maps instead produce punctuation/soft-hyphen soup
+     * sprinkled with mojibake letters (a real 14-page Arabic PDF measured
+     * 5.5%) that clears the absolute floor but reads as rubbish.
+     */
+    public const MIN_MEANINGFUL_RATIO = 0.5;
+
+    /**
+     * When more than this fraction of a text layer's Arabic characters are
+     * presentation-form glyphs (U+FB50–U+FDFF, U+FE70–U+FEFF), the extractor
+     * dumped shaped glyphs rather than logical text — unreadable for search
+     * and for the model — so the document is routed to the vision model.
+     */
+    public const MAX_PRESENTATION_FORM_RATIO = 0.2;
 
     public function __construct(private readonly DocumentVisionExtractor $vision) {}
 
@@ -107,10 +127,33 @@ class UploadedTextExtractor
         return trim($collapsed);
     }
 
-    private function isUsableTextLayer(string $text): bool
+    /**
+     * Whether an extracted PDF text layer is real, logical-order content —
+     * enough letters/digits, and not Arabic presentation-form glyph soup.
+     */
+    public function isUsableTextLayer(string $text): bool
     {
-        $compact = (string) preg_replace('/\s+/u', '', $text);
+        preg_match_all('/[\p{L}\p{N}]/u', $text, $meaningful);
+        $meaningfulCount = count($meaningful[0]);
 
-        return mb_strlen($compact) >= self::MIN_TEXT_LAYER_CHARS;
+        if ($meaningfulCount < self::MIN_TEXT_LAYER_CHARS) {
+            return false;
+        }
+
+        $nonWhitespace = mb_strlen((string) preg_replace('/\s+/u', '', $text));
+
+        if ($meaningfulCount / max(1, $nonWhitespace) < self::MIN_MEANINGFUL_RATIO) {
+            return false;
+        }
+
+        preg_match_all('/[\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}]/u', $text, $shaped);
+
+        if ($shaped[0] === []) {
+            return true;
+        }
+
+        preg_match_all('/[\x{0600}-\x{06FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}]/u', $text, $arabic);
+
+        return count($shaped[0]) / max(1, count($arabic[0])) <= self::MAX_PRESENTATION_FORM_RATIO;
     }
 }

--- a/config/ai.php
+++ b/config/ai.php
@@ -97,6 +97,7 @@ return [
     'vision' => [
         'model' => env('AI_VISION_MODEL', 'google/gemini-2.5-flash'),
         'timeout' => (int) env('AI_VISION_TIMEOUT', 45),
+        'document_timeout' => (int) env('AI_VISION_DOCUMENT_TIMEOUT', 180),
         'max_tokens' => (int) env('AI_VISION_MAX_TOKENS', 2500),
     ],
 

--- a/tests/Feature/Ai/CorpusDocumentIngestionTest.php
+++ b/tests/Feature/Ai/CorpusDocumentIngestionTest.php
@@ -200,6 +200,38 @@ describe('extraction job', function () {
         expect(documentCorpusItem($document)?->chunks()->exists())->toBeTrue();
     });
 
+    it('falls back to the vision model for a PDF whose text layer is punctuation soup with no letters', function () {
+        enableDocumentAiSearch();
+        enableDocumentVision();
+        DocumentExtractionAgent::fake(["## الدليل الإرشادي\n\nالمحتوى الحقيقي للمستند المنسوخ بالرؤية."]);
+
+        $document = makeCorpusDocument('junk-layer.pdf', 'application/pdf');
+
+        ExtractCorpusDocumentJob::dispatch($document->id);
+
+        $document->refresh();
+
+        expect($document->status)->toBe(CorpusDocument::STATUS_READY)
+            ->and($document->extracted_markdown)->toContain('الدليل الإرشادي')
+            ->and($document->extracted_markdown)->not->toContain('- - : ;');
+
+        DocumentExtractionAgent::assertPrompted(
+            fn ($prompt): bool => str_contains($prompt->prompt, 'junk-layer.pdf')
+        );
+    });
+
+    it('judges text-layer usability on letters, order, and shaping', function (string $layer, bool $usable) {
+        expect(app(\App\Ai\Corpus\UploadedTextExtractor::class)->isUsableTextLayer($layer))->toBe($usable);
+    })->with([
+        'long logical arabic' => [str_repeat('يجب على الطالب إكمال جميع المتطلبات الدراسية قبل التخرج. ', 5), true],
+        'long english' => [str_repeat('Students must complete all required credit hours. ', 5), true],
+        'punctuation soup, no letters' => [str_repeat('- - : ; , . ( ) ­ ', 40), false],
+        'mojibake sprinkled in junk (letters clear the floor but not the ratio)' => [str_repeat('ª', 200).str_repeat('­ ( ) : . ', 400), false],
+        'too short despite being real' => ['نص قصير جداً', false],
+        'arabic presentation-form glyph soup' => [str_repeat('ﻣﻜﺎﻓﺄﺓ ﺍﻟﺘﻔﻮﻕ ﻟﻠﻄﻼﺏ ﺍﻟﻤﺘﻔﻮﻗﻴﻦ ﻓﻲ ﺍﻟﻜﻠﻴﺔ ', 10), false],
+        'mostly logical with a stray shaped char' => [str_repeat('مكافأة التفوق للطلاب المتفوقين في الكلية ', 10).'ﻣ', true],
+    ]);
+
     it('extracts an image upload via the vision model', function () {
         enableDocumentAiSearch();
         enableDocumentVision();

--- a/tests/Fixtures/junk-layer.pdf
+++ b/tests/Fixtures/junk-layer.pdf
@@ -1,0 +1,45 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 703 >>
+stream
+BT /F1 12 Tf 50 750 Td 14 TL
+(- - : ; , . - - : ; , . - - : ; , . - - : ; , .) Tj T*
+(- - : ; , . - - : ; , . - - : ; , . - - : ; , .) Tj T*
+(- - : ; , . - - : ; , . - - : ; , . - - : ; , .) Tj T*
+(- - : ; , . - - : ; , . - - : ; , . - - : ; , .) Tj T*
+(- - : ; , . - - : ; , . - - : ; , . - - : ; , .) Tj T*
+(- - : ; , . - - : ; , . - - : ; , . - - : ; , .) Tj T*
+(- - : ; , . - - : ; , . - - : ; , . - - : ; , .) Tj T*
+(- - : ; , . - - : ; , . - - : ; , . - - : ; , .) Tj T*
+(- - : ; , . - - : ; , . - - : ; , . - - : ; , .) Tj T*
+(- - : ; , . - - : ; , . - - : ; , . - - : ; , .) Tj T*
+(- - : ; , . - - : ; , . - - : ; , . - - : ; , .) Tj T*
+(- - : ; , . - - : ; , . - - : ; , . - - : ; , .) Tj T*
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000995 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+1065
+%%EOF


### PR DESCRIPTION
## What

A 14-page Arabic PDF (لائحة الدراسة والاختبارات) uploaded to /manage/corpus extracted as rubbish. Its fonts have broken ToUnicode maps, so the pdfparser text layer came out as whitespace + soft-hyphens + punctuation + mojibake Latin (`ªµÀÁ…`): 40k non-whitespace chars, **5.5% letters, zero Arabic**. That cleared the old "≥120 non-whitespace chars" gate, so the vision fallback never fired.

New text-layer usability gate (any failure → vision model, like scans):
1. ≥120 **letters/digits** (`\p{L}\p{N}`), not just non-whitespace
2. letters+digits ≥ **50% of non-whitespace** (real text is mostly letters; the broken PDF measured 5.5%)
3. Arabic presentation-form glyphs (U+FB50–FDFF, U+FE70–FEFF) ≤ 20% of Arabic chars — above that the layer is shaped-glyph soup, not logical text

Plus `ai.vision.document_timeout` (180s, `AI_VISION_DOCUMENT_TIMEOUT`) for multi-page transcriptions — the 45s single-image budget is too tight (this PDF took 81s).

## Verification

- **Live end-to-end with the reported PDF**: routes to vision, transcribes to 51k chars of clean Arabic markdown (headings, TOC, articles)
- New fixture `junk-layer.pdf` reproduces the bug shape (288 junk chars, 0 letters) and asserts the vision route
- Dataset test for the gate: logical Arabic ✓, English ✓, punctuation soup ✗, mojibake-in-junk ✗, too-short ✗, presentation-form soup ✗, stray shaped char tolerated ✓
- Full suite: **662 passed (2625 assertions)**

After deploy: re-extract the affected production document from /manage/corpus (or I'll dispatch the job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)