### PR TITLE
fix(telegram): fold <br> in AI table cells instead of rendering them raw

### DIFF
--- a/app/Services/TelegramMarkdownService.php
+++ b/app/Services/TelegramMarkdownService.php
@@ -115,6 +115,8 @@ class TelegramMarkdownService
 
     private function convertBlockLine(string $line): string
     {
+        $line = $this->normalizeLineBreaks($line);
+
         if (preg_match('/^\s*(?:[-*_]\s*){3,}$/', $line) === 1) {
             return '';
         }
@@ -124,6 +126,17 @@ class TelegramMarkdownService
         }
 
         return (string) preg_replace('/^(\s*)[-*+]\s+/u', '$1• ', $line);
+    }
+
+    /**
+     * The assistant sometimes emits literal <br> tags (most often inside
+     * table cells to stack sub-items). Telegram's HTML parser supports no
+     * such tag, so after escaping they surface as visible "<br>" text; fold
+     * every <br> / <br/> / <br /> into a real newline instead.
+     */
+    private function normalizeLineBreaks(string $text): string
+    {
+        return (string) preg_replace('/&lt;br\s*\/?&gt;/iu', "\n", $text);
     }
 
     private function isTableRow(string $line): bool
@@ -186,8 +199,16 @@ class TelegramMarkdownService
      */
     private function renderTableRow(array $cells, ?array $headers): string
     {
+        $cells = array_map(fn (string $cell): string => $this->normalizeLineBreaks($cell), $cells);
+
         $first = $cells[0] ?? '';
         $rest = array_slice($cells, 1, preserve_keys: true);
+
+        $isMultiline = array_any($cells, fn (string $cell): bool => str_contains($cell, "\n"));
+
+        if ($isMultiline) {
+            return $this->renderMultilineTableRow($first, $rest, count($cells) === 2 ? null : $headers);
+        }
 
         if (count($cells) === 2) {
             return '• <b>'.$first.'</b>: '.$cells[1];
@@ -205,6 +226,41 @@ class TelegramMarkdownService
         }
 
         return '• <b>'.$first.'</b>'.($parts === [] ? '' : ' — '.implode(' — ', $parts));
+    }
+
+    /**
+     * A row with a cell that stacks several sub-items (via <br>) reads badly
+     * inline, so lay it out vertically: the row key as the bullet, then each
+     * value column under its bold header with the sub-items indented beneath.
+     *
+     * @param  array<int, string>  $rest
+     * @param  array<int, string>|null  $headers
+     */
+    private function renderMultilineTableRow(string $first, array $rest, ?array $headers): string
+    {
+        $lines = ['• <b>'.$first.'</b>'];
+
+        foreach ($rest as $columnIndex => $cell) {
+            if ($cell === '') {
+                continue;
+            }
+
+            $label = trim($headers[$columnIndex] ?? '');
+
+            if ($label !== '') {
+                $lines[] = '   <b>'.$label.'</b>';
+            }
+
+            foreach (explode("\n", $cell) as $subLine) {
+                $subLine = trim($subLine);
+
+                if ($subLine !== '') {
+                    $lines[] = '   '.$subLine;
+                }
+            }
+        }
+
+        return implode("\n", $lines);
     }
 
     /**

--- a/tests/Unit/Services/TelegramMarkdownServiceTest.php
+++ b/tests/Unit/Services/TelegramMarkdownServiceTest.php
@@ -49,6 +49,39 @@ it('renders a headerless table as joined bullet lines', function () {
     expect(telegramHtml($markdown))->toBe("• <b>أ</b> — ب — ج\n• <b>د</b> — هـ — و");
 });
 
+it('folds br tags inside table cells into an indented vertical layout', function () {
+    $markdown = <<<'MD'
+    | البند | علوم الحاسب | هندسة البرمجيات |
+    |---|---|---|
+    | المواد | • الذكاء الاصطناعي<br>• نظم التشغيل | • اختبار البرمجيات<br/>• أنماط التصميم |
+    MD;
+
+    expect(telegramHtml($markdown))->toBe(
+        "• <b>المواد</b>\n"
+        ."   <b>علوم الحاسب</b>\n"
+        ."   • الذكاء الاصطناعي\n"
+        ."   • نظم التشغيل\n"
+        ."   <b>هندسة البرمجيات</b>\n"
+        ."   • اختبار البرمجيات\n"
+        .'   • أنماط التصميم'
+    );
+});
+
+it('folds br tags in a two-column table into stacked value lines', function () {
+    $markdown = "| المهارات | الأساسية |\n|---|---|\n| المطور | • البرمجة<br>• التحليل |";
+
+    expect(telegramHtml($markdown))->toBe(
+        "• <b>المطور</b>\n"
+        ."   • البرمجة\n"
+        .'   • التحليل'
+    );
+});
+
+it('folds br tags in regular paragraph text into newlines', function () {
+    expect(telegramHtml('السطر الأول<br>السطر الثاني<br />السطر الثالث'))
+        ->toBe("السطر الأول\nالسطر الثاني\nالسطر الثالث");
+});
+
 it('converts list markers to bullets and keeps numbered lists', function () {
     expect(telegramHtml("- طلاب البكالوريوس فقط\n* منتظم\n1. أولاً"))
         ->toBe("• طلاب البكالوريوس فقط\n• منتظم\n1. أولاً");


### PR DESCRIPTION
## Problem

The Telegram AI assistant emits markdown comparison tables whose cells stack sub-items using literal `<br>` tags, e.g.:

```
| المواد | • الذكاء الاصطناعي<br>• تعلم الآلة | ... |
```

Every reply passes through `htmlspecialchars` in `TelegramMarkdownService`, which escapes `<br>` to `&lt;br&gt;`. Telegram's `parse_mode=HTML` supports only a small tag whitelist (`b/i/u/s/a/code/pre/blockquote`) — **no `<br>`** — so it renders `&lt;br&gt;` straight back as the visible text `<br>`. Users saw `<br>` littered throughout replies (reported on the "علوم الحاسب vs هندسة البرمجيات" comparison table).

## Fix

In `app/Services/TelegramMarkdownService.php`:

- **`normalizeLineBreaks()`** — folds every `<br>` / `<br/>` / `<br />` (case-insensitive) into a real newline. Applied to paragraph lines and per table cell.
- **`renderMultilineTableRow()`** — a multi-item cell reads terribly inline, so such rows now lay out vertically: the row key as the bullet, each value column under its **bold header**, sub-items indented beneath. Single-line rows keep the existing compact inline form; two-column tables still drop the header label (consistent with prior `key: value` behavior).

### Before → After

```
• المواد المميزة — علوم الحاسب: • الذكاء الاصطناعي<br>• تعلم الآلة — ...
```
becomes
```
• المواد المميزة
   🖥️ علوم الحاسب
   • الذكاء الاصطناعي
   • تعلم الآلة
   🛠️ هندسة البرمجيات
   • نمذجة وتحليل البرمجيات
```

## Tests

Added 3 unit tests (br in 3-column cells → vertical layout, br in 2-column cells → stacked values, br in paragraph text). All 18 tests in the file pass; Pint clean.

## Reviewer notes

- Root cause is the formatter, not the corpus data — no DB/content change needed.
- The model shouldn't emit raw HTML `<br>` at all; this makes the transport robust regardless. A follow-up could tighten the assistant's instructions to discourage `<br>` at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)