### PR TITLE
feat(ai): switch vision model to gemini-3.1-flash-lite + structure-preserving OCR prompt

### DIFF
--- a/app/Ai/Chat/ChatAttachmentTextExtractor.php
+++ b/app/Ai/Chat/ChatAttachmentTextExtractor.php
@@ -166,6 +166,6 @@ class ChatAttachmentTextExtractor
     {
         $model = trim($this->settings->vision_model);
 
-        return $model !== '' ? $model : (string) config('ai.vision.model', 'google/gemini-2.5-flash');
+        return $model !== '' ? $model : (string) config('ai.vision.model', 'google/gemini-3.1-flash-lite');
     }
 }

--- a/app/Ai/Corpus/DocumentVisionExtractor.php
+++ b/app/Ai/Corpus/DocumentVisionExtractor.php
@@ -76,6 +76,6 @@ class DocumentVisionExtractor
     {
         $model = trim($this->settings->vision_model);
 
-        return $model !== '' ? $model : (string) config('ai.vision.model', 'google/gemini-2.5-flash');
+        return $model !== '' ? $model : (string) config('ai.vision.model', 'google/gemini-3.1-flash-lite');
     }
 }

--- a/app/Ai/Corpus/PageImageExtractor.php
+++ b/app/Ai/Corpus/PageImageExtractor.php
@@ -287,7 +287,7 @@ class PageImageExtractor
             $this->ledger->clearContextCosts();
 
             $response = (new DocumentExtractionAgent)->prompt(
-                'انسخ المحتوى النصي للصورة المرفقة كاملاً بصيغة ماركداون. إن لم تحتوِ الصورة نصاً فصِف محتواها بإيجاز في سطر واحد.'."\n\n"
+                'انسخ المحتوى النصي للصورة المرفقة كاملاً بصيغة ماركداون مع الحفاظ على بنيتها: استخدم عناوين وجداول ماركداون عند وجود جداول أو تجميعات (مثل المستويات الدراسية)، واحرص على ربط كل عنصر بمجموعته الصحيحة وقيمه الصحيحة (مثل رمز المقرر واسمه وعدد ساعاته). إن لم تحتوِ الصورة نصاً فصِف محتواها بإيجاز في سطر واحد.'."\n\n"
                     .'Attached image: '.basename($absolutePath),
                 [Image::fromPath($absolutePath, $this->mimeFor($absolutePath))->as(basename($absolutePath))],
                 provider: (string) config('ai.default', 'openrouter'),
@@ -393,6 +393,6 @@ class PageImageExtractor
     {
         $model = trim($this->settings->vision_model);
 
-        return $model !== '' ? $model : (string) config('ai.vision.model', 'google/gemini-2.5-flash');
+        return $model !== '' ? $model : (string) config('ai.vision.model', 'google/gemini-3.1-flash-lite');
     }
 }

