### PR TITLE
Add XOR, NAND, and NOR to the truth table generator

### DIFF
--- a/app/Ai/Tools/TruthTableTool.php
+++ b/app/Ai/Tools/TruthTableTool.php
@@ -24,8 +24,8 @@ class TruthTableTool implements Tool
     public function description(): Stringable|string
     {
         return 'Generate the truth table of a propositional logic formula (توليد جدول الصواب لصيغة منطقية). '
-            .'Connectives may be written in any common notation: ¬ ~ ! not, ∧ /\ && and, ∨ \/ || or, → -> => implies, ↔ <-> iff, '
-            .'and the constants ⊤/T/true and ⊥/F/false. Example: "p /\ q -> ~r". '
+            .'Connectives may be written in any common notation: ¬ ~ ! not, ∧ /\ && and, ↑ ⊼ nand, ∨ \/ || or, ↓ ⊽ nor, ⊕ ⊻ xor, '
+            .'→ -> => implies, ↔ <-> iff, and the constants ⊤/T/true and ⊥/F/false. Example: "p /\ q -> ~r". '
             .'Returns the canonical formula, a monospace table with a column per variable and per subformula, '
             .'and whether the formula is a tautology or a contradiction. Use it instead of computing rows yourself. Supports up to '
             .TruthTableGenerator::MAX_VARIABLES.' variables.';

--- a/app/Services/Logic/FormulaParser.php
+++ b/app/Services/Logic/FormulaParser.php
@@ -9,13 +9,18 @@ namespace App\Services\Logic;
  *
  *  - not:  ¬  ~  !  not
  *  - and:  ∧  /\  &&  &  ^  ·  and
+ *  - nand:  ↑  ⊼  nand
  *  - or:   ∨  \/  ||  |  or
+ *  - nor:  ↓  ⊽  nor
+ *  - xor:  ⊕  ⊻  xor
  *  - implies:  →  ⇒  ->  =>  implies
  *  - iff:  ↔  ⇔  <->  <=>  iff
  *  - constants:  ⊤ T true   /   ⊥ F false
  *
- * Precedence, loosest to tightest: ↔, → (right-associative), ∨, ∧, ¬.
- * Variables are identifiers like p, q, rain (word connectives are reserved,
+ * Precedence, loosest to tightest: ↔, → (right-associative), ∨, ↓, ⊕, ∧, ↑, ¬.
+ * ↑ and ↓ are left-associative and non-associative; the rest of the binary
+ * connectives are left-associative (→ is right-associative). Variables are
+ * identifiers like p, q, rain (word connectives are reserved,
  * case-insensitively).
  */
 class FormulaParser
@@ -31,6 +36,9 @@ class FormulaParser
         ['/\G\s+/u', null],
         ['/\G(?:<->|<=>|↔|⇔)/u', 'IFF'],
         ['/\G(?:->|=>|→|⇒)/u', 'IMPLIES'],
+        ['/\G(?:⊕|⊻)/u', 'XOR'],
+        ['/\G(?:↑|⊼)/u', 'NAND'],
+        ['/\G(?:↓|⊽)/u', 'NOR'],
         ['/\G(?:\/\\\\|&&|∧|·|\^|&)/u', 'AND'],
         ['/\G(?:\\\\\/|\|\||∨|\|)/u', 'OR'],
         ['/\G(?:¬|~|!)/u', 'NOT'],
@@ -49,7 +57,10 @@ class FormulaParser
     private const RESERVED_WORDS = [
         'not' => 'NOT',
         'and' => 'AND',
+        'nand' => 'NAND',
         'or' => 'OR',
+        'nor' => 'NOR',
+        'xor' => 'XOR',
         'implies' => 'IMPLIES',
         'iff' => 'IFF',
         'true' => 'TRUE',
@@ -171,11 +182,35 @@ class FormulaParser
 
     private function parseOr(): Node
     {
-        $node = $this->parseAnd();
+        $node = $this->parseNor();
 
         while ($this->currentKind() === 'OR') {
             $this->position++;
-            $node = Node::binary(NodeKind::OrOp, $node, $this->parseAnd());
+            $node = Node::binary(NodeKind::OrOp, $node, $this->parseNor());
+        }
+
+        return $node;
+    }
+
+    private function parseNor(): Node
+    {
+        $node = $this->parseXor();
+
+        while ($this->currentKind() === 'NOR') {
+            $this->position++;
+            $node = Node::binary(NodeKind::NorOp, $node, $this->parseXor());
+        }
+
+        return $node;
+    }
+
+    private function parseXor(): Node
+    {
+        $node = $this->parseAnd();
+
+        while ($this->currentKind() === 'XOR') {
+            $this->position++;
+            $node = Node::binary(NodeKind::XorOp, $node, $this->parseAnd());
         }
 
         return $node;
@@ -183,11 +218,23 @@ class FormulaParser
 
     private function parseAnd(): Node
     {
-        $node = $this->parseUnary();
+        $node = $this->parseNand();
 
         while ($this->currentKind() === 'AND') {
             $this->position++;
-            $node = Node::binary(NodeKind::AndOp, $node, $this->parseUnary());
+            $node = Node::binary(NodeKind::AndOp, $node, $this->parseNand());
+        }
+
+        return $node;
+    }
+
+    private function parseNand(): Node
+    {
+        $node = $this->parseUnary();
+
+        while ($this->currentKind() === 'NAND') {
+            $this->position++;
+            $node = Node::binary(NodeKind::NandOp, $node, $this->parseUnary());
         }
 
         return $node;

--- a/app/Services/Logic/Node.php
+++ b/app/Services/Logic/Node.php
@@ -52,7 +52,10 @@ final readonly class Node
             NodeKind::Constant => $this->value,
             NodeKind::Not => ! $this->children[0]->evaluate($assignment),
             NodeKind::AndOp => $this->children[0]->evaluate($assignment) && $this->children[1]->evaluate($assignment),
+            NodeKind::NandOp => ! ($this->children[0]->evaluate($assignment) && $this->children[1]->evaluate($assignment)),
             NodeKind::OrOp => $this->children[0]->evaluate($assignment) || $this->children[1]->evaluate($assignment),
+            NodeKind::NorOp => ! ($this->children[0]->evaluate($assignment) || $this->children[1]->evaluate($assignment)),
+            NodeKind::XorOp => $this->children[0]->evaluate($assignment) !== $this->children[1]->evaluate($assignment),
             NodeKind::Implies => ! $this->children[0]->evaluate($assignment) || $this->children[1]->evaluate($assignment),
             NodeKind::Iff => $this->children[0]->evaluate($assignment) === $this->children[1]->evaluate($assignment),
         };
@@ -70,6 +73,9 @@ final readonly class Node
             NodeKind::Not => '¬'.$this->renderChild($this->children[0], parenthesizeEqual: false),
             NodeKind::Implies => $this->renderChild($this->children[0], parenthesizeEqual: true)
                 .' → '.$this->renderChild($this->children[1], parenthesizeEqual: false),
+            NodeKind::NandOp, NodeKind::NorOp => $this->renderChild($this->children[0], parenthesizeEqual: false)
+                .' '.$this->kind->symbol().' '
+                .$this->renderChild($this->children[1], parenthesizeEqual: true),
             default => $this->renderChild($this->children[0], parenthesizeEqual: false)
                 .' '.$this->kind->symbol().' '
                 .$this->renderChild($this->children[1], parenthesizeEqual: false),

--- a/app/Services/Logic/NodeKind.php
+++ b/app/Services/Logic/NodeKind.php
@@ -12,13 +12,18 @@ enum NodeKind
     case Constant;
     case Not;
     case AndOp;
+    case NandOp;
     case OrOp;
+    case NorOp;
+    case XorOp;
     case Implies;
     case Iff;
 
     /**
      * Binding strength — higher binds tighter. ↔ is loosest, ¬ is tightest,
-     * atoms never need parentheses.
+     * atoms never need parentheses. Every connective has a distinct level so
+     * rendering stays unambiguous: the or-family (∨ ↓ ⊕) binds looser than the
+     * and-family (∧ ↑), matching the classic "and before or" convention.
      */
     public function precedence(): int
     {
@@ -26,9 +31,12 @@ enum NodeKind
             self::Iff => 1,
             self::Implies => 2,
             self::OrOp => 3,
-            self::AndOp => 4,
-            self::Not => 5,
-            self::Variable, self::Constant => 6,
+            self::NorOp => 4,
+            self::XorOp => 5,
+            self::AndOp => 6,
+            self::NandOp => 7,
+            self::Not => 8,
+            self::Variable, self::Constant => 9,
         };
     }
 
@@ -41,7 +49,10 @@ enum NodeKind
         return match ($this) {
             self::Not => '¬',
             self::AndOp => '∧',
+            self::NandOp => '↑',
             self::OrOp => '∨',
+            self::NorOp => '↓',
+            self::XorOp => '⊕',
             self::Implies => '→',
             self::Iff => '↔',
             self::Variable, self::Constant => '',

--- a/resources/js/pages/tools/TruthTablePage.vue
+++ b/resources/js/pages/tools/TruthTablePage.vue
@@ -153,12 +153,15 @@ interface TruthTableResult {
     is_contradiction: boolean;
 }
 
-const examples = ['p /\\ q -> ~r', 'p and q or not r', '(p -> q) <-> (~q -> ~p)', 'p ∧ ¬p'];
+const examples = ['p /\\ q -> ~r', 'p and q or not r', 'p xor q', '(p -> q) <-> (~q -> ~p)', 'p ∧ ¬p'];
 
 const syntaxReference = [
     { name: 'النفي (not)', forms: '¬p    ~p    !p    not p' },
     { name: 'العطف (and)', forms: 'p ∧ q    p /\\ q    p && q    p and q' },
+    { name: 'نفي العطف (nand)', forms: 'p ↑ q    p ⊼ q    p nand q' },
     { name: 'الفصل (or)', forms: 'p ∨ q    p \\/ q    p || q    p or q' },
+    { name: 'نفي الفصل (nor)', forms: 'p ↓ q    p ⊽ q    p nor q' },
+    { name: 'الفصل الحصري (xor)', forms: 'p ⊕ q    p ⊻ q    p xor q' },
     { name: 'الشرط (implies)', forms: 'p → q    p -> q    p => q    p implies q' },
     { name: 'التكافؤ (iff)', forms: 'p ↔ q    p <-> q    p <=> q    p iff q' },
     { name: 'الثوابت (constants)', forms: '⊤  T  true    /    ⊥  F  false' },

--- a/tests/Unit/Services/TruthTableGeneratorTest.php
+++ b/tests/Unit/Services/TruthTableGeneratorTest.php
@@ -43,6 +43,90 @@ it('parses or and iff notations identically', function (string $formula) {
     'single pipe' => ['p | q <-> r'],
 ]);
 
+it('evaluates exclusive or (xor)', function () {
+    $table = truthTable('p xor q');
+
+    expect($table->formula)->toBe('p ⊕ q')
+        ->and($table->columns)->toBe(['p', 'q', 'p ⊕ q'])
+        ->and($table->rows)->toBe([
+            [true, true, false],
+            [true, false, true],
+            [false, true, true],
+            [false, false, false],
+        ]);
+});
+
+it('evaluates nand (not-and)', function () {
+    $table = truthTable('p nand q');
+
+    expect($table->formula)->toBe('p ↑ q')
+        ->and($table->columns)->toBe(['p', 'q', 'p ↑ q'])
+        ->and($table->rows)->toBe([
+            [true, true, false],
+            [true, false, true],
+            [false, true, true],
+            [false, false, true],
+        ]);
+});
+
+it('evaluates nor (not-or)', function () {
+    $table = truthTable('p nor q');
+
+    expect($table->formula)->toBe('p ↓ q')
+        ->and($table->columns)->toBe(['p', 'q', 'p ↓ q'])
+        ->and($table->rows)->toBe([
+            [true, true, false],
+            [true, false, false],
+            [false, true, false],
+            [false, false, true],
+        ]);
+});
+
+it('parses every notation for xor, nand, and nor identically', function (string $formula, string $canonical) {
+    expect(truthTable($formula)->formula)->toBe($canonical);
+})->with([
+    'xor unicode' => ['p ⊕ q', 'p ⊕ q'],
+    'xor alt unicode' => ['p ⊻ q', 'p ⊕ q'],
+    'xor word' => ['p XOR q', 'p ⊕ q'],
+    'nand unicode' => ['p ↑ q', 'p ↑ q'],
+    'nand alt unicode' => ['p ⊼ q', 'p ↑ q'],
+    'nand word' => ['p NAND q', 'p ↑ q'],
+    'nor unicode' => ['p ↓ q', 'p ↓ q'],
+    'nor alt unicode' => ['p ⊽ q', 'p ↓ q'],
+    'nor word' => ['p NOR q', 'p ↓ q'],
+]);
+
+it('gives xor precedence over or and under and', function () {
+    $table = truthTable('p or q xor r and s');
+
+    expect($table->formula)->toBe('p ∨ q ⊕ r ∧ s')
+        ->and($table->columns)->toContain('q ⊕ r ∧ s')
+        ->and($table->columns)->toContain('r ∧ s')
+        ->and($table->columns)->not->toContain('p ∨ q');
+});
+
+it('keeps nand and nor left-associative and round-trips their grouping', function () {
+    expect(truthTable('p nand q nand r')->formula)->toBe('p ↑ q ↑ r')
+        ->and(truthTable('p nand (q nand r)')->formula)->toBe('p ↑ (q ↑ r)')
+        ->and(truthTable('p nor q nor r')->formula)->toBe('p ↓ q ↓ r')
+        ->and(truthTable('p nor (q nor r)')->formula)->toBe('p ↓ (q ↓ r)');
+
+    // (p ↑ q) ↑ r differs from p ↑ (q ↑ r) at p=F (row 4): left-assoc is F, right-assoc is T.
+    $leftAssociative = truthTable('p nand q nand r')->rows[4];
+    $rightAssociative = truthTable('p nand (q nand r)')->rows[4];
+
+    expect(end($leftAssociative))->toBeFalse()
+        ->and(end($rightAssociative))->toBeTrue();
+});
+
+it('classifies xor, nand, and nor tautologies and contradictions', function () {
+    expect(truthTable('p xor p')->isContradiction())->toBeTrue()
+        ->and(truthTable('p xor not p')->isTautology())->toBeTrue()
+        ->and(truthTable('(p nand q) <-> not (p and q)')->isTautology())->toBeTrue()
+        ->and(truthTable('(p nor q) <-> not (p or q)')->isTautology())->toBeTrue()
+        ->and(truthTable('p nand q')->isContradiction())->toBeFalse();
+});
+
 it('gives and precedence over or', function () {
     $table = truthTable('p or q and r');
 


### PR DESCRIPTION
The truth table engine handled ¬ ∧ ∨ → ↔ but was missing the exclusive-or
and the two NAND/NOR connectives. Add all three across the shared engine so
the web tool, Telegram bot, and AI assistant pick them up at once.

- Parser accepts ⊕/⊻/xor, ↑/⊼/nand, ↓/⊽/nor with distinct precedence levels
  (or < nor < xor < and < nand) so rendering round-trips unambiguously.
- ↑ and ↓ are non-associative; their right operand is parenthesized on equal
  precedence to preserve grouping.
- Update the site's syntax reference, an example, and the AI tool description.
- Unit tests cover the truth values, every notation, precedence, and the
  left-associative NAND/NOR grouping.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YJWx7gfZJWGbXxf1kRz3pY