### PR TITLE
Add authenticated moderation MCP server with OAuth

### DIFF
--- a/app/Mcp/Servers/UqccAdminServer.php
+++ b/app/Mcp/Servers/UqccAdminServer.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Mcp\Servers;
+
+use App\Mcp\Tools\Moderation\ApprovePageChangeTool;
+use App\Mcp\Tools\Moderation\CreateTutorTool;
+use App\Mcp\Tools\Moderation\CreateUserTool;
+use App\Mcp\Tools\Moderation\DeleteTutorTool;
+use App\Mcp\Tools\Moderation\DeleteUserTool;
+use App\Mcp\Tools\Moderation\ListManagedPagesTool;
+use App\Mcp\Tools\Moderation\ListPendingChangesTool;
+use App\Mcp\Tools\Moderation\ListTutorsTool;
+use App\Mcp\Tools\Moderation\ListUsersTool;
+use App\Mcp\Tools\Moderation\RejectPageChangeTool;
+use App\Mcp\Tools\Moderation\TrashPageTool;
+use App\Mcp\Tools\Moderation\UpdatePageTool;
+use App\Mcp\Tools\Moderation\UpdateTutorTool;
+use App\Mcp\Tools\Moderation\UpdateUserTool;
+use Laravel\Mcp\Server;
+
+/**
+ * Authenticated moderation MCP server for the UQU College of Computing
+ * student guide (uqucc). Unlike the public {@see UqccServer}, every tool
+ * here performs a privileged write (or reads non-public admin state), so the
+ * route is protected by OAuth2 (`auth:api`, Passport) in routes/ai.php.
+ *
+ * Each tool re-checks the signed-in moderator's ability with
+ * `$request->user()->can(...)` — the same abilities the `/manage` panel
+ * enforces (`review-changes`, `manage-private-tutors`, `manage-users`,
+ * `edit-content`) — so an authenticated editor still cannot reach an
+ * admin-only surface.
+ */
+class UqccAdminServer extends Server
+{
+    protected string $name = 'UQU CC Moderation';
+
+    protected string $version = '1.0.0';
+
+    protected string $instructions = <<<'MARKDOWN'
+        Authenticated moderation tools for the College of Computing student guide (uqucc) at Umm Al-Qura University. Every tool acts as the signed-in moderator and enforces the same permissions as the admin panel: review and approve/reject pending page edits, manage private tutors, manage panel users, and edit/trash guide pages. Actions are permanent and change live site content — confirm intent before calling a write tool. Content is Arabic.
+
+        أدوات إشراف موثّقة لدليل طلاب كلية الحاسبات بجامعة أم القرى. كل أداة تعمل نيابةً عن المشرف المسجَّل وتطبّق صلاحيات لوحة الإدارة نفسها: مراجعة التعديلات المعلّقة واعتمادها أو رفضها، وإدارة المدرّسين الخصوصيين، وإدارة مستخدمي اللوحة، وتعديل صفحات الدليل أو حذفها. الإجراءات دائمة وتغيّر محتوى الموقع الفعلي، لذا تأكّد من النية قبل استدعاء أي أداة كتابة.
+        MARKDOWN;
+
+    /**
+     * Serve the whole toolset in one tools/list page.
+     */
+    public int $defaultPaginationLength = 50;
+
+    /**
+     * @var array<int, class-string<\Laravel\Mcp\Server\Tool>>
+     */
+    protected array $tools = [
+        ListPendingChangesTool::class,
+        ApprovePageChangeTool::class,
+        RejectPageChangeTool::class,
+        ListTutorsTool::class,
+        CreateTutorTool::class,
+        UpdateTutorTool::class,
+        DeleteTutorTool::class,
+        ListUsersTool::class,
+        CreateUserTool::class,
+        UpdateUserTool::class,
+        DeleteUserTool::class,
+        ListManagedPagesTool::class,
+        UpdatePageTool::class,
+        TrashPageTool::class,
+    ];
+}

--- a/app/Mcp/Servers/UqccServer.php
+++ b/app/Mcp/Servers/UqccServer.php
@@ -12,9 +12,9 @@ use Laravel\Mcp\Server;
  * through {@see Toolbox} and wrapped per-tool in {@see ReadOnlyToolAdapter}.
  *
  * Registered unauthenticated in routes/ai.php (every tool is read-only and
- * public content only) behind the `mcp` rate limiter. An authenticated admin
- * server would be a sibling class registered on its own path with an auth
- * middleware.
+ * public content only) behind the `mcp` rate limiter. Its privileged sibling
+ * {@see UqccAdminServer} exposes the moderation tools on its own path behind
+ * OAuth (`auth:api`).
  */
 class UqccServer extends Server
 {

--- a/app/Mcp/Tools/Moderation/ApprovePageChangeTool.php
+++ b/app/Mcp/Tools/Moderation/ApprovePageChangeTool.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Models\PageChangeRequest;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\DB;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+
+/**
+ * Approve a pending page change: replay its captured payload against the live
+ * page through Eloquent (so the `Page::booted()` cache flushes fire), then
+ * mark the request approved. Mirrors
+ * {@see \App\Http\Controllers\Manage\PageChangeRequestController::approve()}.
+ */
+#[Description('Approve a pending page edit and publish it to the live page (اعتماد تعديل معلّق ونشره). Takes the change request id from list_pending_changes. Re-application can still fail if the page changed since submission (e.g. a slug was taken); the request then stays pending.')]
+class ApprovePageChangeTool extends ModerationTool
+{
+    protected string $name = 'approve_page_change';
+
+    protected function requiredAbility(): string
+    {
+        return 'review-changes';
+    }
+
+    protected function perform(Request $request, User $user): Response
+    {
+        $changeRequest = PageChangeRequest::query()->find((int) $request->get('change_request_id'));
+
+        if ($changeRequest === null) {
+            return Response::error('لم يُعثر على التعديل المطلوب. No change request found for that id.');
+        }
+
+        if (! $changeRequest->isPending()) {
+            return Response::error('هذا التعديل لم يعد بانتظار المراجعة. This change request is no longer pending.');
+        }
+
+        if ($changeRequest->page === null) {
+            return Response::error('الصفحة المستهدفة لم تعد موجودة — لا يمكن اعتماد التعديل. The target page no longer exists.');
+        }
+
+        try {
+            DB::transaction(function () use ($changeRequest, $user): void {
+                $changeRequest->page->update($changeRequest->payload);
+
+                $changeRequest->update([
+                    'status' => PageChangeRequest::STATUS_APPROVED,
+                    'reviewed_by' => $user->getKey(),
+                    'reviewed_at' => now(),
+                ]);
+            });
+        } catch (\Throwable $exception) {
+            report($exception);
+
+            return Response::error('تعذّر اعتماد التعديل. ربما تغيّرت الصفحة منذ إرساله. Could not apply the change; the page may have changed since submission.');
+        }
+
+        return Response::text('تم اعتماد التعديل ونشره على الصفحة «'.$changeRequest->page->title.'». The change was approved and published.');
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'change_request_id' => $schema->integer()
+                ->description('The id of the pending change request to approve, from list_pending_changes.')
+                ->required(),
+        ];
+    }
+}