--- a/config/ai.php
+++ b/config/ai.php
@@ -111,7 +111,7 @@ return [
     */
 
     'vision' => [
-        'model' => env('AI_VISION_MODEL', 'google/gemini-2.5-flash'),
+        'model' => env('AI_VISION_MODEL', 'google/gemini-3.1-flash-lite'),
         'timeout' => (int) env('AI_VISION_TIMEOUT', 45),
         'document_timeout' => (int) env('AI_VISION_DOCUMENT_TIMEOUT', 180),
         'max_tokens' => (int) env('AI_VISION_MAX_TOKENS', 2500),

--- a/database/settings/2026_07_10_000001_create_ai_settings.php
+++ b/database/settings/2026_07_10_000001_create_ai_settings.php
@@ -12,7 +12,7 @@ return new class extends SettingsMigration
         $this->migrator->add('ai.telegram_ai_enabled', false);
         $this->migrator->add('ai.admin_copilot_enabled', false);
         $this->migrator->add('ai.chat_model', 'deepseek/deepseek-v4-flash');
-        $this->migrator->add('ai.vision_model', 'google/gemini-2.5-flash');
+        $this->migrator->add('ai.vision_model', 'google/gemini-3.1-flash-lite');
         $this->migrator->add('ai.embedding_model', 'openai/text-embedding-3-small');
         $this->migrator->add('ai.daily_budget_usd', 5.0);
         $this->migrator->add('ai.per_session_rate_limit', 20);

--- a/tests/Feature/AiSettingsTest.php
+++ b/tests/Feature/AiSettingsTest.php
@@ -20,7 +20,7 @@ describe('AiSettings defaults', function () {
         $settings = app(AiSettings::class);
 
         expect($settings->chat_model)->toBe('deepseek/deepseek-v4-flash')
-            ->and($settings->vision_model)->toBe('google/gemini-2.5-flash')
+            ->and($settings->vision_model)->toBe('google/gemini-3.1-flash-lite')
             ->and($settings->embedding_model)->toBe('openai/text-embedding-3-small');
     });
 
@@ -77,7 +77,7 @@ describe('manage settings AI card', function () {
             'admin_copilot_enabled' => true,
             'admin_assistant_enabled' => false,
             'chat_model' => 'deepseek/deepseek-v4-flash',
-            'vision_model' => 'google/gemini-2.5-flash',
+            'vision_model' => 'google/gemini-3.1-flash-lite',
             'embedding_model' => 'openai/text-embedding-3-small',
             'daily_budget_usd' => 7.5,
             'per_session_rate_limit' => 25,
@@ -111,7 +111,7 @@ describe('manage settings AI card', function () {
                 ->component('manage/settings/Index')
                 ->where('ai.ai_enabled', false)
                 ->where('ai.chat_model', 'deepseek/deepseek-v4-flash')
-                ->where('ai.vision_model', 'google/gemini-2.5-flash')
+                ->where('ai.vision_model', 'google/gemini-3.1-flash-lite')
                 ->where('ai.embedding_model', 'openai/text-embedding-3-small')
                 ->where('ai.daily_budget_usd', 5)
                 ->where('ai.per_session_rate_limit', 20)


### PR DESCRIPTION
## Why

The `/alkhtt` study-plan images were extracted by `google/gemini-2.5-flash` as flat text dumps — course codes, names, and hours jumbled with no level structure (fixed manually in prod, see below). Benchmarked 11 OpenRouter vision models on 3 of those real images against hand-verified ground truth.

## Benchmark (composite = code recall + level assignment + credit hours + Arabic name fidelity)

| Model | Composite | Halluc. | $/image | Latency |
|---|---|---|---|---|
| **google/gemini-3.1-flash-lite** | **1.000** | 0 | $0.0020 | 9.2s |
| google/gemini-3-flash-preview | 1.000 | 0 | $0.0043 | 11.4s |
| google/gemini-3.5-flash | 1.000 | 0 | $0.0139 | 9.7s |
| google/gemini-2.5-flash (current) | 0.989 | 0 | $0.0034 | 11.3s |
| qwen/qwen3-vl-235b-a22b | 0.956 | 4 | $0.0025 | 48.2s |
| qwen/qwen3-vl-30b-a3b | 0.853 | 6 | $0.0007 | 24.2s |
| mistral-small-3.2-24b | 0.773 | 6 | $0.0005 | 14.0s |
| z-ai/glm-4.6v | 0.764 (hallucinates Arabic names) | 7 | $0.0046 | 95.0s |
| openai/gpt-5-mini | 0.649 (refuses low-res) | 1 | $0.0062 | 47.4s |
| anthropic/claude-haiku-4.5 | 0.634 (garbles codes at low-res) | 1 | $0.0088 | 14.7s |
| google/gemini-2.5-flash-lite | 0.628 (truncates large tables) | 0 | $0.0002 | 6.8s |

Winner is cheaper than the current model ($0.25/M in vs $0.30/M) and perfect on every metric including the hardest low-res image.

## Changes

- Vision model default → `google/gemini-3.1-flash-lite` (config, settings migration, code fallbacks, tests)
- Ingestion OCR prompt now explicitly asks to preserve structure (markdown headings/tables, correct item↔group↔values association) — the flat-dump failure mode was largely prompt-induced
- Prod `ai.vision_model` setting already switched (settings cache cleared)

## Notes

- The `corpus_image_extractions` perma-cache (by file-bytes/URL hash) already prevents re-OCR on page edits; `status=extracted` rows are never re-read, so manual corrections persist.
- The 7 `/alkhtt` extraction rows were hand-corrected in prod (`model='manual'`) and page 121 re-ingested (66 chunks ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)