### PR TITLE
fix(manage): show review-mode editors their own pending page edits

### DIFF
--- a/app/Http/Controllers/Manage/PageController.php
+++ b/app/Http/Controllers/Manage/PageController.php
@@ -94,6 +94,12 @@ class PageController extends Controller
     {
         $page->load(['children', 'users']);
 
+        $pendingChange = $this->pendingChangeFor($page);
+
+        if ($pendingChange !== null) {
+            $page->fill($pendingChange->payload);
+        }
+
         $allPages = Page::withTrashed()->orderBy('order')->orderBy('id')->get(['id', 'title', 'parent_id', 'order', 'deleted_at']);
         $pagesById = $allPages->keyBy('id');
         $livePagesByParent = $allPages->filter(fn (Page $candidate) => ! $candidate->trashed())
@@ -149,29 +155,32 @@ class PageController extends Controller
             'copilot' => [
                 'enabled' => app(AiSettings::class)->isFeatureEnabled('admin_copilot'),
             ],
-            'review' => $this->reviewContext($page),
+            'review' => [
+                'mode' => auth()->user()?->mustHaveChangesReviewed() ?? false,
+                'has_pending' => $pendingChange !== null,
+            ],
         ]);
     }
 
     /**
-     * Review banner context for the workspace: whether the viewer's own saves
-     * are review-gated, and whether they already have a pending change waiting
-     * on this page.
-     *
-     * @return array{mode: bool, has_pending: bool}
+     * The viewer's own pending change request against this page, if their
+     * saves are review-gated and they have one. The workspace overlays this
+     * payload onto the page so a review-mode editor sees (and can keep
+     * editing) their proposed version rather than the untouched live page.
      */
-    protected function reviewContext(Page $page): array
+    protected function pendingChangeFor(Page $page): ?PageChangeRequest
     {
         $user = auth()->user();
-        $mode = $user !== null && $user->mustHaveChangesReviewed();
 
-        return [
-            'mode' => $mode,
-            'has_pending' => $mode && $page->changeRequests()
-                ->where('author_id', $user->id)
-                ->where('status', PageChangeRequest::STATUS_PENDING)
-                ->exists(),
-        ];
+        if ($user === null || ! $user->mustHaveChangesReviewed()) {
+            return null;
+        }
+
+        return $page->changeRequests()
+            ->where('author_id', $user->id)
+            ->where('status', PageChangeRequest::STATUS_PENDING)
+            ->latest('updated_at')
+            ->first();
     }
 
     /**

--- a/resources/js/pages/manage/pages/Edit.vue
+++ b/resources/js/pages/manage/pages/Edit.vue
@@ -227,7 +227,9 @@ onUnmounted(() => {
             <ShieldCheck class="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden="true" />
             <p>
                 تعديلاتك على هذه الصفحة تُرسل للمراجعة ولا تظهر على الموقع إلا بعد اعتمادها.
-                <span v-if="review.has_pending" class="font-medium">لديك تعديل بانتظار المراجعة على هذه الصفحة.</span>
+                <span v-if="review.has_pending" class="font-medium"
+                    >لديك تعديل بانتظار المراجعة، والحقول أدناه تعرض نسختك المقترحة لا المنشورة.</span
+                >
             </p>
         </div>
 

--- a/tests/Feature/Manage/ReviewsTest.php
+++ b/tests/Feature/Manage/ReviewsTest.php
@@ -82,6 +82,64 @@ describe('review-mode capture on page update', function () {
             ->get("/manage/pages/{$page->id}/edit")
             ->assertInertia(fn (Assert $inertia) => $inertia->where('review.has_pending', true));
     });
+
+    it('overlays the editor\'s own pending payload onto the workspace so they see their proposed version', function () {
+        $page = PageFactory::new()->create(['title' => 'الأصل', 'icon' => 'star', 'html_content' => 'قديم']);
+
+        PageChangeRequest::factory()->create([
+            'page_id' => $page->id,
+            'author_id' => $this->reviewEditor->id,
+            'payload' => ['title' => 'المقترح', 'icon' => 'heart'],
+        ]);
+
+        $this->actingAs($this->reviewEditor)
+            ->get("/manage/pages/{$page->id}/edit")
+            ->assertInertia(fn (Assert $inertia) => $inertia
+                ->where('page.title', 'المقترح')
+                ->where('page.icon', 'heart')
+                ->where('page.html_content', 'قديم')
+                ->where('review.has_pending', true)
+                ->etc());
+
+        expect($page->fresh()->title)->toBe('الأصل');
+    });
+
+    it('does not overlay another editor\'s pending payload', function () {
+        $otherReviewer = User::factory()->create(['requires_review' => true]);
+        $otherReviewer->assignRole('editor');
+
+        $page = PageFactory::new()->create(['title' => 'الأصل']);
+
+        PageChangeRequest::factory()->create([
+            'page_id' => $page->id,
+            'author_id' => $otherReviewer->id,
+            'payload' => ['title' => 'تعديل شخص آخر'],
+        ]);
+
+        $this->actingAs($this->reviewEditor)
+            ->get("/manage/pages/{$page->id}/edit")
+            ->assertInertia(fn (Assert $inertia) => $inertia
+                ->where('page.title', 'الأصل')
+                ->where('review.has_pending', false)
+                ->etc());
+    });
+
+    it('shows the live page to an unrestricted editor even when a pending change exists', function () {
+        $page = PageFactory::new()->create(['title' => 'الأصل']);
+
+        PageChangeRequest::factory()->create([
+            'page_id' => $page->id,
+            'author_id' => $this->reviewEditor->id,
+            'payload' => ['title' => 'المقترح'],
+        ]);
+
+        $this->actingAs($this->editor)
+            ->get("/manage/pages/{$page->id}/edit")
+            ->assertInertia(fn (Assert $inertia) => $inertia
+                ->where('page.title', 'الأصل')
+                ->where('review.has_pending', false)
+                ->etc());
+    });
 });
 
 describe('review queue authorization', function () {


### PR DESCRIPTION
A review-mode editor's save is captured as a pending PageChangeRequest and
the live page is left untouched, but the workspace always serialized the live
page — so reopening it showed the original content, hiding the editor's own
proposed changes with no way to see or continue them.

Overlay the editor's own pending payload onto the page in
PageController::edit() before serializing, so they see and can keep editing
their proposal (further saves already merge into the same pending request).
The overlay is scoped to the viewer's own pending request; unrestricted
editors and other users still see the live page. Clarify the banner copy to
say the fields show the proposed, not the published, version.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L5sPmadbuhvxDxtDa4x8Cq