--- a/app/Mcp/Tools/Moderation/CreateTutorTool.php
+++ b/app/Mcp/Tools/Moderation/CreateTutorTool.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Http\Requests\Manage\StorePrivateTutorRequest;
+use App\Models\PrivateTutor\PrivateTutor;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+
+/**
+ * Create a private tutor and attach its courses. Mirrors
+ * {@see \App\Http\Controllers\Manage\PrivateTutorController::store()}, reusing
+ * {@see StorePrivateTutorRequest} for validation.
+ */
+#[Description('Create a new private tutor (إضافة مدرّس خصوصي جديد). Provide the name, an optional URL, and optional course_ids (from list_tutors) to attach the courses the tutor teaches.')]
+class CreateTutorTool extends ModerationTool
+{
+    protected string $name = 'create_tutor';
+
+    protected function requiredAbility(): string
+    {
+        return 'manage-private-tutors';
+    }
+
+    protected function perform(Request $request, User $user): Response
+    {
+        $rules = (new StorePrivateTutorRequest)->rules();
+        $messages = (new StorePrivateTutorRequest)->messages();
+
+        $data = $this->validateInput($request, $rules, $messages);
+
+        if ($data instanceof Response) {
+            return $data;
+        }
+
+        $tutor = PrivateTutor::create(array_filter(
+            [
+                'name' => $data['name'],
+                'url' => $data['url'] ?? null,
+            ],
+            fn (mixed $value): bool => $value !== null,
+        ));
+
+        if (array_key_exists('course_ids', $data)) {
+            $tutor->courses()->sync($data['course_ids'] ?? []);
+        }
+
+        return Response::text('تم إنشاء المدرّس «'.$tutor->name.'» (id: '.$tutor->id.'). Tutor created.');
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'name' => $schema->string()
+                ->description('The tutor\'s name.')
+                ->required(),
+            'url' => $schema->string()
+                ->description('Optional link to the tutor (e.g. a WhatsApp/Telegram/X profile). Must be a valid URL.'),
+            'course_ids' => $schema->array()
+                ->description('Optional ids of the courses this tutor teaches, from list_tutors.')
+                ->items($schema->integer()),
+        ];
+    }
+}

--- a/app/Mcp/Tools/Moderation/CreateUserTool.php
+++ b/app/Mcp/Tools/Moderation/CreateUserTool.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Http\Requests\Manage\StoreUserRequest;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+
+/**
+ * Create a panel user. Mirrors
+ * {@see \App\Http\Controllers\Manage\UserController::store()}: the email
+ * starts verified, and roles / requires_review only apply when the acting
+ * moderator holds `assign-roles`. Reuses {@see StoreUserRequest}'s rules and
+ * messages, dropping only its form-only `confirmed` password rule.
+ */
+#[Description('Create a new panel user (إضافة مستخدم جديد للوحة). Provide name, email and password. Roles and the requires_review flag are applied only if you hold the assign-roles permission. The email is marked verified on creation.')]
+class CreateUserTool extends ModerationTool
+{
+    protected string $name = 'create_user';
+
+    protected function requiredAbility(): string
+    {
+        return 'manage-users';
+    }
+
+    protected function perform(Request $request, User $user): Response
+    {
+        $rules = (new StoreUserRequest)->rules();
+        $rules['password'] = array_values(array_filter(
+            $rules['password'],
+            fn (mixed $rule): bool => $rule !== 'confirmed',
+        ));
+
+        $data = $this->validateInput($request, $rules, (new StoreUserRequest)->messages());
+
+        if ($data instanceof Response) {
+            return $data;
+        }
+
+        $panelUser = new User([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => $data['password'],
+        ]);
+        $panelUser->email_verified_at = now();
+
+        if ($user->can('assign-roles')) {
+            $panelUser->requires_review = (bool) ($data['requires_review'] ?? false);
+        }
+
+        $panelUser->save();
+
+        if ($user->can('assign-roles')) {
+            $panelUser->syncRoles($data['roles'] ?? []);
+        }
+
+        return Response::text('تم إنشاء المستخدم «'.$panelUser->name.'» (id: '.$panelUser->id.'). User created.');
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'name' => $schema->string()
+                ->description('The user\'s display name.')
+                ->required(),
+            'email' => $schema->string()
+                ->description('The user\'s email address. Must be unique.')
+                ->required(),
+            'password' => $schema->string()
+                ->description('The user\'s password (at least 8 characters).')
+                ->required(),
+            'roles' => $schema->array()
+                ->description('Role names to assign (from list_users role_options). Applied only if you hold assign-roles.')
+                ->items($schema->string()),
+            'requires_review' => $schema->boolean()
+                ->description('Whether this user\'s content edits must be reviewed before going live. Applied only if you hold assign-roles.'),
+        ];
+    }
+}

--- a/app/Mcp/Tools/Moderation/DeleteTutorTool.php
+++ b/app/Mcp/Tools/Moderation/DeleteTutorTool.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Models\PrivateTutor\PrivateTutor;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+
+/**
+ * Delete a private tutor. Attached courses are detached, not deleted. Mirrors
+ * {@see \App\Http\Controllers\Manage\PrivateTutorController::destroy()}.
+ */
+#[Description('Delete a private tutor (حذف مدرّس خصوصي). Requires tutor_id (from list_tutors). The tutor\'s courses are kept — only the tutor and its course links are removed. This cannot be undone.')]
+class DeleteTutorTool extends ModerationTool
+{
+    protected string $name = 'delete_tutor';
+
+    protected function requiredAbility(): string
+    {
+        return 'manage-private-tutors';
+    }
+
+    protected function perform(Request $request, User $user): Response
+    {
+        $tutor = PrivateTutor::query()->find((int) $request->get('tutor_id'));
+
+        if ($tutor === null) {
+            return Response::error('لم يُعثر على المدرّس المطلوب. No tutor found for that id.');
+        }
+
+        $name = $tutor->name;
+        $tutor->delete();
+
+        return Response::text('تم حذف المدرّس «'.$name.'». Tutor deleted.');
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'tutor_id' => $schema->integer()
+                ->description('The id of the tutor to delete, from list_tutors.')
+                ->required(),
+        ];
+    }
+}

--- a/app/Mcp/Tools/Moderation/DeleteUserTool.php
+++ b/app/Mcp/Tools/Moderation/DeleteUserTool.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+
+/**
+ * Delete a panel user. Self-deletion is blocked and authored pages survive
+ * (only the author pivot rows are removed). Mirrors
+ * {@see \App\Http\Controllers\Manage\UserController::destroy()}.
+ */
+#[Description('Delete a panel user (حذف مستخدم من اللوحة). Requires user_id (from list_users). You cannot delete your own account. Pages the user authored are kept. This cannot be undone.')]
+class DeleteUserTool extends ModerationTool
+{
+    protected string $name = 'delete_user';
+
+    protected function requiredAbility(): string
+    {
+        return 'manage-users';
+    }
+
+    protected function perform(Request $request, User $user): Response
+    {
+        $target = User::query()->find((int) $request->get('user_id'));
+
+        if ($target === null) {
+            return Response::error('لم يُعثر على المستخدم المطلوب. No user found for that id.');
+        }
+
+        if ($user->is($target)) {
+            return Response::error('لا يمكنك حذف حسابك. You cannot delete your own account.');
+        }
+
+        $name = $target->name;
+        $target->delete();
+
+        return Response::text('تم حذف المستخدم «'.$name.'». User deleted.');
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'user_id' => $schema->integer()
+                ->description('The id of the user to delete, from list_users.')
+                ->required(),
+        ];
+    }
+}

