### PR TITLE
fix(corpus): detect reversed-Arabic PDF text layers and route to vision

### DIFF
--- a/app/Ai/Corpus/UploadedTextExtractor.php
+++ b/app/Ai/Corpus/UploadedTextExtractor.php
@@ -148,12 +148,59 @@ class UploadedTextExtractor
 
         preg_match_all('/[\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}]/u', $text, $shaped);
 
-        if ($shaped[0] === []) {
-            return true;
+        if ($shaped[0] !== []) {
+            preg_match_all('/[\x{0600}-\x{06FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}]/u', $text, $arabic);
+
+            if (count($shaped[0]) / max(1, count($arabic[0])) > self::MAX_PRESENTATION_FORM_RATIO) {
+                return false;
+            }
         }
 
-        preg_match_all('/[\x{0600}-\x{06FF}\x{FB50}-\x{FDFF}\x{FE70}-\x{FEFF}]/u', $text, $arabic);
+        return ! $this->looksLikeReversedArabic($text);
+    }
 
-        return count($shaped[0]) / max(1, count($arabic[0])) <= self::MAX_PRESENTATION_FORM_RATIO;
+    /**
+     * Detects the other classic Arabic-PDF failure: logical codepoints dumped
+     * in VISUAL (left-to-right) order, so every word reads backwards —
+     * «جامعة» extracts as «ةعماج». The tell is positional: ة and ى are
+     * word-FINAL letters in real Arabic but lead reversed words, and the
+     * «ال» article prefix flips into a «لا» suffix. When reversed signals
+     * outweigh normal ones across the text's Arabic words, the layer is
+     * unusable.
+     */
+    private function looksLikeReversedArabic(string $text): bool
+    {
+        preg_match_all('/[\x{0620}-\x{064A}]{2,}/u', $text, $matches);
+        $words = $matches[0];
+
+        if (count($words) < 20) {
+            return false;
+        }
+
+        $reversed = 0;
+        $normal = 0;
+
+        foreach ($words as $word) {
+            $first = mb_substr($word, 0, 1);
+            $last = mb_substr($word, -1);
+
+            if ($first === 'ة' || $first === 'ى') {
+                $reversed++;
+            }
+
+            if ($last === 'ة' || $last === 'ى') {
+                $normal++;
+            }
+
+            if (mb_substr($word, 0, 2) === 'ال') {
+                $normal++;
+            }
+
+            if (mb_substr($word, -2) === 'لا') {
+                $reversed++;
+            }
+        }
+
+        return $reversed > $normal;
     }
 }

--- a/tests/Feature/Ai/CorpusDocumentIngestionTest.php
+++ b/tests/Feature/Ai/CorpusDocumentIngestionTest.php
@@ -229,6 +229,7 @@ describe('extraction job', function () {
         'mojibake sprinkled in junk (letters clear the floor but not the ratio)' => [str_repeat('ª', 200).str_repeat('­ ( ) : . ', 400), false],
         'too short despite being real' => ['نص قصير جداً', false],
         'arabic presentation-form glyph soup' => [str_repeat('ﻣﻜﺎﻓﺄﺓ ﺍﻟﺘﻔﻮﻕ ﻟﻠﻄﻼﺏ ﺍﻟﻤﺘﻔﻮﻗﻴﻦ ﻓﻲ ﺍﻟﻜﻠﻴﺔ ', 10), false],
+        'reversed arabic (visual-order dump)' => [str_repeat('ىرقلا مأ ةعماج يف يبلاطلا طابضنلااو كولسلا دعاوق ةداملا ىلع ءانب ةرداصلا تارابتخلااو ةيعماجلا ةساردلا ةحئلا ', 5), false],
         'mostly logical with a stray shaped char' => [str_repeat('مكافأة التفوق للطلاب المتفوقين في الكلية ', 10).'ﻣ', true],
     ]);
 


### PR DESCRIPTION
## What

Second rubbish-extraction mode (follow-up to #99): some Arabic PDFs extract with **logical codepoints in visual order** — every word reversed («جامعة» → «ةعماج»). That layer is 96% letters, zero presentation forms, so it passed every gate from #99 while being useless for search.

Detection is positional statistics over the layer's Arabic words (≥20 words to judge):
- ة / ى lead a word → reversed signal (they're word-final letters in real Arabic)
- «لا» word suffix → reversed signal (the flipped «ال» article)
- word ends in ة/ى or starts with «ال» → normal signal

Reversed signals > normal signals ⇒ route to the vision model like scans.

## Verification

- Both reported PDFs (قواعد السلوك والانضباط الطلابي, قواعد حقوق الطلبة) now fail the gate and route to vision; live transcription of the conduct PDF produced clean logical-order Arabic markdown (15.7k chars, 29s)
- Normal Arabic (and the vision output itself) passes the gate — no false positives
- New dataset case uses the real reversed extractor output
- Full suite: **663 passed (2626 assertions)**

After deploy: re-extract affected production documents and ingest the new uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)