### PR TITLE
Fix dirty state check in Telegram settings form

### DIFF
--- a/resources/js/components/manage/pages/PageTelegramTab.vue
+++ b/resources/js/components/manage/pages/PageTelegramTab.vue
@@ -231,8 +231,8 @@ function submit(): void {
                 </div>
 
                 <div class="flex justify-end">
-                    <span :title="!form.isDirty && !form.processing ? 'لا توجد تغييرات لحفظها' : undefined">
-                        <Button type="submit" :disabled="!form.isDirty || form.processing">
+                    <span :title="!isDirty && !form.processing ? 'لا توجد تغييرات لحفظها' : undefined">
+                        <Button type="submit" :disabled="!isDirty || form.processing">
                             <Loader2 v-if="form.processing" class="size-4 animate-spin" />
                             حفظ إعدادات تيليجرام
                         </Button>


### PR DESCRIPTION
## Summary
Fixed the dirty state validation in the Telegram settings form to use the computed `isDirty` property instead of `form.isDirty`.

## Changes
- Updated the submit button's disabled state check to use `isDirty` instead of `form.isDirty`
- Updated the button's title attribute tooltip condition to use `isDirty` instead of `form.isDirty`

## Details
The form was checking `form.isDirty` directly, but the component uses a computed property `isDirty` for tracking form changes. This ensures the button's disabled state and tooltip are properly synchronized with the actual form dirty state.

https://claude.ai/code/session_014EmG21yb67D15xN14LJhdT