--- a/app/Mcp/Tools/Moderation/ListManagedPagesTool.php
+++ b/app/Mcp/Tools/Moderation/ListManagedPagesTool.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Models\Page;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+/**
+ * Every guide page with its id and management state — hidden and trashed
+ * pages included, unlike the public content tools. The lookup a client needs
+ * before update_page / trash_page.
+ */
+#[IsReadOnly]
+#[Description('List all guide pages with their ids and management state, including hidden and trashed pages (قائمة كل صفحات الدليل مع المعرّفات وحالتها، شاملة المخفية والمحذوفة). Use the ids with update_page / trash_page.')]
+class ListManagedPagesTool extends ModerationTool
+{
+    protected string $name = 'list_managed_pages';
+
+    protected function requiredAbility(): string
+    {
+        return 'edit-content';
+    }
+
+    protected function perform(Request $request, User $user): Response
+    {
+        $pages = Page::withTrashed()
+            ->orderBy('order')
+            ->orderBy('id')
+            ->get()
+            ->map(fn (Page $page): array => [
+                'id' => $page->id,
+                'title' => $page->title,
+                'slug' => $page->slug,
+                'parent_id' => $page->parent_id,
+                'hidden' => (bool) $page->hidden,
+                'hidden_from_bot' => (bool) $page->hidden_from_bot,
+                'smart_search' => (bool) $page->smart_search,
+                'trashed' => $page->trashed(),
+            ]);
+
+        return Response::text((string) json_encode($pages, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}

--- a/app/Mcp/Tools/Moderation/ListPendingChangesTool.php
+++ b/app/Mcp/Tools/Moderation/ListPendingChangesTool.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Models\PageChangeRequest;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+/**
+ * The review queue: page edits review-mode editors submitted and that are
+ * still waiting on a decision. Read-only companion to
+ * {@see ApprovePageChangeTool} / {@see RejectPageChangeTool}.
+ */
+#[IsReadOnly]
+#[Description('List the page edits awaiting review (التعديلات المعلّقة بانتظار المراجعة). Each entry has the change request id, the target page, the author, the fields it changes, and when it was submitted — pass the id to approve_page_change or reject_page_change.')]
+class ListPendingChangesTool extends ModerationTool
+{
+    protected string $name = 'list_pending_changes';
+
+    protected function requiredAbility(): string
+    {
+        return 'review-changes';
+    }
+
+    protected function perform(Request $request, User $user): Response
+    {
+        $pending = PageChangeRequest::query()
+            ->where('status', PageChangeRequest::STATUS_PENDING)
+            ->with(['page', 'author'])
+            ->latest('updated_at')
+            ->get()
+            ->map(fn (PageChangeRequest $change): array => [
+                'id' => $change->id,
+                'page_title' => $change->page?->title,
+                'page_trashed' => (bool) $change->page?->trashed(),
+                'author' => $change->author?->name,
+                'changed_fields' => array_keys($change->payload),
+                'submitted_at' => $change->created_at?->toDateTimeString(),
+            ])
+            ->values();
+
+        if ($pending->isEmpty()) {
+            return Response::text('لا توجد تعديلات بانتظار المراجعة. No page edits are awaiting review.');
+        }
+
+        return Response::text((string) json_encode($pending, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}

--- a/app/Mcp/Tools/Moderation/ListTutorsTool.php
+++ b/app/Mcp/Tools/Moderation/ListTutorsTool.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Models\PrivateTutor\PrivateTutor;
+use App\Models\PrivateTutor\PrivateTutorCourse;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+/**
+ * The private tutors and courses, with their ids — the lookup a client needs
+ * before create_tutor / update_tutor / delete_tutor.
+ */
+#[IsReadOnly]
+#[Description('List all private tutors and the available courses with their ids (قائمة المدرّسين الخصوصيين والمقررات مع المعرّفات). Use the course ids here as course_ids when creating or updating a tutor.')]
+class ListTutorsTool extends ModerationTool
+{
+    protected string $name = 'list_tutors';
+
+    protected function requiredAbility(): string
+    {
+        return 'manage-private-tutors';
+    }
+
+    protected function perform(Request $request, User $user): Response
+    {
+        $tutors = PrivateTutor::query()
+            ->with(['courses' => fn ($query) => $query->orderBy('order')])
+            ->orderBy('order')
+            ->get()
+            ->map(fn (PrivateTutor $tutor): array => [
+                'id' => $tutor->id,
+                'name' => $tutor->name,
+                'url' => $tutor->url,
+                'courses' => $tutor->courses
+                    ->map(fn (PrivateTutorCourse $course): array => [
+                        'id' => $course->id,
+                        'name' => $course->name,
+                    ])
+                    ->values(),
+            ]);
+
+        $courses = PrivateTutorCourse::query()
+            ->orderBy('order')
+            ->get(['id', 'name'])
+            ->map(fn (PrivateTutorCourse $course): array => [
+                'id' => $course->id,
+                'name' => $course->name,
+            ]);
+
+        return Response::text((string) json_encode([
+            'tutors' => $tutors,
+            'courses' => $courses,
+        ], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}

--- a/app/Mcp/Tools/Moderation/ListUsersTool.php
+++ b/app/Mcp/Tools/Moderation/ListUsersTool.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+use Spatie\Permission\Models\Role;
+
+/**
+ * The panel users with their roles and ids, plus the assignable role names —
+ * the lookup a client needs before create_user / update_user / delete_user.
+ */
+#[IsReadOnly]
+#[Description('List the panel users with their roles, review flag and ids, plus the assignable role names (قائمة مستخدمي اللوحة وأدوارهم). Use the ids with update_user / delete_user and the role names with create_user / update_user.')]
+class ListUsersTool extends ModerationTool
+{
+    protected string $name = 'list_users';
+
+    protected function requiredAbility(): string
+    {
+        return 'manage-users';
+    }
+
+    protected function perform(Request $request, User $user): Response
+    {
+        $users = User::query()
+            ->with('roles')
+            ->orderBy('id')
+            ->get()
+            ->map(fn (User $panelUser): array => [
+                'id' => $panelUser->id,
+                'name' => $panelUser->name,
+                'email' => $panelUser->email,
+                'roles' => $panelUser->getRoleNames()->values(),
+                'requires_review' => $panelUser->requires_review,
+                'verified' => $panelUser->email_verified_at !== null,
+            ]);
+
+        return Response::text((string) json_encode([
+            'users' => $users,
+            'role_options' => Role::query()->orderBy('name')->pluck('name'),
+        ], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}

--- a/app/Mcp/Tools/Moderation/ModerationTool.php
+++ b/app/Mcp/Tools/Moderation/ModerationTool.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Validator;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+
+/**
+ * Base for every tool on the authenticated {@see \App\Mcp\Servers\UqccAdminServer}.
+ *
+ * The server route is already OAuth-protected (`auth:api`), so a request only
+ * reaches here with a signed-in user; this base adds the second gate — the
+ * per-tool ability check — mirroring the `can:` middleware the `/manage`
+ * panel routes use. Concrete tools implement {@see perform()} (called only
+ * once authorized) and {@see requiredAbility()}.
+ */
+abstract class ModerationTool extends Tool
+{
+    /**
+     * The ability the signed-in moderator must hold to run this tool, checked
+     * through the app's gates/permissions exactly as the panel does.
+     */
+    abstract protected function requiredAbility(): string;
+
+    public function handle(Request $request): Response
+    {
+        $user = $request->user();
+
+        if (! $user instanceof User || ! $user->can($this->requiredAbility())) {
+            return Response::error('ليست لديك صلاحية تنفيذ هذا الإجراء. You are not authorized to perform this action.');
+        }
+
+        return $this->perform($request, $user);
+    }
+
+    abstract protected function perform(Request $request, User $user): Response;
+
+    /**
+     * Validate the tool arguments against the same rules the `/manage` panel
+     * uses, reusing its Arabic messages. Returns the validated data, or a
+     * ready-to-return error {@see Response} carrying the first failure so a
+     * tool can `if ($x instanceof Response) return $x;`.
+     *
+     * @param  array<string, mixed>  $rules
+     * @param  array<string, string>  $messages
+     * @return array<string, mixed>|Response
+     */
+    protected function validateInput(Request $request, array $rules, array $messages = []): array|Response
+    {
+        $validator = Validator::make($request->all(), $rules, $messages);
+
+        if ($validator->fails()) {
+            return Response::error('تعذّر تنفيذ الإجراء: '.$validator->errors()->first());
+        }
+
+        return $validator->validated();
+    }
+}

--- a/app/Mcp/Tools/Moderation/RejectPageChangeTool.php
+++ b/app/Mcp/Tools/Moderation/RejectPageChangeTool.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Models\PageChangeRequest;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+
+/**
+ * Reject a pending page change: discard it without touching the live page.
+ * Mirrors {@see \App\Http\Controllers\Manage\PageChangeRequestController::reject()}.
+ */
+#[Description('Reject a pending page edit — the live page is left untouched (رفض تعديل معلّق دون تغيير الصفحة). Takes the change request id from list_pending_changes and an optional note recorded on the request.')]
+class RejectPageChangeTool extends ModerationTool
+{
+    protected string $name = 'reject_page_change';
+
+    protected function requiredAbility(): string
+    {
+        return 'review-changes';
+    }
+
+    protected function perform(Request $request, User $user): Response
+    {
+        $changeRequest = PageChangeRequest::query()->find((int) $request->get('change_request_id'));
+
+        if ($changeRequest === null) {
+            return Response::error('لم يُعثر على التعديل المطلوب. No change request found for that id.');
+        }
+
+        if (! $changeRequest->isPending()) {
+            return Response::error('هذا التعديل لم يعد بانتظار المراجعة. This change request is no longer pending.');
+        }
+
+        $changeRequest->update([
+            'status' => PageChangeRequest::STATUS_REJECTED,
+            'reviewed_by' => $user->getKey(),
+            'reviewed_at' => now(),
+            'review_note' => $request->get('note'),
+        ]);
+
+        return Response::text('تم رفض التعديل — لم تتغيّر الصفحة. The change was rejected; the page is unchanged.');
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'change_request_id' => $schema->integer()
+                ->description('The id of the pending change request to reject, from list_pending_changes.')
+                ->required(),
+            'note' => $schema->string()
+                ->description('Optional note explaining the rejection, recorded on the request.'),
+        ];
+    }
+}

--- a/app/Mcp/Tools/Moderation/TrashPageTool.php
+++ b/app/Mcp/Tools/Moderation/TrashPageTool.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Models\Page;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+
+/**
+ * Soft-delete a page (move it to the trash) or restore a trashed one. Both go
+ * through Eloquent so the `Page::booted()` cache flushes fire.
+ *
+ * Trashing is destructive and cannot be represented as a reviewable change
+ * request, so — unlike {@see UpdatePageTool} — it is refused for review-mode
+ * editors: their account funnels edits through the review queue, and a live
+ * delete would bypass it. They should ask a reviewer or admin.
+ */
+#[Description('Move a guide page to the trash, or restore a trashed page (نقل صفحة إلى المهملات أو استعادتها). Requires page_id (from list_managed_pages); set restore=true to restore. Soft delete only — content is recoverable. Not available to review-mode accounts.')]
+class TrashPageTool extends ModerationTool
+{
+    protected string $name = 'trash_page';
+
+    protected function requiredAbility(): string
+    {
+        return 'edit-content';
+    }
+
+    protected function perform(Request $request, User $user): Response
+    {
+        if ($user->mustHaveChangesReviewed()) {
+            return Response::error('حسابك في وضع المراجعة، ولا يمكنه حذف الصفحات أو استعادتها مباشرةً. اطلب ذلك من مراجع أو مدير. Your account is in review mode and cannot trash or restore pages directly.');
+        }
+
+        $restore = filter_var($request->get('restore'), FILTER_VALIDATE_BOOL);
+
+        $page = Page::withTrashed()->find((int) $request->get('page_id'));
+
+        if ($page === null) {
+            return Response::error('لم يُعثر على الصفحة المطلوبة. No page found for that id.');
+        }
+
+        if ($restore) {
+            if (! $page->trashed()) {
+                return Response::error('الصفحة «'.$page->title.'» ليست في المهملات. That page is not in the trash.');
+            }
+
+            $page->restore();
+
+            return Response::text('تمت استعادة الصفحة «'.$page->title.'». Page restored.');
+        }
+
+        if ($page->trashed()) {
+            return Response::error('الصفحة «'.$page->title.'» موجودة في المهملات بالفعل. That page is already in the trash.');
+        }
+
+        $page->delete();
+
+        return Response::text('تم نقل الصفحة «'.$page->title.'» إلى المهملات. Page moved to the trash.');
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'page_id' => $schema->integer()
+                ->description('The id of the page to trash or restore, from list_managed_pages.')
+                ->required(),
+            'restore' => $schema->boolean()
+                ->description('Set to true to restore a trashed page instead of trashing it. Defaults to false.'),
+        ];
+    }
+}

--- a/app/Mcp/Tools/Moderation/UpdatePageTool.php
+++ b/app/Mcp/Tools/Moderation/UpdatePageTool.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Http\Requests\Manage\UpdatePageRequest;
+use App\Models\Page;
+use App\Models\PageChangeRequest;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\Rule;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+
+/**
+ * Update a guide page's settings. Mirrors the review-aware half of
+ * {@see \App\Http\Controllers\Manage\PageController::update()}: for a
+ * moderator whose edits are review-gated ({@see User::mustHaveChangesReviewed()})
+ * the payload never touches the live page — it is captured (and merged into
+ * their existing pending request for this page) for a reviewer to approve;
+ * everyone else writes straight through Eloquent so the `Page::booted()` cache
+ * flushes fire.
+ *
+ * Content (`html_content`, quick-response fields) and structural moves
+ * (`parent_id`) stay in the `/manage` workspace; this tool covers the page's
+ * title, slug, icon and visibility flags.
+ */
+#[Description('Update a guide page\'s title, slug, icon or visibility flags (تعديل إعدادات صفحة: العنوان، الرابط، الأيقونة، خيارات الإخفاء). Requires page_id (from list_managed_pages) and only the fields you want to change. If your account is in review mode, the edit is submitted to the review queue instead of published immediately. Page content editing stays in the admin panel.')]
+class UpdatePageTool extends ModerationTool
+{
+    protected function requiredAbility(): string
+    {
+        return 'edit-content';
+    }
+
+    protected string $name = 'update_page';
+
+    protected function perform(Request $request, User $user): Response
+    {
+        $page = Page::withTrashed()->find((int) $request->get('page_id'));
+
+        if ($page === null) {
+            return Response::error('لم يُعثر على الصفحة المطلوبة. No page found for that id.');
+        }
+
+        $data = $this->validateInput(
+            $request,
+            [
+                'title' => ['sometimes', 'required', 'string', 'max:255'],
+                'slug' => [
+                    'sometimes', 'required', 'string', 'max:255',
+                    'regex:/^\/[a-z0-9_\-\/]*$/',
+                    Rule::unique('pages', 'slug')->ignore($page->id),
+                ],
+                'icon' => ['sometimes', 'nullable', 'string', 'max:255'],
+                'hidden' => ['sometimes', 'boolean'],
+                'hidden_from_bot' => ['sometimes', 'boolean'],
+                'hidden_from_ai' => ['sometimes', 'boolean'],
+                'smart_search' => ['sometimes', 'boolean'],
+                'requires_prefix' => ['sometimes', 'boolean'],
+            ],
+            (new UpdatePageRequest)->messages(),
+        );
+
+        if ($data instanceof Response) {
+            return $data;
+        }
+
+        if ($data === []) {
+            return Response::error('لم تُرسل أي حقول للتعديل. No editable fields were provided.');
+        }
+
+        if ($user->mustHaveChangesReviewed()) {
+            $pending = $page->changeRequests()
+                ->where('author_id', $user->getKey())
+                ->where('status', PageChangeRequest::STATUS_PENDING)
+                ->first();
+
+            $page->changeRequests()->updateOrCreate(
+                ['id' => $pending?->id],
+                [
+                    'author_id' => $user->getKey(),
+                    'status' => PageChangeRequest::STATUS_PENDING,
+                    'payload' => array_merge($pending?->payload ?? [], $data),
+                ],
+            );
+
+            return Response::text('تم إرسال تعديلك للمراجعة. سيظهر على الموقع بعد اعتماده من مراجع. Your edit was submitted for review and will publish once approved.');
+        }
+
+        $page->update($data);
+
+        return Response::text('تم تحديث الصفحة «'.$page->title.'». Page updated.');
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'page_id' => $schema->integer()
+                ->description('The id of the page to update, from list_managed_pages.')
+                ->required(),
+            'title' => $schema->string()
+                ->description('The page title.'),
+            'slug' => $schema->string()
+                ->description('The page slug, starting with "/" and using lowercase Latin letters, digits, hyphens and slashes only. Must be unique.'),
+            'icon' => $schema->string()
+                ->description('Optional icon name. Send empty to clear.'),
+            'hidden' => $schema->boolean()
+                ->description('Whether the page is hidden from the website.'),
+            'hidden_from_bot' => $schema->boolean()
+                ->description('Whether the page is hidden from the Telegram bot.'),
+            'hidden_from_ai' => $schema->boolean()
+                ->description('Whether the page is hidden from the AI assistant.'),
+            'smart_search' => $schema->boolean()
+                ->description('Whether the page is included in smart search.'),
+            'requires_prefix' => $schema->boolean()
+                ->description('Whether the bot requires the «دليل» keyword to surface this page.'),
+        ];
+    }
+}

--- a/app/Mcp/Tools/Moderation/UpdateTutorTool.php
+++ b/app/Mcp/Tools/Moderation/UpdateTutorTool.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Http\Requests\Manage\UpdatePrivateTutorRequest;
+use App\Models\PrivateTutor\PrivateTutor;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+
+/**
+ * Update a private tutor and sync its attached courses. Mirrors
+ * {@see \App\Http\Controllers\Manage\PrivateTutorController::update()},
+ * reusing {@see UpdatePrivateTutorRequest} for validation. `course_ids` is
+ * only synced when provided, matching the panel.
+ */
+#[Description('Update an existing private tutor (تعديل بيانات مدرّس خصوصي). Requires tutor_id (from list_tutors); name and url are replaced, and course_ids — when provided — replace the tutor\'s attached courses.')]
+class UpdateTutorTool extends ModerationTool
+{
+    protected string $name = 'update_tutor';
+
+    protected function requiredAbility(): string
+    {
+        return 'manage-private-tutors';
+    }
+
+    protected function perform(Request $request, User $user): Response
+    {
+        $arguments = $request->all();
+
+        $tutor = PrivateTutor::query()->find((int) ($arguments['tutor_id'] ?? 0));
+
+        if ($tutor === null) {
+            return Response::error('لم يُعثر على المدرّس المطلوب. No tutor found for that id.');
+        }
+
+        $rules = (new UpdatePrivateTutorRequest)->rules();
+        $messages = (new UpdatePrivateTutorRequest)->messages();
+
+        $data = $this->validateInput($request, $rules, $messages);
+
+        if ($data instanceof Response) {
+            return $data;
+        }
+
+        $attributes = ['name' => $data['name']];
+
+        if (array_key_exists('url', $arguments)) {
+            $attributes['url'] = $data['url'] ?? null;
+        }
+
+        $tutor->update($attributes);
+
+        if (array_key_exists('course_ids', $arguments)) {
+            $tutor->courses()->sync($data['course_ids'] ?? []);
+        }
+
+        return Response::text('تم تحديث بيانات المدرّس «'.$tutor->name.'». Tutor updated.');
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'tutor_id' => $schema->integer()
+                ->description('The id of the tutor to update, from list_tutors.')
+                ->required(),
+            'name' => $schema->string()
+                ->description('The tutor\'s name.')
+                ->required(),
+            'url' => $schema->string()
+                ->description('Optional link to the tutor. Must be a valid URL. Send empty to clear.'),
+            'course_ids' => $schema->array()
+                ->description('Optional ids of the courses this tutor teaches (replaces the current set), from list_tutors.')
+                ->items($schema->integer()),
+        ];
+    }
+}

--- a/app/Mcp/Tools/Moderation/UpdateUserTool.php
+++ b/app/Mcp/Tools/Moderation/UpdateUserTool.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Mcp\Tools\Moderation;
+
+use App\Http\Requests\Manage\UpdateUserRequest;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\Validator as ValidatorInstance;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+
+/**
+ * Update a panel user. Mirrors
+ * {@see \App\Http\Controllers\Manage\UserController::update()}: the password
+ * only changes when provided, verification/roles/requires_review follow the
+ * same rules, and — like {@see UpdateUserRequest}'s `after()` hook — a
+ * moderator holding `assign-roles` cannot strip the admin role from their own
+ * account. Only fields you send are changed.
+ */
+#[Description('Update an existing panel user (تعديل بيانات مستخدم). Requires user_id (from list_users). Only the fields you send change. Password changes only when provided; roles / requires_review apply only if you hold assign-roles.')]
+class UpdateUserTool extends ModerationTool
+{
+    protected string $name = 'update_user';
+
+    protected function requiredAbility(): string
+    {
+        return 'manage-users';
+    }
+
+    protected function perform(Request $request, User $user): Response
+    {
+        $arguments = $request->all();
+
+        $target = User::query()->find((int) ($arguments['user_id'] ?? 0));
+
+        if ($target === null) {
+            return Response::error('لم يُعثر على المستخدم المطلوب. No user found for that id.');
+        }
+
+        $validator = Validator::make(
+            $arguments,
+            [
+                'name' => ['required', 'string', 'max:255'],
+                'email' => ['required', 'string', 'email', 'max:255', Rule::unique('users', 'email')->ignore($target)],
+                'password' => ['nullable', 'string', Password::defaults()],
+                'verified' => ['sometimes', 'boolean'],
+                'username' => ['nullable', 'string', 'max:255', Rule::unique('users', 'username')->ignore($target)],
+                'url' => ['nullable', 'string', 'url', 'max:255'],
+                'avatar' => ['nullable', 'string', 'url', 'max:255'],
+                'roles' => ['sometimes', 'array'],
+                'roles.*' => ['string', 'exists:roles,name'],
+                'requires_review' => ['sometimes', 'boolean'],
+            ],
+            (new UpdateUserRequest)->messages(),
+        );
+
+        $validator->after(function (ValidatorInstance $validator) use ($arguments, $user, $target): void {
+            $roles = $arguments['roles'] ?? null;
+
+            if (! $user->is($target) || ! is_array($roles) || ! $user->can('assign-roles')) {
+                return;
+            }
+
+            if ($target->hasRole('admin') && ! in_array('admin', $roles, true)) {
+                $validator->errors()->add('roles', 'لا يمكنك إزالة دور المدير من حسابك.');
+            }
+        });
+
+        if ($validator->fails()) {
+            return Response::error('تعذّر تنفيذ الإجراء: '.$validator->errors()->first());
+        }
+
+        $data = $validator->validated();
+
+        $attributes = [
+            'name' => $data['name'],
+            'email' => $data['email'],
+        ];
+
+        foreach (['username', 'url', 'avatar'] as $optional) {
+            if (array_key_exists($optional, $arguments)) {
+                $attributes[$optional] = $data[$optional] ?? null;
+            }
+        }
+
+        $target->fill($attributes);
+
+        if (array_key_exists('password', $arguments) && ($data['password'] ?? null) !== null && $data['password'] !== '') {
+            $target->password = $data['password'];
+        }
+
+        if (array_key_exists('verified', $arguments)) {
+            $verified = filter_var($arguments['verified'], FILTER_VALIDATE_BOOL);
+            $target->email_verified_at = $verified ? ($target->email_verified_at ?? now()) : null;
+        }
+
+        if (array_key_exists('requires_review', $arguments) && $user->can('assign-roles')) {
+            $target->requires_review = filter_var($arguments['requires_review'], FILTER_VALIDATE_BOOL);
+        }
+
+        $target->save();
+
+        if (array_key_exists('roles', $arguments) && $user->can('assign-roles')) {
+            $target->syncRoles($data['roles'] ?? []);
+        }
+
+        return Response::text('تم تحديث بيانات المستخدم «'.$target->name.'». User updated.');
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'user_id' => $schema->integer()
+                ->description('The id of the user to update, from list_users.')
+                ->required(),
+            'name' => $schema->string()
+                ->description('The user\'s display name.')
+                ->required(),
+            'email' => $schema->string()
+                ->description('The user\'s email address. Must be unique.')
+                ->required(),
+            'password' => $schema->string()
+                ->description('A new password (at least 8 characters). Omit to keep the current one.'),
+            'verified' => $schema->boolean()
+                ->description('Whether the email is verified.'),
+            'username' => $schema->string()
+                ->description('Optional unique username.'),
+            'url' => $schema->string()
+                ->description('Optional profile URL.'),
+            'avatar' => $schema->string()
+                ->description('Optional avatar image URL.'),
+            'roles' => $schema->array()
+                ->description('Role names to assign (replaces current roles). Applied only if you hold assign-roles.')
+                ->items($schema->string()),
+            'requires_review' => $schema->boolean()
+                ->description('Whether this user\'s content edits must be reviewed. Applied only if you hold assign-roles.'),
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,14 +7,16 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Passport\Contracts\OAuthenticatable;
+use Laravel\Passport\HasApiTokens;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 use Spatie\Permission\Traits\HasRoles;
 
-class User extends Authenticatable
+class User extends Authenticatable implements OAuthenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, HasRoles, LogsActivity, Notifiable;
+    use HasApiTokens, HasFactory, HasRoles, LogsActivity, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Passport\Passport;
 use Pgvector\Laravel\Schema as PgvectorSchema;
 
 class AppServiceProvider extends ServiceProvider
@@ -34,6 +35,14 @@ class AppServiceProvider extends ServiceProvider
         $this->configureRateLimiting();
 
         Gate::define('review-changes', fn (User $user): bool => $user->canReviewChanges());
+
+        /*
+         * The consent screen an MCP client's OAuth authorization request lands
+         * on after the moderator signs in — the "approve / deny this agent"
+         * step of the authorization-code flow (routes/ai.php). Uses the app's
+         * own RTL Arabic view instead of Passport's default English one.
+         */
+        Passport::authorizationView(fn (array $parameters) => view('mcp.authorize', $parameters));
     }
 
     /**
@@ -48,6 +57,10 @@ class AppServiceProvider extends ServiceProvider
      * are stateless HTTP callers without a session cookie, so it keys by
      * client IP only; the budget is higher than `ai-search` because one
      * agent session legitimately chains several JSON-RPC calls.
+     *
+     * `mcp-admin` throttles the authenticated moderation MCP endpoint. Once
+     * OAuth-authenticated there is a stable identity, so it keys by user id
+     * (falling back to IP) with a higher budget than the public server.
      *
      * `ai-chat` is the assistant chat's BURST limiter (same session-first
      * key as `ai-search`); the operator's per-session DAILY quota and the
@@ -65,6 +78,10 @@ class AppServiceProvider extends ServiceProvider
 
         RateLimiter::for('mcp', function (Request $request): Limit {
             return Limit::perMinute(30)->by('mcp:'.(string) $request->ip());
+        });
+
+        RateLimiter::for('mcp-admin', function (Request $request): Limit {
+            return Limit::perMinute(60)->by('mcp-admin:'.($request->user()?->getAuthIdentifier() ?? (string) $request->ip()));
         });
 
         RateLimiter::for('ai-chat', function (Request $request): Limit {

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "laravel/ai": "^0.9",
         "laravel/framework": "^12.0",
         "laravel/mcp": "~0.7.0",
+        "laravel/passport": "^13.0",
         "laravel/tinker": "^2.10.1",
         "laravel/wayfinder": "^0.1.11",
         "league/commonmark": "^2.8",

--- a/config/auth.php
+++ b/config/auth.php
@@ -40,6 +40,11 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+
+        'api' => [
+            'driver' => 'passport',
+            'provider' => 'users',
+        ],
     ],
 
     /*

--- a/resources/views/mcp/authorize.blade.php
+++ b/resources/views/mcp/authorize.blade.php
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>الإذن بالوصول — {{ config('app.name') }}</title>
+    <style>
+        :root {
+            color-scheme: dark;
+            --bg: #1a1a1a;
+            --card: #242424;
+            --border: #3a3a3a;
+            --text: #ededed;
+            --muted: #a0a0a0;
+            --brand: #16a34a;
+            --brand-hover: #15803d;
+            --danger: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-block-size: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1.5rem;
+            background: var(--bg);
+            color: var(--text);
+            font-family: system-ui, -apple-system, "Segoe UI", Tahoma, Arial, sans-serif;
+            line-height: 1.7;
+        }
+
+        .card {
+            inline-size: 100%;
+            max-inline-size: 30rem;
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 1rem;
+            padding: 2rem;
+        }
+
+        h1 {
+            margin: 0 0 0.5rem;
+            font-size: 1.35rem;
+        }
+
+        p {
+            margin: 0 0 1rem;
+            color: var(--muted);
+        }
+
+        .client {
+            font-weight: 700;
+            color: var(--text);
+        }
+
+        ul {
+            margin: 0 0 1.5rem;
+            padding-inline-start: 1.25rem;
+        }
+
+        li {
+            margin-block-end: 0.35rem;
+        }
+
+        .actions {
+            display: flex;
+            gap: 0.75rem;
+            margin-block-start: 1.5rem;
+        }
+
+        form {
+            flex: 1;
+            margin: 0;
+        }
+
+        button {
+            inline-size: 100%;
+            padding: 0.75rem 1rem;
+            border: 1px solid transparent;
+            border-radius: 0.6rem;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            font-family: inherit;
+        }
+
+        .approve {
+            background: var(--brand);
+            color: #fff;
+        }
+
+        .approve:hover {
+            background: var(--brand-hover);
+        }
+
+        .deny {
+            background: transparent;
+            color: var(--text);
+            border-color: var(--border);
+        }
+
+        .deny:hover {
+            border-color: var(--danger);
+            color: #fca5a5;
+        }
+    </style>
+</head>
+<body>
+    <main class="card">
+        <h1>طلب إذن بالوصول</h1>
+
+        <p>
+            يطلب <span class="client">{{ $client->name }}</span> الإذن بالوصول إلى أدوات الإشراف
+            في {{ config('app.name') }} نيابةً عنك (<span dir="ltr">{{ $user->email }}</span>).
+        </p>
+
+        @if (count($scopes) > 0)
+            <p>سيتمكّن هذا التطبيق من:</p>
+            <ul>
+                @foreach ($scopes as $scope)
+                    <li>{{ $scope->description }}</li>
+                @endforeach
+            </ul>
+        @endif
+
+        <div class="actions">
+            <form method="post" action="{{ route('passport.authorizations.approve') }}">
+                @csrf
+                <input type="hidden" name="state" value="{{ $request->state }}">
+                <input type="hidden" name="client_id" value="{{ $client->getKey() }}">
+                <input type="hidden" name="auth_token" value="{{ $authToken }}">
+                <button type="submit" class="approve">السماح بالوصول</button>
+            </form>
+
+            <form method="post" action="{{ route('passport.authorizations.deny') }}">
+                @csrf
+                @method('DELETE')
+                <input type="hidden" name="state" value="{{ $request->state }}">
+                <input type="hidden" name="client_id" value="{{ $client->getKey() }}">
+                <input type="hidden" name="auth_token" value="{{ $authToken }}">
+                <button type="submit" class="deny">رفض</button>
+            </form>
+        </div>
+    </main>
+</body>
+</html>

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Mcp\Servers\UqccAdminServer;
 use App\Mcp\Servers\UqccServer;
 use Laravel\Mcp\Facades\Mcp;
 
@@ -10,10 +11,25 @@ use Laravel\Mcp\Facades\Mcp;
 |
 | laravel/mcp auto-loads this file when it exists (see
 | McpServiceProvider::registerRoutes), before the web routes, so the /mcp
-| endpoint is never shadowed by the catch-all page route. The server is
-| public and read-only; the `mcp` limiter is defined in AppServiceProvider.
+| endpoint is never shadowed by the catch-all page route.
+|
+| Two servers are exposed:
+|   - /mcp        public, read-only, unauthenticated (UqccServer).
+|   - /mcp/admin  moderation tools, protected by OAuth2 (UqccAdminServer).
+|
+| `Mcp::oauthRoutes()` registers the OAuth2 discovery + dynamic client
+| registration endpoints an MCP client needs to negotiate access; the admin
+| server route is guarded by `auth:api` (Passport). An unauthenticated
+| browser hitting the authorization endpoint is redirected to the /manage
+| login and back (see bootstrap/app.php `redirectGuestsTo`). Both `mcp` and
+| `mcp-admin` limiters are defined in AppServiceProvider.
 |
 */
 
+Mcp::oauthRoutes();
+
 Mcp::web('/mcp', UqccServer::class)
     ->middleware('throttle:mcp');
+
+Mcp::web('/mcp/admin', UqccAdminServer::class)
+    ->middleware(['auth:api', 'throttle:mcp-admin']);

--- a/tests/Feature/Ai/McpAdminServerTest.php
+++ b/tests/Feature/Ai/McpAdminServerTest.php
@@ -1,0 +1,208 @@
+<?php
+
+use App\Models\Page;
+use App\Models\PageChangeRequest;
+use App\Models\PrivateTutor\PrivateTutor;
+use App\Models\User;
+use Database\Seeders\RolesAndPermissionsSeeder;
+use Laravel\Passport\Passport;
+
+use function Pest\Laravel\postJson;
+
+beforeEach(function () {
+    $this->seed(RolesAndPermissionsSeeder::class);
+});
+
+/**
+ * A tools/call JSON-RPC envelope for the authenticated admin MCP server.
+ *
+ * @param  array<string, mixed>  $arguments
+ * @return array<string, mixed>
+ */
+function adminRpc(string $tool, array $arguments = []): array
+{
+    return [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => ['name' => $tool, 'arguments' => $arguments],
+    ];
+}
+
+function makeUser(string $role, bool $requiresReview = false): User
+{
+    $user = User::factory()->create(['requires_review' => $requiresReview]);
+    $user->assignRole($role);
+
+    return $user;
+}
+
+it('rejects unauthenticated access to the admin server', function () {
+    postJson('/mcp/admin', adminRpc('list_pending_changes'))->assertUnauthorized();
+});
+
+it('lists all fourteen moderation tools for an authorized moderator', function () {
+    Passport::actingAs(makeUser('admin'));
+
+    $response = postJson('/mcp/admin', [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/list',
+    ]);
+
+    $response->assertOk();
+
+    $names = collect($response->json('result.tools'))->pluck('name')->all();
+
+    expect($names)->toBe([
+        'list_pending_changes',
+        'approve_page_change',
+        'reject_page_change',
+        'list_tutors',
+        'create_tutor',
+        'update_tutor',
+        'delete_tutor',
+        'list_users',
+        'create_user',
+        'update_user',
+        'delete_user',
+        'list_managed_pages',
+        'update_page',
+        'trash_page',
+    ]);
+});
+
+it('lets a reviewer approve a pending change and publishes it to the live page', function () {
+    $editor = makeUser('editor');
+    $page = Page::factory()->create(['title' => 'العنوان القديم']);
+    $change = PageChangeRequest::factory()->create([
+        'page_id' => $page->id,
+        'status' => PageChangeRequest::STATUS_PENDING,
+        'payload' => ['title' => 'العنوان الجديد'],
+    ]);
+
+    Passport::actingAs($editor);
+
+    postJson('/mcp/admin', adminRpc('approve_page_change', ['change_request_id' => $change->id]))
+        ->assertOk();
+
+    expect($page->fresh()->title)->toBe('العنوان الجديد')
+        ->and($change->fresh()->status)->toBe(PageChangeRequest::STATUS_APPROVED)
+        ->and($change->fresh()->reviewed_by)->toBe($editor->id);
+});
+
+it('denies approval to an editor whose own changes require review', function () {
+    $reviewGated = makeUser('editor', requiresReview: true);
+    $page = Page::factory()->create(['title' => 'كما هو']);
+    $change = PageChangeRequest::factory()->create([
+        'page_id' => $page->id,
+        'status' => PageChangeRequest::STATUS_PENDING,
+        'payload' => ['title' => 'محاولة'],
+    ]);
+
+    Passport::actingAs($reviewGated);
+
+    $response = postJson('/mcp/admin', adminRpc('approve_page_change', ['change_request_id' => $change->id]));
+
+    expect($response->json('result.isError'))->toBeTrue()
+        ->and($page->fresh()->title)->toBe('كما هو')
+        ->and($change->fresh()->status)->toBe(PageChangeRequest::STATUS_PENDING);
+});
+
+it('funnels a review-mode editor page edit into the review queue instead of the live page', function () {
+    $reviewGated = makeUser('editor', requiresReview: true);
+    $page = Page::factory()->create(['title' => 'الأصلي']);
+
+    Passport::actingAs($reviewGated);
+
+    postJson('/mcp/admin', adminRpc('update_page', ['page_id' => $page->id, 'title' => 'المقترح']))
+        ->assertOk();
+
+    expect($page->fresh()->title)->toBe('الأصلي');
+
+    $pending = PageChangeRequest::query()
+        ->where('page_id', $page->id)
+        ->where('author_id', $reviewGated->id)
+        ->where('status', PageChangeRequest::STATUS_PENDING)
+        ->first();
+
+    expect($pending)->not->toBeNull()
+        ->and($pending->payload['title'])->toBe('المقترح');
+});
+
+it('updates the live page directly for an editor who is not review-gated', function () {
+    $editor = makeUser('editor');
+    $page = Page::factory()->create(['title' => 'قبل', 'hidden' => false]);
+
+    Passport::actingAs($editor);
+
+    postJson('/mcp/admin', adminRpc('update_page', ['page_id' => $page->id, 'title' => 'بعد', 'hidden' => true]))
+        ->assertOk();
+
+    expect($page->fresh()->title)->toBe('بعد')
+        ->and($page->fresh()->hidden)->toBeTrue()
+        ->and(PageChangeRequest::query()->count())->toBe(0);
+});
+
+it('refuses to trash a page for a review-mode editor', function () {
+    $reviewGated = makeUser('editor', requiresReview: true);
+    $page = Page::factory()->create();
+
+    Passport::actingAs($reviewGated);
+
+    $response = postJson('/mcp/admin', adminRpc('trash_page', ['page_id' => $page->id]));
+
+    expect($response->json('result.isError'))->toBeTrue()
+        ->and($page->fresh()->trashed())->toBeFalse();
+});
+
+it('lets an admin create a tutor but denies an editor', function () {
+    Passport::actingAs(makeUser('admin'));
+
+    postJson('/mcp/admin', adminRpc('create_tutor', ['name' => 'أ. محمد']))->assertOk();
+
+    expect(PrivateTutor::query()->where('name', 'أ. محمد')->exists())->toBeTrue();
+
+    Passport::actingAs(makeUser('editor'));
+
+    $response = postJson('/mcp/admin', adminRpc('create_tutor', ['name' => 'أ. خالد']));
+
+    expect($response->json('result.isError'))->toBeTrue()
+        ->and(PrivateTutor::query()->where('name', 'أ. خالد')->exists())->toBeFalse();
+});
+
+it('denies user management to a non-admin', function () {
+    Passport::actingAs(makeUser('editor'));
+
+    $response = postJson('/mcp/admin', adminRpc('list_users'));
+
+    expect($response->json('result.isError'))->toBeTrue();
+});
+
+it('lets an admin create a user with the email pre-verified', function () {
+    Passport::actingAs(makeUser('admin'));
+
+    postJson('/mcp/admin', adminRpc('create_user', [
+        'name' => 'مشرف جديد',
+        'email' => 'new-mod@uqu.test',
+        'password' => 'super-secret-pw',
+        'roles' => ['editor'],
+    ]))->assertOk();
+
+    $created = User::query()->where('email', 'new-mod@uqu.test')->first();
+
+    expect($created)->not->toBeNull()
+        ->and($created->email_verified_at)->not->toBeNull()
+        ->and($created->hasRole('editor'))->toBeTrue();
+});
+
+it('blocks an admin from deleting their own account', function () {
+    $admin = makeUser('admin');
+
+    Passport::actingAs($admin);
+
+    $response = postJson('/mcp/admin', adminRpc('delete_user', ['user_id' => $admin->id]));
+
+    expect($response->json('result.isError'))->toBeTrue()
+        ->and(User::query()->whereKey($admin->id)->exists())->toBeTrue();
+});


### PR DESCRIPTION
Expose a second MCP server at /mcp/admin alongside the public read-only
/mcp, carrying moderation tools that act as the signed-in moderator. The
route is protected by OAuth2 (Laravel Passport): an MCP client negotiates
access via Mcp::oauthRoutes(), and an unauthenticated browser hitting the
authorization endpoint is redirected to the /manage login and back, then
shown an RTL Arabic consent screen.

Every tool re-checks the same abilities the /manage panel enforces, so an
authenticated editor still cannot reach an admin-only surface:
- Review (review-changes): list pending, approve, reject page changes.
- Tutors (manage-private-tutors): list, create, update, delete.
- Users (manage-users): list, create, update, delete.
- Pages (edit-content): list, update settings, trash/restore.

Editors are first-class: page edits by a review-mode editor are funnelled
into the change-request queue (never touching the live page), exactly like
the panel; destructive page trashing is refused for review-mode accounts.
All writes go through Eloquent so the model-event cache flushes still fire,
and validation reuses the panel's Form Request rules and Arabic messages.

Requires laravel/passport (added to composer.json). Post-pull setup:
  composer update laravel/passport
  php artisan install:api --passport
  php artisan migrate
(install:api publishes the OAuth migrations and generates signing keys.)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LyPSSGZuUuuHWdXb9tscqj