### PR TITLE
feat(quiz): post the daily question now, and reschedule when it goes out

### DIFF
--- a/app/Console/Commands/PostDailyQuiz.php
+++ b/app/Console/Commands/PostDailyQuiz.php
@@ -5,8 +5,10 @@ namespace App\Console\Commands;
 use App\Ai\Quiz\QuizAuthor;
 use App\Models\DailyQuiz;
 use App\Services\Quiz\QuizPoster;
+use App\Services\Quiz\QuizSchedule;
 use App\Settings\QuizSettings;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
 use Throwable;
 
 /**
@@ -14,14 +16,27 @@ use Throwable;
  * non-anonymous quiz poll. When the nightly generation failed to leave a
  * question, generation is retried inline so a transient AI failure doesn't
  * silently skip the day (and break everyone's streaks).
+ *
+ * The command is scheduled every minute and decides for itself whether the
+ * posting moment has come, because that moment is a setting any single day can
+ * override — see {@see QuizSchedule}. `--force` ignores the clock and posts
+ * right now, including re-posting a question whose poll was deleted from the
+ * group by mistake.
  */
 class PostDailyQuiz extends Command
 {
-    protected $signature = 'quiz:post';
+    protected $signature = 'quiz:post {--force : Post today\'s question right now, even before its scheduled time or after it was already posted}';
 
     protected $description = 'Post today\'s quiz question to the configured Telegram group';
 
-    public function handle(QuizSettings $settings, QuizAuthor $author, QuizPoster $poster): int
+    /**
+     * How long to wait before retrying the inline fallback generation. The
+     * command runs every minute; a failing authoring model must not be asked
+     * that often.
+     */
+    private const FALLBACK_RETRY_MINUTES = 15;
+
+    public function handle(QuizSettings $settings, QuizSchedule $schedule, QuizAuthor $author, QuizPoster $poster): int
     {
         if (! $settings->isConfigured()) {
             $this->info('Daily quiz is disabled or has no target group — skipping.');
@@ -29,29 +44,51 @@ class PostDailyQuiz extends Command
             return self::SUCCESS;
         }
 
+        $force = (bool) $this->option('force');
         $quiz = DailyQuiz::forDate(today());
 
-        if ($quiz !== null && ! $quiz->isReady()) {
-            $this->info('Today\'s quiz has already been posted — skipping.');
-
-            return self::SUCCESS;
-        }
-
-        if ($quiz === null) {
-            $this->warn('No quiz was generated for today — generating one now.');
-
-            try {
-                $quiz = $author->generateForDate(today());
-            } catch (Throwable $exception) {
-                report($exception);
-                $this->error("Fallback generation failed: {$exception->getMessage()}");
+        if ($force) {
+            if ($quiz === null) {
+                $this->error('There is no question for today — generate one first.');
 
                 return self::FAILURE;
             }
+
+            if (! $quiz->isReady() && ! $quiz->isPosted()) {
+                $this->error('Today\'s question is already closed — it cannot be posted again.');
+
+                return self::FAILURE;
+            }
+        } else {
+            if ($quiz !== null && ! $quiz->isReady()) {
+                $this->info('Today\'s quiz has already been posted — skipping.');
+
+                return self::SUCCESS;
+            }
+
+            if (! $schedule->isTodayDue()) {
+                return self::SUCCESS;
+            }
+
+            if ($quiz === null) {
+                if (! $this->fallbackAttemptable()) {
+                    $this->info('Fallback generation was tried recently — waiting before the next attempt.');
+
+                    return self::SUCCESS;
+                }
+
+                $quiz = $this->generateFallback($author);
+
+                if ($quiz === null) {
+                    return self::FAILURE;
+                }
+            }
         }
 
+        $reposting = $quiz->isPosted();
+
         try {
-            $quiz = $poster->post($quiz);
+            $quiz = $poster->post($quiz, $force);
         } catch (Throwable $exception) {
             report($exception);
             $this->error("Posting failed: {$exception->getMessage()}");
@@ -59,8 +96,36 @@ class PostDailyQuiz extends Command
             return self::FAILURE;
         }
 
-        $this->info("Posted quiz #{$quiz->id} to {$quiz->posts()->count()} chat(s).");
+        $verb = $reposting ? 'Re-posted' : 'Posted';
+        $this->info("{$verb} quiz #{$quiz->id} to {$quiz->posts()->open()->count()} chat(s).");
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Whether an inline generation attempt is allowed right now — throttled so
+     * the per-minute schedule can't hammer the authoring model.
+     */
+    private function fallbackAttemptable(): bool
+    {
+        return Cache::add(
+            'quiz:post-fallback:'.today()->toDateString(),
+            true,
+            now()->addMinutes(self::FALLBACK_RETRY_MINUTES),
+        );
+    }
+
+    private function generateFallback(QuizAuthor $author): ?DailyQuiz
+    {
+        $this->warn('No quiz was generated for today — generating one now.');
+
+        try {
+            return $author->generateForDate(today());
+        } catch (Throwable $exception) {
+            report($exception);
+            $this->error("Fallback generation failed: {$exception->getMessage()}");
+
+            return null;
+        }
     }
 }

--- a/app/Http/Controllers/Manage/QuizController.php
+++ b/app/Http/Controllers/Manage/QuizController.php
@@ -5,12 +5,15 @@ namespace App\Http\Controllers\Manage;
 use App\Ai\Quiz\QuizAuthor;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manage\GenerateDailyQuizRequest;
+use App\Http\Requests\Manage\UpdateQuizScheduleRequest;
 use App\Http\Requests\Manage\UpdateQuizSettingsRequest;
 use App\Jobs\GenerateDailyQuizJob;
 use App\Models\DailyQuiz;
 use App\Models\QuizPlayer;
 use App\Models\QuizTopic;
 use App\Models\TelegramChatSetting;
+use App\Services\Quiz\QuizPoster;
+use App\Services\Quiz\QuizSchedule;
 use App\Settings\QuizSettings;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -18,6 +21,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Inertia\Inertia;
 use Inertia\Response;
+use Throwable;
 
 /**
  * The daily quiz control room. The front door shows the one question the
@@ -37,9 +41,10 @@ class QuizController extends Controller
     /** How far ahead the generate dialog looks for a free day before giving up. */
     private const MAX_SCHEDULING_HORIZON_DAYS = 365;
 
-    public function index(QuizSettings $settings): Response
+    public function index(QuizSettings $settings, QuizSchedule $schedule): Response
     {
         $current = $this->currentQuiz();
+        $today = DailyQuiz::forDate(today());
 
         return Inertia::render('manage/quiz/Index', [
             'settings' => [
@@ -55,6 +60,11 @@ class QuizController extends Controller
                     'chat_id' => (string) $chat->chat_id,
                     'title' => $chat->title,
                 ]),
+            'schedule' => [
+                'post_time' => $schedule->postTimeFor(null),
+                'today_post_time' => $today?->post_time,
+                'today_posts_at' => $schedule->todayPostsAt()->toISOString(),
+            ],
             'topics' => $this->topics(),
             'currentQuiz' => $current === null ? null : $this->quizPayload($current),
             'upcoming' => $this->upcoming(),
@@ -62,7 +72,7 @@ class QuizController extends Controller
             'limits' => $this->limits(),
             'today' => today()->toDateString(),
             'nextFreeDate' => $this->nextFreeDate(),
-            'todayQuizStatus' => DailyQuiz::forDate(today())?->status,
+            'todayQuizStatus' => $today?->status,
             'weeklyTop' => $this->leaderboard('weekly_points'),
             'allTimeTop' => $this->leaderboard('total_points'),
         ]);
@@ -146,6 +156,76 @@ class QuizController extends Controller
         return back()->with('success', $replace
             ? "بدأ إعادة توليد {$day} — سيتحدّث خلال دقائق."
             : "بدأ توليد {$day} — سيظهر خلال دقائق.");
+    }
+
+    /**
+     * Send today's question to the groups right now, ahead of its scheduled
+     * time — and re-send it when it already went out, the escape hatch for a
+     * poll someone deleted from the group. Runs inline rather than queued so
+     * the admin sees the Telegram outcome on the spot.
+     */
+    public function post(QuizSettings $settings, QuizPoster $poster): RedirectResponse
+    {
+        if (! $settings->isConfigured()) {
+            return back()->withErrors(['post' => 'سؤال اليوم غير مفعّل أو بلا مجموعات مستهدفة.']);
+        }
+
+        $quiz = DailyQuiz::forDate(today());
+
+        if ($quiz === null) {
+            return back()->withErrors(['post' => 'لا يوجد سؤال لهذا اليوم — ولّده أولاً.']);
+        }
+
+        if (! $quiz->isReady() && ! $quiz->isPosted()) {
+            return back()->withErrors(['post' => 'سؤال اليوم أُغلق ولا يمكن نشره من جديد.']);
+        }
+
+        $reposting = $quiz->isPosted();
+
+        try {
+            $poster->post($quiz, force: true);
+        } catch (Throwable $exception) {
+            report($exception);
+
+            return back()->withErrors(['post' => $exception->getMessage()]);
+        }
+
+        return back()->with('success', $reposting
+            ? 'أُعيد نشر سؤال اليوم في المجموعات — الإجابات المسجّلة سابقاً محفوظة.'
+            : 'نُشر سؤال اليوم في المجموعات.');
+    }
+
+    /**
+     * Move the posting time — for every day (the default) or for today's
+     * question alone, which then goes out at its own time and leaves the
+     * default untouched. Clearing the one-day time returns it to the default.
+     */
+    public function updateSchedule(UpdateQuizScheduleRequest $request, QuizSettings $settings): RedirectResponse
+    {
+        $postTime = $request->validated('post_time');
+
+        if ($request->validated('scope') === UpdateQuizScheduleRequest::SCOPE_DEFAULT) {
+            $settings->post_time = $postTime;
+            $settings->save();
+
+            return back()->with('success', "تم ضبط موعد النشر اليومي على {$postTime}.");
+        }
+
+        $quiz = DailyQuiz::forDate(today());
+
+        if ($quiz === null) {
+            return back()->withErrors(['post_time' => 'لا يوجد سؤال لهذا اليوم لإعادة جدولته.']);
+        }
+
+        if (! $quiz->isReady()) {
+            return back()->withErrors(['post_time' => 'سؤال اليوم نُشر بالفعل — لا يمكن إعادة جدولته.']);
+        }
+
+        $quiz->update(['post_time' => $postTime]);
+
+        return back()->with('success', $postTime === null
+            ? 'عاد سؤال اليوم إلى موعد النشر الافتراضي.'
+            : "سيُنشر سؤال اليوم الساعة {$postTime} بدل الموعد الافتراضي.");
     }
 
     /**
@@ -274,6 +354,7 @@ class QuizController extends Controller
             'hint' => $quiz->hint,
             'obvious_hint' => $quiz->obvious_hint,
             'status' => $quiz->status,
+            'post_time' => $quiz->post_time,
             'topic' => $quiz->topic?->name,
             'posted_at' => $quiz->posted_at?->toISOString(),
             'answers_count' => $quiz->answers_count ?? 0,

--- a/app/Http/Requests/Manage/UpdateQuizScheduleRequest.php
+++ b/app/Http/Requests/Manage/UpdateQuizScheduleRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Requests\Manage;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateQuizScheduleRequest extends FormRequest
+{
+    /** Reschedule «اليوم فقط» — this day's question only. */
+    public const SCOPE_TODAY = 'today';
+
+    /** Reschedule «كل الأيام» — the default posting time. */
+    public const SCOPE_DEFAULT = 'default';
+
+    /**
+     * Any panel user may reschedule the quiz (parity with the quiz settings).
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * `post_time` is «HH:MM» in the app timezone. It may only be null for the
+     * one-day scope, where clearing it drops the override and returns that day
+     * to the default time.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'scope' => ['required', Rule::in([self::SCOPE_TODAY, self::SCOPE_DEFAULT])],
+            'post_time' => [
+                $this->input('scope') === self::SCOPE_TODAY ? 'nullable' : 'required',
+                'date_format:H:i',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'scope.required' => 'حدد نطاق الجدولة.',
+            'scope.in' => 'نطاق الجدولة غير صالح.',
+            'post_time.required' => 'حدد موعد النشر.',
+            'post_time.date_format' => 'موعد النشر يجب أن يكون بصيغة الساعة والدقيقة، مثل 16:00.',
+        ];
+    }
+}

--- a/app/Models/DailyQuiz.php
+++ b/app/Models/DailyQuiz.php
@@ -36,6 +36,7 @@ class DailyQuiz extends Model
         'hint',
         'obvious_hint',
         'status',
+        'post_time',
         'posted_at',
         'closed_at',
     ];

--- a/app/Services/Quiz/QuizPoster.php
+++ b/app/Services/Quiz/QuizPoster.php
@@ -8,6 +8,7 @@ use App\Models\QuizPlayer;
 use App\Models\QuizPost;
 use App\Services\TelegramMarkdownService;
 use App\Settings\QuizSettings;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Log;
 use RuntimeException;
 use Telegram\Bot\Api;
@@ -41,18 +42,25 @@ class QuizPoster
      * the day they belong to. A group that fails (bot kicked, no rights) is
      * logged and skipped; the quiz counts as posted while at least one group
      * got it.
+     *
+     * `$force` re-posts a question that already went out — the escape hatch
+     * for a poll that was deleted from the group by mistake. The quiz keeps
+     * its identity, so the answers already recorded on it stay valid and
+     * nobody can score twice; its own earlier polls are stopped quietly,
+     * without the end-of-day recap, because the day is not over.
      */
-    public function post(DailyQuiz $quiz): DailyQuiz
+    public function post(DailyQuiz $quiz, bool $force = false): DailyQuiz
     {
         if (! $this->settings->isConfigured()) {
             throw new RuntimeException('سؤال اليوم غير مهيأ — فعّله وحدد المجموعات من صفحة سؤال اليوم.');
         }
 
-        if (! $quiz->isReady()) {
+        if (! $quiz->isReady() && ! ($force && $quiz->isPosted())) {
             throw new RuntimeException('هذا السؤال ليس بانتظار النشر.');
         }
 
-        $this->closeOpenQuizzes();
+        $this->closeOpenQuizzes($quiz);
+        $this->retireOwnPosts($quiz);
 
         $content = $this->contentHtml($quiz);
 
@@ -68,6 +76,8 @@ class QuizPoster
             $params['explanation'] = $quiz->explanation;
         }
 
+        $delivered = 0;
+
         foreach ($this->settings->targets() as $target) {
             try {
                 if ($content !== null) {
@@ -80,14 +90,21 @@ class QuizPoster
 
                 $message = $this->telegram()->sendPoll($target->apply($params));
 
-                $post = QuizPost::create([
+                // One post row per quiz per group (a unique index enforces
+                // it), so a re-post moves the row onto the new poll instead of
+                // adding a second one that would silently fail to save.
+                QuizPost::updateOrCreate([
                     'daily_quiz_id' => $quiz->id,
                     'chat_id' => $message->getChat()->getId(),
+                ], [
                     'message_id' => $message->getMessageId(),
                     'message_thread_id' => $target->threadId,
                     'telegram_poll_id' => $message->getPoll()?->getId(),
                     'posted_at' => now(),
+                    'closed_at' => null,
                 ]);
+
+                $delivered++;
             } catch (\Throwable $exception) {
                 Log::error('Failed to post quiz to chat', [
                     'quiz_id' => $quiz->id,
@@ -97,7 +114,7 @@ class QuizPoster
             }
         }
 
-        if ($quiz->posts()->doesntExist()) {
+        if ($delivered === 0) {
             throw new RuntimeException('تعذّر نشر السؤال في أي من المجموعات المحددة.');
         }
 
@@ -128,39 +145,70 @@ class QuizPoster
     }
 
     /**
-     * Stop every still-open quiz poll (normally yesterday's, one per group).
-     * A poll Telegram already closed just makes stopPoll throw; the post is
-     * marked closed regardless so scoring stops accepting its votes.
+     * Stop every still-open quiz poll (normally yesterday's, one per group)
+     * and mark its quiz closed. `$except` spares one quiz — the one being
+     * re-posted, which is continuing rather than ending.
      */
-    public function closeOpenQuizzes(): void
+    public function closeOpenQuizzes(?DailyQuiz $except = null): void
     {
-        $openPosts = QuizPost::query()->open()->with('quiz')->get();
+        $openPosts = QuizPost::query()
+            ->open()
+            ->when($except !== null, fn (Builder $query) => $query->where('daily_quiz_id', '!=', $except->id))
+            ->with('quiz')
+            ->get();
 
         foreach ($openPosts as $post) {
-            try {
-                $this->telegram()->stopPoll([
-                    'chat_id' => $post->chat_id,
-                    'message_id' => $post->message_id,
-                ]);
-            } catch (\Throwable $exception) {
-                Log::warning('Failed to stop previous quiz poll', [
-                    'quiz_post_id' => $post->id,
-                    'message' => $exception->getMessage(),
-                ]);
-            }
-
-            $this->sendRecap($post);
-
-            $post->update(['closed_at' => now()]);
+            $this->retirePost($post, recap: true);
         }
 
         DailyQuiz::query()
             ->where('status', DailyQuiz::STATUS_POSTED)
+            ->when($except !== null, fn (Builder $query) => $query->whereKeyNot($except->getKey()))
             ->get()
             ->each(fn (DailyQuiz $quiz) => $quiz->update([
                 'status' => DailyQuiz::STATUS_CLOSED,
                 'closed_at' => now(),
             ]));
+    }
+
+    /**
+     * Stop the quiz's own polls from an earlier posting round, without a
+     * recap — a re-post is not the end of the day, and the recap belongs to
+     * the poll that actually closes it.
+     */
+    private function retireOwnPosts(DailyQuiz $quiz): void
+    {
+        foreach ($quiz->posts()->open()->get() as $post) {
+            $this->retirePost($post, recap: false);
+        }
+    }
+
+    /**
+     * Take one live poll out of circulation: close it on Telegram, optionally
+     * reply with the day's recap, and mark the post closed so scoring stops
+     * accepting its votes. A poll Telegram already closed — or a message
+     * someone deleted — just makes the call throw; the post is marked closed
+     * regardless.
+     */
+    private function retirePost(QuizPost $post, bool $recap): void
+    {
+        try {
+            $this->telegram()->stopPoll([
+                'chat_id' => $post->chat_id,
+                'message_id' => $post->message_id,
+            ]);
+        } catch (\Throwable $exception) {
+            Log::warning('Failed to stop previous quiz poll', [
+                'quiz_post_id' => $post->id,
+                'message' => $exception->getMessage(),
+            ]);
+        }
+
+        if ($recap) {
+            $this->sendRecap($post);
+        }
+
+        $post->update(['closed_at' => now()]);
     }
 
     /**

--- a/app/Services/Quiz/QuizSchedule.php
+++ b/app/Services/Quiz/QuizSchedule.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Services\Quiz;
+
+use App\Models\DailyQuiz;
+use App\Settings\QuizSettings;
+use Carbon\CarbonImmutable;
+
+/**
+ * When the daily question goes out.
+ *
+ * The time is a setting rather than a fixed schedule entry, and any single day
+ * may override it once ({@see DailyQuiz::$post_time}) without disturbing the
+ * default — so `quiz:post` runs every minute and asks this service whether the
+ * moment has come, instead of being pinned to one hour at deploy time.
+ */
+class QuizSchedule
+{
+    /** Used when no posting time is configured at all. */
+    public const DEFAULT_POST_TIME = '16:00';
+
+    public function __construct(private readonly QuizSettings $settings) {}
+
+    /**
+     * The time of day the given question goes out, as «HH:MM» — its own
+     * one-off time when an admin rescheduled it, otherwise the default.
+     */
+    public function postTimeFor(?DailyQuiz $quiz): string
+    {
+        $time = $quiz?->post_time ?? $this->settings->post_time;
+
+        return filled($time) ? $time : self::DEFAULT_POST_TIME;
+    }
+
+    /** The exact moment the given question is meant to go out. */
+    public function postsAt(DailyQuiz $quiz): CarbonImmutable
+    {
+        return CarbonImmutable::parse($quiz->quiz_date)->setTimeFromTimeString($this->postTimeFor($quiz));
+    }
+
+    /** The moment today's question goes out. */
+    public function todayPostsAt(): CarbonImmutable
+    {
+        return CarbonImmutable::parse(today())
+            ->setTimeFromTimeString($this->postTimeFor(DailyQuiz::forDate(today())));
+    }
+
+    /** Whether today's posting moment has arrived. */
+    public function isTodayDue(): bool
+    {
+        return ! $this->todayPostsAt()->isFuture();
+    }
+}

--- a/app/Settings/QuizSettings.php
+++ b/app/Settings/QuizSettings.php
@@ -26,6 +26,12 @@ class QuizSettings extends Settings
      */
     public array $chat_ids;
 
+    /**
+     * The time of day the question goes out, as «HH:MM» in the app timezone.
+     * A single day can override it — see {@see \App\Services\Quiz\QuizSchedule}.
+     */
+    public string $post_time;
+
     public static function group(): string
     {
         return 'quiz';

--- a/database/migrations/2026_08_05_234502_add_post_time_to_daily_quizzes.php
+++ b/database/migrations/2026_08_05_234502_add_post_time_to_daily_quizzes.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * A one-off posting time for a single day, as «HH:MM». Null means the
+     * question goes out at the `quiz.post_time` default like every other day.
+     */
+    public function up(): void
+    {
+        Schema::table('daily_quizzes', function (Blueprint $table) {
+            $table->string('post_time', 5)->nullable()->after('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('daily_quizzes', function (Blueprint $table) {
+            $table->dropColumn('post_time');
+        });
+    }
+};

--- a/database/settings/2026_08_05_234600_add_quiz_post_time.php
+++ b/database/settings/2026_08_05_234600_add_quiz_post_time.php
@@ -1,0 +1,21 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    /**
+     * The time of day the question goes out, as «HH:MM». It used to be baked
+     * into the schedule; making it a setting lets admins move it — and move a
+     * single day on its own — without a deploy.
+     */
+    public function up(): void
+    {
+        $this->migrator->add('quiz.post_time', '16:00');
+    }
+
+    public function down(): void
+    {
+        $this->migrator->delete('quiz.post_time');
+    }
+};

--- a/resources/js/components/manage/quiz/QuizCard.vue
+++ b/resources/js/components/manage/quiz/QuizCard.vue
@@ -9,7 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { arabicCount } from '@/lib/arabic';
-import { formatShortDate, formatWeekdayDate } from '@/lib/formatters';
+import { formatShortDate, formatTimeOfDay, formatWeekdayDate } from '@/lib/formatters';
 import { CheckCircle2, EllipsisVertical, Pencil, Trash2 } from 'lucide-vue-next';
 import { computed } from 'vue';
 import { lockReason, statusBadges, type Quiz } from './types';
@@ -39,6 +39,9 @@ const locked = computed(() => lockReason(props.quiz));
                         {{ prominent ? formatWeekdayDate(quiz.quiz_date) : formatShortDate(quiz.quiz_date) }}
                     </span>
                     <Badge :variant="statusBadges[quiz.status].variant">{{ statusBadges[quiz.status].label }}</Badge>
+                    <Badge v-if="quiz.post_time && quiz.status === 'ready'" variant="outline" title="موعد نشر خاص بهذا اليوم">
+                        {{ formatTimeOfDay(quiz.post_time) }}
+                    </Badge>
                     <Badge v-if="quiz.topic" variant="outline">{{ quiz.topic }}</Badge>
                     <span v-if="quiz.status !== 'ready'">
                         {{ arabicCount(quiz.answers_count, { singular: 'إجابة', dual: 'إجابتان', plural: 'إجابات' }) }} — منها

--- a/resources/js/components/manage/quiz/types.ts
+++ b/resources/js/components/manage/quiz/types.ts
@@ -12,10 +12,22 @@ export interface Quiz {
     hint: string | null;
     obvious_hint: string | null;
     status: QuizStatus;
+    /** A one-day posting time («HH:MM»), or null to follow the default. */
+    post_time: string | null;
     topic: string | null;
     posted_at: string | null;
     answers_count: number;
     correct_answers_count: number;
+}
+
+/** When the daily question goes out: the default, and today's own override. */
+export interface Schedule {
+    /** The default posting time for every day, as «HH:MM». */
+    post_time: string;
+    /** Today's own posting time when it was rescheduled on its own. */
+    today_post_time: string | null;
+    /** The moment today's question goes out, resolved server-side. */
+    today_posts_at: string;
 }
 
 /** A day in the upcoming queue, without the question body — just the schedule. */
@@ -23,6 +35,8 @@ export interface QueuedDay {
     id: number;
     quiz_date: string;
     status: QuizStatus;
+    /** A one-day posting time («HH:MM»), or null to follow the default. */
+    post_time: string | null;
     topic: string | null;
 }
 

--- a/resources/js/lib/formatters.ts
+++ b/resources/js/lib/formatters.ts
@@ -75,6 +75,13 @@ export function formatDayOffset(isoDate: string, today: string): string {
     return relativeTimeFormatter.format(days, 'day');
 }
 
+const timeOfDayFormatter = new Intl.DateTimeFormat('ar', { hour: 'numeric', minute: '2-digit' });
+
+/** "16:00" → an Arabic clock label ("٤:٠٠ م"). */
+export function formatTimeOfDay(time: string): string {
+    return timeOfDayFormatter.format(new Date(`2000-01-01T${time}:00`));
+}
+
 const dateTimeFormatter = new Intl.DateTimeFormat('ar', { dateStyle: 'medium', timeStyle: 'short' });
 
 export function formatDateTime(iso: string): string {

--- a/resources/js/pages/manage/quiz/Index.vue
+++ b/resources/js/pages/manage/quiz/Index.vue
@@ -6,7 +6,7 @@ import PageHeader from '@/components/manage/PageHeader.vue';
 import GenerateQuizDialog from '@/components/manage/quiz/GenerateQuizDialog.vue';
 import QuizCard from '@/components/manage/quiz/QuizCard.vue';
 import QuizEditorDialog from '@/components/manage/quiz/QuizEditorDialog.vue';
-import type { Limits, QueuedDay, Quiz, Topic } from '@/components/manage/quiz/types';
+import type { Limits, QueuedDay, Quiz, Schedule, Topic } from '@/components/manage/quiz/types';
 import { statusBadges } from '@/components/manage/quiz/types';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -16,13 +16,14 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { TagsInput, TagsInputInput, TagsInputItem, TagsInputItemDelete, TagsInputItemText } from '@/components/ui/tags-input';
 import { Textarea } from '@/components/ui/textarea';
 import { arabicCount } from '@/lib/arabic';
-import { formatDateTime, formatDayOffset, formatRelativeTime, formatShortDate, formatWeekdayDate } from '@/lib/formatters';
+import { formatDateTime, formatDayOffset, formatRelativeTime, formatShortDate, formatTimeOfDay, formatWeekdayDate } from '@/lib/formatters';
 import { Head, Link, router, useForm } from '@inertiajs/vue3';
-import { CalendarClock, EllipsisVertical, Library, Loader2, Pencil, PenLine, Plus, Sparkles, Trash2, Trophy } from 'lucide-vue-next';
+import { CalendarClock, Clock, EllipsisVertical, Library, Loader2, Pencil, PenLine, Plus, Send, Sparkles, Trash2, Trophy } from 'lucide-vue-next';
 import { computed, ref } from 'vue';
 
 defineOptions({ layout: ManageLayout });
@@ -49,6 +50,7 @@ interface Player {
 
 const props = defineProps<{
     settings: QuizSettingsValues;
+    schedule: Schedule;
     groupChats: GroupChat[];
     topics: Topic[];
     currentQuiz: Quiz | null;
@@ -82,7 +84,7 @@ const currentQuizContext = computed(() => {
     }
 
     if (!showingFutureDay.value) {
-        return { tone: 'muted' as const, text: 'هذا سؤال اليوم — راجعه وعدّله قبل النشر التلقائي الساعة 4 عصراً.' };
+        return { tone: 'muted' as const, text: `هذا سؤال اليوم — راجعه وعدّله قبل النشر التلقائي ${formatTimeOfDay(todayPostTime.value)}.` };
     }
 
     const day = `${formatWeekdayDate(props.currentQuiz.quiz_date)} (${formatDayOffset(props.currentQuiz.quiz_date, props.today)})`;
@@ -91,11 +93,110 @@ const currentQuizContext = computed(() => {
         return { tone: 'muted' as const, text: `سؤال اليوم نُشر بالفعل ولم يعد قابلاً للتعديل — المعروض هنا هو سؤال ${day}.` };
     }
 
-    return { tone: 'warning' as const, text: `لا يوجد سؤال لليوم! المعروض هو أقرب سؤال قادم — ${day}. ولّد سؤالاً لليوم قبل الساعة 4 عصراً.` };
+    return {
+        tone: 'warning' as const,
+        text: `لا يوجد سؤال لليوم! المعروض هو أقرب سؤال قادم — ${day}. ولّد سؤالاً لليوم قبل ${formatTimeOfDay(todayPostTime.value)}.`,
+    };
 });
 
 /** The queue after the question already shown in full above it. */
 const queueAhead = computed(() => props.upcoming.filter((day) => day.id !== props.currentQuiz?.id));
+
+/* ------------------------------------------------------------------ */
+/* Posting: when today's question goes out, and sending it by hand     */
+/* ------------------------------------------------------------------ */
+
+const configured = computed(() => props.settings.enabled && props.settings.chat_ids.length > 0);
+
+/** The time today's question actually goes out — its own, or the default. */
+const todayPostTime = computed(() => props.schedule.today_post_time ?? props.schedule.post_time);
+
+/** Today's question is live in the groups — re-posting is the deleted-poll fix. */
+const todayIsLive = computed(() => props.todayQuizStatus === 'posted');
+
+/** Today's own time can only be moved while the question is still waiting. */
+const todayReschedulable = computed(() => props.todayQuizStatus === 'ready');
+
+/** Why «نشر الآن» is unavailable, or null when it is available. */
+const postNowBlockedReason = computed(() => {
+    if (!configured.value) {
+        return 'فعّل سؤال اليوم وحدد المجموعات المستهدفة أولاً.';
+    }
+
+    if (props.todayQuizStatus === null) {
+        return 'لا يوجد سؤال لهذا اليوم — ولّده أولاً.';
+    }
+
+    if (props.todayQuizStatus === 'closed') {
+        return 'سؤال اليوم أُغلق ولا يمكن نشره من جديد.';
+    }
+
+    return null;
+});
+
+const postDialogOpen = ref(false);
+const posting = ref(false);
+
+function postNow(): void {
+    posting.value = true;
+
+    router.post(
+        '/manage/quiz/post',
+        {},
+        {
+            preserveScroll: true,
+            onSuccess: () => {
+                postDialogOpen.value = false;
+            },
+            onFinish: () => {
+                posting.value = false;
+            },
+        },
+    );
+}
+
+const scheduleDialogOpen = ref(false);
+
+const scheduleForm = useForm({
+    scope: 'default' as 'default' | 'today',
+    post_time: props.schedule.post_time,
+});
+
+function openScheduleDialog(): void {
+    scheduleForm.clearErrors();
+    scheduleForm.scope = 'default';
+    scheduleForm.post_time = props.schedule.post_time;
+    scheduleDialogOpen.value = true;
+}
+
+/** Keep the time field showing whatever the chosen scope currently applies. */
+function onScheduleScopeChange(scope: 'default' | 'today'): void {
+    scheduleForm.scope = scope;
+    scheduleForm.post_time = scope === 'today' ? todayPostTime.value : props.schedule.post_time;
+}
+
+function submitSchedule(): void {
+    scheduleForm.put('/manage/quiz/schedule', {
+        preserveScroll: true,
+        onSuccess: () => {
+            scheduleDialogOpen.value = false;
+        },
+    });
+}
+
+/** Drop today's one-day time so it follows the daily default again. */
+function clearTodaySchedule(): void {
+    router.put(
+        '/manage/quiz/schedule',
+        { scope: 'today', post_time: null },
+        {
+            preserveScroll: true,
+            onSuccess: () => {
+                scheduleDialogOpen.value = false;
+            },
+        },
+    );
+}
 
 /* ------------------------------------------------------------------ */
 /* Generate / write / edit / delete                                    */
@@ -251,8 +352,6 @@ const chatIdsError = computed(() => {
 
     return key ? errors[key] : null;
 });
-
-const configured = computed(() => props.settings.enabled && props.settings.chat_ids.length > 0);
 </script>
 
 <template>
@@ -267,8 +366,30 @@ const configured = computed(() => props.settings.enabled && props.settings.chat_
         <!-- The one question that can be edited right now -->
         <Card>
             <CardHeader class="flex flex-row flex-wrap items-center justify-between gap-2 space-y-0">
-                <CardTitle class="text-lg">{{ showingFutureDay ? 'السؤال القادم' : 'سؤال اليوم' }}</CardTitle>
+                <div class="space-y-1">
+                    <CardTitle class="text-lg">{{ showingFutureDay ? 'السؤال القادم' : 'سؤال اليوم' }}</CardTitle>
+                    <p class="text-xs text-muted-foreground">
+                        <template v-if="todayIsLive">منشور الآن — يُغلق مع نشر سؤال الغد</template>
+                        <template v-else>يُنشر {{ formatTimeOfDay(todayPostTime) }}</template>
+                        <span v-if="schedule.today_post_time && todayReschedulable"> — موعد خاص لليوم فقط</span>
+                    </p>
+                </div>
                 <div class="flex flex-wrap items-center gap-2">
+                    <Button variant="ghost" size="sm" @click="openScheduleDialog">
+                        <Clock class="size-4" />
+                        موعد النشر
+                    </Button>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        :disabled="postNowBlockedReason !== null || posting"
+                        :title="postNowBlockedReason ?? undefined"
+                        @click="postDialogOpen = true"
+                    >
+                        <Loader2 v-if="posting" class="size-4 animate-spin" />
+                        <Send v-else class="size-4" />
+                        {{ todayIsLive ? 'إعادة النشر الآن' : 'نشر الآن' }}
+                    </Button>
                     <Button size="sm" variant="outline" @click="openQuizEditor(null)">
                         <PenLine class="size-4" />
                         كتابة سؤال يدوياً
@@ -280,6 +401,9 @@ const configured = computed(() => props.settings.enabled && props.settings.chat_
                 </div>
             </CardHeader>
             <CardContent class="space-y-4">
+                <p v-if="configured && postNowBlockedReason" class="text-xs text-muted-foreground">{{ postNowBlockedReason }}</p>
+                <p v-if="$page.props.errors.post" class="text-sm text-destructive-foreground">{{ $page.props.errors.post }}</p>
+                <p v-if="$page.props.errors.post_time" class="text-sm text-destructive-foreground">{{ $page.props.errors.post_time }}</p>
                 <p
                     v-if="currentQuizContext"
                     class="rounded-lg border p-3 text-sm"
@@ -477,7 +601,8 @@ const configured = computed(() => props.settings.enabled && props.settings.chat_
                         <div class="space-y-1">
                             <Label for="quiz-enabled">تفعيل سؤال اليوم</Label>
                             <p class="text-xs text-muted-foreground">
-                                عند التفعيل: يُولَّد السؤال فجراً، ويُنشر في المجموعة الساعة 4 عصراً، وتُعلن نتائج الأسبوع مساء الخميس.
+                                عند التفعيل: يُولَّد السؤال فجراً، ويُنشر في المجموعة {{ formatTimeOfDay(schedule.post_time) }}، وتُعلن نتائج الأسبوع
+                                مساء الخميس. لتغيير الموعد استخدم «موعد النشر» في بطاقة سؤال اليوم.
                             </p>
                         </div>
                         <Switch id="quiz-enabled" v-model="settingsForm.enabled" />
@@ -536,6 +661,91 @@ const configured = computed(() => props.settings.enabled && props.settings.chat_
             </CardContent>
         </Card>
     </div>
+
+    <!-- Post / re-post today's question now -->
+    <ConfirmDialog
+        v-model:open="postDialogOpen"
+        :title="todayIsLive ? 'إعادة نشر سؤال اليوم' : 'نشر سؤال اليوم الآن'"
+        :confirm-label="todayIsLive ? 'إعادة النشر' : 'نشر الآن'"
+        :processing="posting"
+        @confirm="postNow"
+    >
+        <template v-if="todayIsLive">
+            سيُرسل السؤال نفسه من جديد إلى المجموعات المحددة، ويُغلق التصويت القديم إن كان ما زال موجوداً. النقاط والإجابات المسجّلة سابقاً تبقى كما
+            هي، ومن أجاب من قبل لا يستطيع أخذ نقاط مرة أخرى.
+        </template>
+        <template v-else> سيُنشر سؤال اليوم في المجموعات المحددة فوراً بدل انتظار موعده، ويُغلق تصويت اليوم السابق مع نشر خلاصته. </template>
+    </ConfirmDialog>
+
+    <!-- Posting time: for every day, or for today alone -->
+    <Dialog v-model:open="scheduleDialogOpen">
+        <DialogContent class="sm:max-w-lg">
+            <DialogHeader>
+                <DialogTitle>موعد نشر السؤال</DialogTitle>
+            </DialogHeader>
+
+            <form class="space-y-4" @submit.prevent="submitSchedule">
+                <div class="space-y-2">
+                    <Label for="schedule-scope">نطاق التغيير</Label>
+                    <Select
+                        id="schedule-scope"
+                        :model-value="scheduleForm.scope"
+                        @update:model-value="(value) => onScheduleScopeChange(value as 'default' | 'today')"
+                    >
+                        <SelectTrigger class="w-full" aria-label="نطاق تغيير موعد النشر">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="default">كل الأيام — الموعد الافتراضي</SelectItem>
+                            <SelectItem value="today" :disabled="!todayReschedulable">اليوم فقط — سؤال اليوم وحده</SelectItem>
+                        </SelectContent>
+                    </Select>
+                    <p v-if="!todayReschedulable" class="text-xs text-muted-foreground">
+                        «اليوم فقط» غير متاح: لا يوجد سؤال بانتظار النشر لهذا اليوم.
+                    </p>
+                    <p v-if="scheduleForm.errors.scope" class="text-sm text-destructive-foreground">{{ scheduleForm.errors.scope }}</p>
+                </div>
+
+                <div class="space-y-2">
+                    <Label for="schedule-time">الساعة</Label>
+                    <Input
+                        id="schedule-time"
+                        v-model="scheduleForm.post_time"
+                        type="time"
+                        dir="ltr"
+                        class="w-40 text-start tabular-nums"
+                        :aria-invalid="scheduleForm.errors.post_time ? true : undefined"
+                    />
+                    <p class="text-xs text-muted-foreground">
+                        بتوقيت مكة المكرمة. تغيير «كل الأيام» يسري على كل يوم قادم، وعلى سؤال اليوم أيضاً ما دام لم يُنشر بعد. تذكيرات المشاركة تبقى
+                        على مواعيدها الثابتة.
+                    </p>
+                    <p v-if="scheduleForm.errors.post_time" class="text-sm text-destructive-foreground">{{ scheduleForm.errors.post_time }}</p>
+                </div>
+
+                <DialogFooter class="gap-2 sm:justify-between">
+                    <Button
+                        v-if="schedule.today_post_time && todayReschedulable"
+                        type="button"
+                        variant="ghost"
+                        :disabled="scheduleForm.processing"
+                        @click="clearTodaySchedule"
+                    >
+                        إلغاء موعد اليوم الخاص
+                    </Button>
+                    <span v-else />
+
+                    <span class="flex gap-2">
+                        <Button type="button" variant="outline" @click="scheduleDialogOpen = false">إلغاء</Button>
+                        <Button type="submit" :disabled="scheduleForm.processing">
+                            <Loader2 v-if="scheduleForm.processing" class="size-4 animate-spin" />
+                            حفظ الموعد
+                        </Button>
+                    </span>
+                </DialogFooter>
+            </form>
+        </DialogContent>
+    </Dialog>
 
     <GenerateQuizDialog v-model:open="generateDialogOpen" :topics="topics" :upcoming="upcoming" :today="today" :default-date="nextFreeDate" />
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -33,9 +33,12 @@ Schedule::command('quiz:generate')
     ->withoutOverlapping()
     ->runInBackground();
 
+// Runs every minute and posts only when the configured moment arrives — the
+// posting time is a setting, and a single day can be rescheduled on its own,
+// so it cannot be pinned to one hour here (see App\Services\Quiz\QuizSchedule).
 Schedule::command('quiz:post')
-    ->dailyAt('16:00')
-    ->withoutOverlapping()
+    ->everyMinute()
+    ->withoutOverlapping(10)
     ->runInBackground();
 
 Schedule::command('quiz:announce-weekly')

--- a/routes/manage.php
+++ b/routes/manage.php
@@ -74,6 +74,8 @@ Route::prefix('manage')->name('manage.')->group(function () {
         Route::get('/quiz/archive', [QuizController::class, 'archive'])->name('quiz.archive');
         Route::put('/quiz/settings', [QuizController::class, 'updateSettings'])->name('quiz.settings.update');
         Route::post('/quiz/generate', [QuizController::class, 'generate'])->name('quiz.generate');
+        Route::post('/quiz/post', [QuizController::class, 'post'])->name('quiz.post');
+        Route::put('/quiz/schedule', [QuizController::class, 'updateSchedule'])->name('quiz.schedule.update');
         Route::post('/quiz/topics', [QuizTopicController::class, 'store'])->name('quiz.topics.store');
         Route::put('/quiz/topics/{topic}', [QuizTopicController::class, 'update'])->name('quiz.topics.update');
         Route::delete('/quiz/topics/{topic}', [QuizTopicController::class, 'destroy'])->name('quiz.topics.destroy');

--- a/tests/Feature/Manage/QuizManagementTest.php
+++ b/tests/Feature/Manage/QuizManagementTest.php
@@ -2,12 +2,16 @@
 
 use App\Jobs\GenerateDailyQuizJob;
 use App\Models\DailyQuiz;
+use App\Models\QuizAnswer;
 use App\Models\QuizTopic;
 use App\Models\User;
+use App\Services\Quiz\QuizPoster;
+use App\Services\Quiz\QuizSchedule;
 use App\Settings\QuizSettings;
 use Database\Seeders\RolesAndPermissionsSeeder;
 use Illuminate\Support\Facades\Queue;
 use Inertia\Testing\AssertableInertia as Assert;
+use Tests\Fakes\FakeTelegramApi;
 
 beforeEach(function () {
     $this->withoutVite();
@@ -506,4 +510,132 @@ it('refuses to regenerate a quiz that is already posted', function () {
         ->assertSessionHasErrors('generate');
 
     Queue::assertNothingPushed();
+});
+
+/** Turn the feature on with one target group — the state on-demand posting needs. */
+function configuredQuizGroups(): void
+{
+    $settings = app(QuizSettings::class);
+    $settings->enabled = true;
+    $settings->chat_ids = ['-100200300'];
+    $settings->save();
+}
+
+it('exposes the posting schedule on the page', function () {
+    DailyQuiz::factory()->create(['quiz_date' => today(), 'post_time' => '19:30']);
+
+    $this->actingAs($this->admin)
+        ->get('/manage/quiz')
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('schedule.post_time', QuizSchedule::DEFAULT_POST_TIME)
+            ->where('schedule.today_post_time', '19:30')
+            ->has('schedule.today_posts_at')
+            ->where('currentQuiz.post_time', '19:30'));
+});
+
+it('moves the default posting time for every day', function () {
+    $this->actingAs($this->admin)
+        ->put('/manage/quiz/schedule', ['scope' => 'default', 'post_time' => '18:45'])
+        ->assertRedirect();
+
+    expect(app(QuizSettings::class)->post_time)->toBe('18:45');
+});
+
+it('moves today\'s posting time only, leaving the default alone', function () {
+    $quiz = DailyQuiz::factory()->create(['quiz_date' => today()]);
+
+    $this->actingAs($this->admin)
+        ->put('/manage/quiz/schedule', ['scope' => 'today', 'post_time' => '20:00'])
+        ->assertRedirect();
+
+    expect($quiz->refresh()->post_time)->toBe('20:00')
+        ->and(app(QuizSettings::class)->post_time)->toBe(QuizSchedule::DEFAULT_POST_TIME);
+});
+
+it('clears today\'s one-day time and returns it to the default', function () {
+    $quiz = DailyQuiz::factory()->create(['quiz_date' => today(), 'post_time' => '20:00']);
+
+    $this->actingAs($this->admin)
+        ->put('/manage/quiz/schedule', ['scope' => 'today', 'post_time' => null])
+        ->assertRedirect();
+
+    expect($quiz->refresh()->post_time)->toBeNull();
+});
+
+it('rejects a malformed posting time', function () {
+    $this->actingAs($this->admin)
+        ->put('/manage/quiz/schedule', ['scope' => 'default', 'post_time' => '25:99'])
+        ->assertSessionHasErrors('post_time');
+
+    expect(app(QuizSettings::class)->post_time)->toBe(QuizSchedule::DEFAULT_POST_TIME);
+});
+
+it('refuses to reschedule a question that already went out', function () {
+    DailyQuiz::factory()->posted()->create(['quiz_date' => today()]);
+
+    $this->actingAs($this->admin)
+        ->put('/manage/quiz/schedule', ['scope' => 'today', 'post_time' => '20:00'])
+        ->assertSessionHasErrors('post_time');
+});
+
+it('posts today\'s question on demand', function () {
+    configuredQuizGroups();
+
+    $fake = new FakeTelegramApi;
+    $this->app->bind(QuizPoster::class, fn (): QuizPoster => new QuizPoster(app(QuizSettings::class), $fake));
+
+    $quiz = DailyQuiz::factory()->create(['quiz_date' => today()]);
+
+    $this->actingAs($this->admin)
+        ->post('/manage/quiz/post')
+        ->assertRedirect()
+        ->assertSessionHas('success');
+
+    expect($fake->sentPolls)->toHaveCount(1)
+        ->and($quiz->refresh()->status)->toBe(DailyQuiz::STATUS_POSTED);
+});
+
+it('re-posts a question whose poll was deleted, keeping its answers', function () {
+    configuredQuizGroups();
+
+    $fake = new FakeTelegramApi;
+    $this->app->bind(QuizPoster::class, fn (): QuizPoster => new QuizPoster(app(QuizSettings::class), $fake));
+
+    $quiz = DailyQuiz::factory()->posted()->create(['quiz_date' => today()]);
+    QuizAnswer::factory()->count(2)->create(['daily_quiz_id' => $quiz->id]);
+
+    $this->actingAs($this->admin)
+        ->post('/manage/quiz/post')
+        ->assertRedirect()
+        ->assertSessionHas('success');
+
+    expect($fake->sentPolls)->toHaveCount(1)
+        ->and($quiz->refresh()->status)->toBe(DailyQuiz::STATUS_POSTED)
+        ->and($quiz->answers()->count())->toBe(2)
+        ->and($quiz->posts()->open()->count())->toBe(1);
+});
+
+it('refuses to post on demand while the quiz is not configured', function () {
+    DailyQuiz::factory()->create(['quiz_date' => today()]);
+
+    $this->actingAs($this->admin)
+        ->post('/manage/quiz/post')
+        ->assertSessionHasErrors(['post' => 'سؤال اليوم غير مفعّل أو بلا مجموعات مستهدفة.']);
+});
+
+it('refuses to post on demand when today has no question yet', function () {
+    configuredQuizGroups();
+
+    $this->actingAs($this->admin)
+        ->post('/manage/quiz/post')
+        ->assertSessionHasErrors(['post' => 'لا يوجد سؤال لهذا اليوم — ولّده أولاً.']);
+});
+
+it('refuses to post on demand once the question has closed', function () {
+    configuredQuizGroups();
+    DailyQuiz::factory()->closed()->create(['quiz_date' => today()]);
+
+    $this->actingAs($this->admin)
+        ->post('/manage/quiz/post')
+        ->assertSessionHasErrors(['post' => 'سؤال اليوم أُغلق ولا يمكن نشره من جديد.']);
 });

--- a/tests/Feature/Quiz/QuizPostingTest.php
+++ b/tests/Feature/Quiz/QuizPostingTest.php
@@ -7,12 +7,20 @@ use App\Models\QuizPlayer;
 use App\Models\QuizPost;
 use App\Models\QuizTopic;
 use App\Services\Quiz\QuizPoster;
+use App\Services\Quiz\QuizSchedule;
 use App\Settings\AiSettings;
 use App\Settings\QuizSettings;
+use Illuminate\Support\Facades\Cache;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Tests\Fakes\FakeTelegramApi;
 
 beforeEach(function () {
+    // The command runs every minute and posts only once its moment arrives;
+    // sit on the default posting time so the clock is never the reason a test
+    // sees nothing. Cache backs the fallback-generation throttle.
+    $this->travelTo(today()->setTimeFromTimeString(QuizSchedule::DEFAULT_POST_TIME));
+    Cache::flush();
+
     config()->set('ai.providers.openrouter.key', 'test-key');
 
     $ai = app(AiSettings::class);
@@ -335,4 +343,148 @@ it('omits the explanation parameter when the quiz has none', function () {
     $this->artisan('quiz:post')->assertExitCode(0);
 
     expect($this->fake->sentPolls[0])->not->toHaveKey('explanation');
+});
+
+it('waits for the configured posting time before going out', function () {
+    $settings = app(QuizSettings::class);
+    $settings->post_time = '18:00';
+    $settings->save();
+
+    DailyQuiz::factory()->create(['quiz_date' => today()]);
+
+    $this->artisan('quiz:post')->assertExitCode(0);
+
+    expect($this->fake->sentPolls)->toBeEmpty();
+
+    $this->travelTo(today()->setTime(18, 0));
+
+    $this->artisan('quiz:post')->assertExitCode(0);
+
+    expect($this->fake->sentPolls)->toHaveCount(1)
+        ->and(DailyQuiz::forDate(today())->status)->toBe(DailyQuiz::STATUS_POSTED);
+});
+
+it('honours a one-day posting time without touching the default', function () {
+    $quiz = DailyQuiz::factory()->create(['quiz_date' => today(), 'post_time' => '20:30']);
+
+    $this->artisan('quiz:post')->assertExitCode(0);
+
+    expect($this->fake->sentPolls)->toBeEmpty();
+
+    $this->travelTo(today()->setTime(20, 30));
+
+    $this->artisan('quiz:post')->assertExitCode(0);
+
+    expect($this->fake->sentPolls)->toHaveCount(1)
+        ->and($quiz->refresh()->status)->toBe(DailyQuiz::STATUS_POSTED)
+        ->and(app(QuizSettings::class)->post_time)->toBe(QuizSchedule::DEFAULT_POST_TIME);
+});
+
+it('posts immediately with --force, ahead of the scheduled time', function () {
+    $this->travelTo(today()->setTime(9, 0));
+
+    $quiz = DailyQuiz::factory()->create(['quiz_date' => today()]);
+
+    $this->artisan('quiz:post', ['--force' => true])->assertExitCode(0);
+
+    expect($this->fake->sentPolls)->toHaveCount(1)
+        ->and($quiz->refresh()->status)->toBe(DailyQuiz::STATUS_POSTED);
+});
+
+it('re-posts an already posted question with --force, keeping its recorded answers', function () {
+    $quiz = livePostedQuiz(['quiz_date' => today()], ['message_id' => 999]);
+    QuizAnswer::factory()->count(3)->create(['daily_quiz_id' => $quiz->id]);
+
+    $this->artisan('quiz:post', ['--force' => true])->assertExitCode(0);
+
+    $quiz->refresh();
+
+    expect($this->fake->sentPolls)->toHaveCount(1)
+        ->and($this->fake->stoppedPolls)->toHaveCount(1)
+        ->and($this->fake->stoppedPolls[0]['message_id'])->toBe(999)
+        ->and($quiz->status)->toBe(DailyQuiz::STATUS_POSTED)
+        ->and($quiz->answers()->count())->toBe(3)
+        // One row per group: the re-post moves it onto the new poll.
+        ->and($quiz->posts()->count())->toBe(1)
+        ->and($quiz->posts()->open()->count())->toBe(1)
+        ->and($quiz->posts()->first()->message_id)->not->toBe(999)
+        ->and($quiz->posts()->first()->telegram_poll_id)->not->toBeNull()
+        ->and(DailyQuiz::query()->count())->toBe(1);
+});
+
+it('keeps answers landing on the same quiz after a re-post', function () {
+    $quiz = livePostedQuiz(['quiz_date' => today()]);
+
+    $this->artisan('quiz:post', ['--force' => true])->assertExitCode(0);
+
+    expect(DailyQuiz::findByPollId($quiz->posts()->first()->telegram_poll_id)?->id)->toBe($quiz->id);
+});
+
+it('sends no recap when re-posting, because the day is not over', function () {
+    $quiz = livePostedQuiz(['quiz_date' => today()], ['message_id' => 999]);
+    QuizAnswer::factory()->count(3)->create(['daily_quiz_id' => $quiz->id]);
+
+    $this->artisan('quiz:post', ['--force' => true])->assertExitCode(0);
+
+    expect(collect($this->fake->sentMessages)->pluck('reply_to_message_id')->filter())->toBeEmpty();
+});
+
+it('still recaps and closes the previous day when re-posting today', function () {
+    $yesterday = livePostedQuiz(['quiz_date' => today()->subDay()], ['message_id' => 555]);
+    QuizAnswer::factory()->create(['daily_quiz_id' => $yesterday->id]);
+
+    livePostedQuiz(['quiz_date' => today()], ['message_id' => 999]);
+
+    $this->artisan('quiz:post', ['--force' => true])->assertExitCode(0);
+
+    expect(collect($this->fake->sentMessages)->firstWhere('reply_to_message_id', 555))->not->toBeNull()
+        ->and($yesterday->refresh()->status)->toBe(DailyQuiz::STATUS_CLOSED)
+        ->and(DailyQuiz::forDate(today())->status)->toBe(DailyQuiz::STATUS_POSTED);
+});
+
+it('fails a re-post when every group rejects it, leaving the old post closed', function () {
+    $broken = new class extends FakeTelegramApi
+    {
+        public function sendPoll(array $params): \Telegram\Bot\Objects\Message
+        {
+            throw new RuntimeException('Forbidden');
+        }
+    };
+
+    $this->app->bind(QuizPoster::class, fn (): QuizPoster => new QuizPoster(app(QuizSettings::class), $broken));
+
+    $quiz = livePostedQuiz(['quiz_date' => today()]);
+
+    $this->artisan('quiz:post', ['--force' => true])->assertExitCode(1);
+
+    expect($quiz->refresh()->status)->toBe(DailyQuiz::STATUS_POSTED)
+        ->and($quiz->posts()->open()->count())->toBe(0);
+});
+
+it('refuses to force-post a closed question', function () {
+    DailyQuiz::factory()->closed()->create(['quiz_date' => today()]);
+
+    $this->artisan('quiz:post', ['--force' => true])->assertExitCode(1);
+
+    expect($this->fake->sentPolls)->toBeEmpty();
+});
+
+it('refuses to force-post when today has no question at all', function () {
+    $this->artisan('quiz:post', ['--force' => true])->assertExitCode(1);
+
+    expect($this->fake->sentPolls)->toBeEmpty();
+});
+
+it('throttles the inline fallback generation across per-minute runs', function () {
+    QuizTopic::factory()->create();
+
+    QuizAuthoringAgent::fake(['not a tool call at all']);
+
+    $this->artisan('quiz:post')->assertExitCode(1);
+
+    // A second run one minute later must not ask the authoring model again.
+    $this->travelTo(now()->addMinute());
+    $this->artisan('quiz:post')->assertExitCode(0);
+
+    expect(DailyQuiz::query()->count())->toBe(0);
 });


### PR DESCRIPTION
## Why

Today's question was posted at 16:00 and then **deleted from the group by mistake** — turnout collapsed from 67 answers the day before to 5. There was no way to send it again: the posting time was baked into the schedule and `QuizPoster::post()` refused anything that wasn't `ready`.

(The live poll has already been restored on prod by hand — this PR is the button that makes it a normal operation.)

## What

Two actions on `/manage/quiz`, next to the current question:

- **«نشر الآن» / «إعادة النشر الآن»** — sends today's question immediately. A re-post keeps the quiz's identity, so answers already recorded stay attached and nobody can score twice (`QuizAnswerRecorder` dedupes per quiz+player). The quiz's own dead poll is stopped quietly, *without* the end-of-day recap; yesterday's poll still closes and recaps normally.
- **«موعد النشر»** — moves the posting time either for **every day** (new `quiz.post_time` setting) or for **today's question alone** (new `daily_quizzes.post_time`), which leaves the default untouched and can be cleared again.

Because the moment is data now, `quiz:post` is scheduled `everyMinute()` and decides for itself whether it has arrived. `quiz:post --force` skips the clock entirely.

## Bug found along the way

`quiz_posts` is unique on `(daily_quiz_id, chat_id)`. A second `QuizPost::create()` for the same group threw *inside* the per-group `try/catch`, and the `posts()->doesntExist()` guard then saw the stale row and reported success — leaving a live poll in the group that no vote could map back to. Posting now upserts the row, and delivery is counted rather than inferred.

Also throttled the inline fallback generation to one attempt per 15 minutes, since the command went from once a day to once a minute.

## Not in scope

The six reminder phases keep their fixed hours — they're an editorial rhythm across the window, not a function of the posting time. Moving the posting time far from 16:00 will drift them relative to the window; worth a follow-up if the time actually moves.

## Verification

- `php artisan test` — 1166 passed; the 2 failures (`PublicRoutesTest`, `ExampleTest`, both on `/`) are pre-existing on `main`.
- New coverage: due-time gating (default + one-day override), `--force` ahead of time, re-post preserving answers / poll mapping / single post row, no-recap-on-re-post, previous day still recapped, re-post failure leaving the old post closed, closed/missing-question refusals, fallback throttle, and all four panel endpoints incl. validation.
- `vue-tsc` clean, `pint` clean, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)