### PR TITLE
Wire ai-kit's safety seam: TurnGuard/KillSwitch at every AI gate, pinned config

### DIFF
--- a/app/Ai/Admin/Actions/Corpus/AuthorPageFromDocumentAction.php
+++ b/app/Ai/Admin/Actions/Corpus/AuthorPageFromDocumentAction.php
@@ -26,6 +26,11 @@ use Saad\AiKit\Safety\BudgetGuard;
  */
 class AuthorPageFromDocumentAction extends AdminAction
 {
+    public function __construct(
+        private readonly PageAuthor $author,
+        private readonly BudgetGuard $budget,
+    ) {}
+
     public function name(): string
     {
         return 'author_page_from_document';
@@ -56,10 +61,8 @@ class AuthorPageFromDocumentAction extends AdminAction
      */
     public function validate(array $input, User $user): array
     {
-        $author = app(PageAuthor::class);
-
-        if (! $author->isEnabled()) {
-            throw new AdminActionException($author->disabledReason() ?? 'توليد الصفحات من المستندات غير متاح حالياً.');
+        if (! $this->author->isEnabled()) {
+            throw new AdminActionException($this->author->disabledReason() ?? 'توليد الصفحات من المستندات غير متاح حالياً.');
         }
 
         $document = CorpusDocument::query()->find((int) ($input['document_id'] ?? 0));
@@ -76,7 +79,7 @@ class AuthorPageFromDocumentAction extends AdminAction
             throw new AdminActionException('يوجد توليد قيد التنفيذ لهذا المستند بالفعل.');
         }
 
-        if (app(BudgetGuard::class)->exceeded()) {
+        if ($this->budget->exceeded()) {
             throw new AdminActionException(__('ai-kit::safety.budget_exceeded'));
         }
 

--- a/app/Ai/Admin/Tools/Concerns/GatedByAdminAssistant.php
+++ b/app/Ai/Admin/Tools/Concerns/GatedByAdminAssistant.php
@@ -2,20 +2,21 @@
 
 namespace App\Ai\Admin\Tools\Concerns;
 
-use App\Settings\AiSettings;
+use Saad\AiKit\Safety\KillSwitch;
 
 /**
- * Shared gating for the admin assistant's tools: while the master
- * `ai_enabled` switch or the `admin_assistant_enabled` feature toggle is off,
- * the tools refuse instead of running. The HTTP endpoints gate first, so this
- * is defence in depth for any other surface that might hand these tools to a
- * model.
+ * Shared gating for the admin assistant's tools: while ai-kit's kill switch
+ * is engaged for the `admin_assistant` scope (the master `ai_enabled`
+ * switch, the `admin_assistant_enabled` feature toggle, or the kit's cache
+ * switch), the tools refuse instead of running. The HTTP endpoints gate
+ * first, so this is defence in depth for any other surface that might hand
+ * these tools to a model.
  */
 trait GatedByAdminAssistant
 {
     protected function adminAssistantIsDisabled(): bool
     {
-        return ! app(AiSettings::class)->isFeatureEnabled('admin_assistant');
+        return app(KillSwitch::class)->engaged('admin_assistant');
     }
 
     protected function adminAssistantDisabledReply(): string

--- a/app/Ai/Tools/Concerns/GatedByAiSettings.php
+++ b/app/Ai/Tools/Concerns/GatedByAiSettings.php
@@ -2,19 +2,20 @@
 
 namespace App\Ai\Tools\Concerns;
 
-use App\Settings\AiSettings;
+use Saad\AiKit\Safety\KillSwitch;
 
 /**
- * Shared gating for every AI tool: while the master `ai_enabled` kill switch
- * in {@see AiSettings} is off, tools answer with a bilingual refusal instead
- * of running. Feature-specific toggles (e.g. `search_enabled`) are checked
- * by the tools that need them on top of this.
+ * Shared gating for every AI tool: while the global kill switch is engaged
+ * (the operator's master `ai_enabled` toggle or ai-kit's cache switch),
+ * tools answer with a bilingual refusal instead of running.
+ * Feature-specific toggles (e.g. `search_enabled`) are checked by the tools
+ * that need them on top of this.
  */
 trait GatedByAiSettings
 {
     protected function aiToolsAreDisabled(): bool
     {
-        return ! app(AiSettings::class)->ai_enabled;
+        return app(KillSwitch::class)->engaged();
     }
 
     protected function aiDisabledReply(): string

--- a/app/Http/Controllers/Ai/ChatAttachmentController.php
+++ b/app/Http/Controllers/Ai/ChatAttachmentController.php
@@ -6,9 +6,10 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Ai\ChatAttachmentRequest;
 use App\Jobs\Ai\ExtractChatAttachmentJob;
 use App\Models\Ai\ChatAttachment;
-use App\Settings\AiSettings;
 use Illuminate\Http\JsonResponse;
-use Saad\AiKit\Safety\BudgetGuard;
+use Saad\AiKit\Safety\Exceptions\AiKilledException;
+use Saad\AiKit\Safety\Exceptions\AiUnavailableException;
+use Saad\AiKit\Safety\TurnGuard;
 
 /**
  * POST /ai/chat/attachments (name: ai.chat.attachments.store) — store one
@@ -20,14 +21,14 @@ use Saad\AiKit\Safety\BudgetGuard;
  */
 class ChatAttachmentController extends Controller
 {
-    public function __invoke(ChatAttachmentRequest $request, AiSettings $settings, BudgetGuard $budget): JsonResponse
+    public function __invoke(ChatAttachmentRequest $request, TurnGuard $guard): JsonResponse
     {
-        if (! $settings->isFeatureEnabled('assistant')) {
+        try {
+            $guard->check('assistant');
+        } catch (AiKilledException) {
             return response()->json(['message' => 'المساعد الذكي غير متاح حالياً.'], 503);
-        }
-
-        if ($budget->exceeded()) {
-            return response()->json(['message' => __('ai-kit::safety.budget_exceeded')], 503);
+        } catch (AiUnavailableException $exception) {
+            return response()->json(['message' => $exception->userFacingReason()], 503);
         }
 
         $file = $request->file('file');

--- a/app/Http/Controllers/Ai/ChatController.php
+++ b/app/Http/Controllers/Ai/ChatController.php
@@ -20,7 +20,10 @@ use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\RateLimiter;
 use Laravel\Ai\Models\ConversationMessage;
 use Saad\AiKit\Conversations\ConversationOwnership;
-use Saad\AiKit\Safety\BudgetGuard;
+use Saad\AiKit\Safety\Exceptions\AiKilledException;
+use Saad\AiKit\Safety\Exceptions\AiUnavailableException;
+use Saad\AiKit\Safety\KillSwitch;
+use Saad\AiKit\Safety\TurnGuard;
 use Saad\AiKit\Streaming\SseStream;
 use Saad\AiKit\Streaming\StreamEventMapper;
 use Saad\AiKit\Streaming\StreamResult;
@@ -38,10 +41,10 @@ use Throwable;
  * consulted), then `done`, or `error`. Pre-flight failures (feature toggle,
  * budget, daily quota) answer as plain JSON before any stream starts.
  *
- * Layered gates, in order: assistant toggle (503, SearchController's
- * pattern) → daily spend budget via ai-kit's BudgetGuard (503) → the `ai-chat`
- * burst limiter on the route (429) → the operator's per-session daily
- * message quota (429).
+ * Layered gates, in order: ai-kit's TurnGuard (503) — the assistant toggle
+ * via the operator's AiSettings, the kit's cache kill switch, and the daily
+ * spend budget in one call — → the `ai-chat` burst limiter on the route
+ * (429) → the operator's per-session daily message quota (429).
  */
 class ChatController extends Controller
 {
@@ -54,18 +57,18 @@ class ChatController extends Controller
     public function send(
         ChatMessageRequest $request,
         AiSettings $settings,
-        BudgetGuard $budget,
+        TurnGuard $guard,
         ConversationOwnership $ownership,
         CitationExtractor $citations,
         AttachmentContext $attachmentContext,
         CategoryContext $categoryContext,
     ): JsonResponse|StreamedResponse {
-        if (! $settings->isFeatureEnabled('assistant')) {
+        try {
+            $guard->check(self::FEATURE);
+        } catch (AiKilledException) {
             return $this->disabledResponse();
-        }
-
-        if ($budget->exceeded()) {
-            return response()->json(['message' => __('ai-kit::safety.budget_exceeded')], 503);
+        } catch (AiUnavailableException $exception) {
+            return response()->json(['message' => $exception->userFacingReason()], 503);
         }
 
         $sessionId = $request->session()->getId();
@@ -94,7 +97,7 @@ class ChatController extends Controller
      */
     public function show(
         Request $request,
-        AiSettings $settings,
+        KillSwitch $killSwitch,
         ConversationOwnership $ownership,
         CitationExtractor $citations,
         AttachmentContext $attachmentContext,
@@ -102,7 +105,9 @@ class ChatController extends Controller
         AnswerLinkGuard $linkGuard,
         string $conversation,
     ): JsonResponse {
-        if (! $settings->isFeatureEnabled('assistant')) {
+        // Reading a stored thread costs nothing, so only the kill switch
+        // (toggle or cache) gates it — never the daily budget.
+        if ($killSwitch->engaged(self::FEATURE)) {
             return $this->disabledResponse();
         }
 

--- a/app/Http/Controllers/Manage/AdminAssistantController.php
+++ b/app/Http/Controllers/Manage/AdminAssistantController.php
@@ -20,7 +20,10 @@ use Saad\AiKit\Approvals\Proposal;
 use Saad\AiKit\Approvals\ProposalExecutor;
 use Saad\AiKit\Approvals\ProposalTrailer;
 use Saad\AiKit\Conversations\ConversationOwnership;
-use Saad\AiKit\Safety\BudgetGuard;
+use Saad\AiKit\Safety\Exceptions\AiKilledException;
+use Saad\AiKit\Safety\Exceptions\AiUnavailableException;
+use Saad\AiKit\Safety\KillSwitch;
+use Saad\AiKit\Safety\TurnGuard;
 use Saad\AiKit\Streaming\SseStream;
 use Saad\AiKit\Streaming\StreamEventMapper;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -34,9 +37,10 @@ use Throwable;
  * pending action, so the client renders تأكيد/رفض cards inline. Conversations
  * belong to the authenticated admin (AdminOwner, "admin:{id}").
  *
- * Layered gates on every endpoint: panel auth (route middleware) → master
- * ai_enabled AND admin_assistant_enabled (503 with the reason) → daily spend
- * budget (503) → the route's per-admin burst limiter (429).
+ * Layered gates on every endpoint: panel auth (route middleware) → ai-kit's
+ * kill switch, which folds master ai_enabled AND admin_assistant_enabled
+ * (503 with the reason) with the kit's cache switch → daily spend budget on
+ * turn entry (503, via TurnGuard) → the route's per-admin burst limiter (429).
  */
 class AdminAssistantController extends Controller
 {
@@ -48,11 +52,11 @@ class AdminAssistantController extends Controller
      * Always renders; when the feature is off the page explains how to
      * enable it instead of hiding (disabled-with-reason).
      */
-    public function index(AiSettings $settings): Response
+    public function index(AiSettings $settings, KillSwitch $killSwitch): Response
     {
         return Inertia::render('manage/assistant/Index', [
             'assistant' => [
-                'enabled' => $settings->isFeatureEnabled('admin_assistant'),
+                'enabled' => ! $killSwitch->engaged(self::FEATURE),
                 'disabledReason' => $this->disabledReason($settings),
             ],
         ]);
@@ -65,15 +69,15 @@ class AdminAssistantController extends Controller
     public function send(
         AdminAssistantMessageRequest $request,
         AiSettings $settings,
-        BudgetGuard $budget,
+        TurnGuard $guard,
         ConversationOwnership $ownership,
     ): JsonResponse|StreamedResponse {
-        if (! $settings->isFeatureEnabled('admin_assistant')) {
+        try {
+            $guard->check(self::FEATURE);
+        } catch (AiKilledException) {
             return $this->disabledResponse($settings);
-        }
-
-        if ($budget->exceeded()) {
-            return response()->json(['message' => __('ai-kit::safety.budget_exceeded')], 503);
+        } catch (AiUnavailableException $exception) {
+            return response()->json(['message' => $exception->userFacingReason()], 503);
         }
 
         /** @var User $admin */
@@ -98,10 +102,11 @@ class AdminAssistantController extends Controller
     public function show(
         Request $request,
         AiSettings $settings,
+        KillSwitch $killSwitch,
         ConversationOwnership $ownership,
         string $conversation,
     ): JsonResponse {
-        if (! $settings->isFeatureEnabled('admin_assistant')) {
+        if ($killSwitch->engaged(self::FEATURE)) {
             return $this->disabledResponse($settings);
         }
 
@@ -141,10 +146,11 @@ class AdminAssistantController extends Controller
      */
     public function confirm(
         AiSettings $settings,
+        KillSwitch $killSwitch,
         ProposalExecutor $executor,
         Proposal $proposal,
     ): JsonResponse {
-        if (! $settings->isFeatureEnabled('admin_assistant')) {
+        if ($killSwitch->engaged(self::FEATURE)) {
             return $this->disabledResponse($settings);
         }
 
@@ -168,10 +174,11 @@ class AdminAssistantController extends Controller
      */
     public function reject(
         AiSettings $settings,
+        KillSwitch $killSwitch,
         ProposalExecutor $executor,
         Proposal $proposal,
     ): JsonResponse {
-        if (! $settings->isFeatureEnabled('admin_assistant')) {
+        if ($killSwitch->engaged(self::FEATURE)) {
             return $this->disabledResponse($settings);
         }
 

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -5,23 +5,25 @@ namespace App\Http\Controllers;
 use App\Ai\Corpus\CorpusRetriever;
 use App\Ai\Corpus\CorpusSearchResult;
 use App\Http\Requests\SearchRequest;
-use App\Settings\AiSettings;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Str;
+use Saad\AiKit\Safety\KillSwitch;
 
 /**
  * Public JSON endpoint for corpus search — the read side the search palette
- * consumes. Gated on the AiSettings search toggle (behind the master AI kill
- * switch): when disabled it answers 503 with `enabled: false` so the frontend
- * can distinguish "feature off" from "no results" without a shared prop.
+ * consumes. Gated on ai-kit's kill switch for the `search` scope (the
+ * AiSettings search toggle behind the master AI switch, plus the kit's
+ * cache switch): when disabled it answers 503 with `enabled: false` so the
+ * frontend can distinguish "feature off" from "no results" without a shared
+ * prop.
  */
 class SearchController extends Controller
 {
     private const SNIPPET_LENGTH = 160;
 
-    public function __invoke(SearchRequest $request, CorpusRetriever $retriever, AiSettings $settings): JsonResponse
+    public function __invoke(SearchRequest $request, CorpusRetriever $retriever, KillSwitch $killSwitch): JsonResponse
     {
-        if (! $settings->isFeatureEnabled('search')) {
+        if ($killSwitch->engaged('search')) {
             return response()->json([
                 'enabled' => false,
                 'results' => [],

--- a/app/Services/Telegram/Handlers/AiChatHandler.php
+++ b/app/Services/Telegram/Handlers/AiChatHandler.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Facades\Storage;
 use Laravel\Ai\Streaming\Events\Error as ErrorEvent;
 use Saad\AiKit\Conversations\ConversationOwnership;
 use Saad\AiKit\Safety\BudgetGuard;
+use Saad\AiKit\Safety\KillSwitch;
 use Telegram\Bot\Api;
 use Telegram\Bot\Objects\Document;
 use Telegram\Bot\Objects\Message;
@@ -38,7 +39,8 @@ use Throwable;
  * agent, tools, and Arabic instructions as the web chat, replying in chats
  * where the assistant is activated.
  *
- * Layered gates, in order: AiSettings telegram feature toggle → the chat's
+ * Layered gates, in order: ai-kit's kill switch (the AiSettings telegram
+ * feature toggle plus the kit's cache switch) → the chat's
  * own activation row ({@see TelegramChatSetting}, default OFF — /ai_on) →
  * the explicit «سيك …» ask prefix on the message text/caption (the ONLY
  * invocation, in every chat type — the bot never answers plain chatter,
@@ -105,6 +107,7 @@ class AiChatHandler extends BaseHandler
     public function __construct(
         Api $telegram,
         protected AiSettings $settings,
+        protected KillSwitch $killSwitch,
         protected BudgetGuard $budget,
         protected ChatAttachmentTextExtractor $extractor,
         protected AttachmentContext $attachmentContext,
@@ -126,6 +129,7 @@ class AiChatHandler extends BaseHandler
         return new self(
             $telegram,
             app(AiSettings::class),
+            app(KillSwitch::class),
             app(BudgetGuard::class),
             app(ChatAttachmentTextExtractor::class),
             app(AttachmentContext::class),
@@ -138,7 +142,7 @@ class AiChatHandler extends BaseHandler
 
     public function handle(Message $message): void
     {
-        if (! $this->settings->isFeatureEnabled(self::FEATURE)) {
+        if ($this->killSwitch->engaged(self::FEATURE)) {
             return;
         }
 
@@ -179,7 +183,7 @@ class AiChatHandler extends BaseHandler
      */
     public function handleMediaGroup(Message $leadMessage, array $sources, bool $truncated = false): void
     {
-        if (! $this->settings->isFeatureEnabled(self::FEATURE)) {
+        if ($this->killSwitch->engaged(self::FEATURE)) {
             return;
         }
 

--- a/config/ai-kit.php
+++ b/config/ai-kit.php
@@ -1,0 +1,256 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Modules
+    |--------------------------------------------------------------------------
+    |
+    | Each module registers its own service provider when enabled. Apps opt
+    | out of what they don't use (uqucc never enables credits; config-only
+    | catalogs skip the sync command, etc.).
+    |
+    */
+
+    'modules' => [
+        'gateway' => true,
+        'agents' => true,
+        'conversations' => true,
+        'streaming' => true,
+        'approvals' => true,
+        'attachments' => true,
+        'usage' => true,
+        'catalog' => true,
+        'safety' => true,
+        'rag' => false,
+        'credits' => false,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Gateway
+    |--------------------------------------------------------------------------
+    |
+    | The canonical ReasoningOpenRouterGateway replaces the stock openrouter
+    | driver's text gateway. Retries cover transient statuses only —
+    | connection timeouts are deliberately not retried. The final-step nudge
+    | is sent to the model when tools are withheld on the last step; it is
+    | model-facing text, so it ships bilingual rather than localized.
+    |
+    */
+
+    'gateway' => [
+        'register_openrouter_driver' => true,
+        'spend_context_prefix' => 'ai',
+        'force_usage_accounting' => true,
+        'retry' => [
+            'attempts' => 3,
+            'backoff_ms' => 500,
+            'statuses' => [408, 409, 429, 500, 502, 503, 504],
+        ],
+        'final_step' => [
+            'withhold_tools' => true,
+            'message' => 'انتهت خطوات استخدام الأدوات. قدّم الآن إجابتك النهائية للمستخدم نصاً بناءً على ما توصلت إليه، وإن لم تجد المعلومة فقل ذلك صراحةً. '
+                .'Tool steps are over — write your complete final answer as plain text now; if the information was not found, say so plainly.',
+        ],
+
+        // Statuses that convert to ProviderOverloadedException after retries
+        // are exhausted — the trigger for failing over to the next model in
+        // a declared chain. Stock laravel/ai only maps 503.
+        'failover' => [
+            'overloaded_statuses' => [500, 502, 503, 504, 529],
+        ],
+
+        // Enough step failures inside the window open the circuit for the
+        // cooldown; while open, requests to that model fail over immediately
+        // without touching the network. Uses the default cache store unless
+        // one is named — it must be shared across workers in production.
+        'circuit_breaker' => [
+            'enabled' => true,
+            'cache_store' => env('AI_KIT_BREAKER_CACHE_STORE'),
+            'failure_threshold' => 5,
+            'window_seconds' => 120,
+            'cooldown_seconds' => 60,
+            'half_open_seconds' => 30,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Streaming
+    |--------------------------------------------------------------------------
+    |
+    | The resumable TurnBuffer keeps each turn's event log in this cache
+    | store for `ttl_seconds` — generous enough that a user can close the
+    | tab mid-reply and still resume after a break. Use a store shared
+    | across web and queue workers in production. The tail loop stops after
+    | `max_stream_seconds` (the client's EventSource reconnects with its
+    | last id), emits a keepalive comment after `keepalive_seconds` of
+    | silence so proxies don't buffer the stream shut, and polls the buffer
+    | every `poll_interval_ms`.
+    |
+    */
+
+    'streaming' => [
+        'cache_store' => env('AI_KIT_STREAMING_CACHE_STORE'),
+        'ttl_seconds' => (int) env('AI_KIT_STREAMING_TTL_SECONDS', 7200),
+        'max_stream_seconds' => (int) env('AI_KIT_STREAMING_MAX_SECONDS', 180),
+        'keepalive_seconds' => (int) env('AI_KIT_STREAMING_KEEPALIVE_SECONDS', 15),
+        'poll_interval_ms' => (int) env('AI_KIT_STREAMING_POLL_INTERVAL_MS', 150),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Conversations
+    |--------------------------------------------------------------------------
+    |
+    | `encrypt` binds the kit's EncryptedConversationStore over laravel/ai's
+    | ConversationStore contract: message content is encrypted with the app
+    | key before it touches the database, and pre-encryption plaintext rows
+    | still read back. It is OPT-IN, and turning it on is a one-way door for
+    | every row written while it is on: those rows are readable only through
+    | this store and only with the app key that wrote them. Decide before you
+    | have traffic, keep the key, and do not flip it back and forth. With it
+    | off the vendor store stays bound (or bind your own). Table names and
+    | the connection follow the vendor keys (`ai.conversations.tables.*`,
+    | `ai.conversations.connection`).
+    |
+    | `persist_tool_traces` keeps attachments / tool_calls / tool_results /
+    | usage / meta on message rows. Off by default — traces can carry user
+    | data at rest. laravel/ai's built-in tool-approval pause/resume
+    | reconstructs turns from those traces, so enable this if you use it.
+    |
+    | `retention_days` is the idle window `ai-kit:prune-conversations`
+    | deletes beyond (the --days option overrides per run). The command
+    | fires a ConversationsPruning event with the doomed ids first, so apps
+    | can cascade their own per-conversation resources.
+    |
+    */
+
+    'conversations' => [
+        'encrypt' => false,
+        'persist_tool_traces' => false,
+        // Anonymous session chats are short-lived; a week of history is
+        // plenty and keeps the conversations table small.
+        'retention_days' => 7,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Usage
+    |--------------------------------------------------------------------------
+    |
+    | Every completed agent turn writes one canonical row to `table`,
+    | recorded from laravel/ai's AgentPrompted / AgentStreamed events — no
+    | app code involved. `drain_spend` clears the spend collector after each
+    | turn; set it to false while an app still drains the collector itself
+    | (dual-write transition). Apps label turns by setting the
+    | `feature_context_key` Context value before prompting.
+    |
+    */
+
+    'usage' => [
+        'table' => 'ai_usage_events',
+        'drain_spend' => true,
+        'feature_context_key' => 'ai-kit.feature',
+        'record_failovers' => true,
+
+        // One structured log record per turn / failover attempt, with OTel
+        // GenAI attribute names. null channel = the default log channel.
+        'trace' => [
+            'enabled' => env('AI_KIT_TURN_TRACES', true),
+            'channel' => env('AI_KIT_TRACE_CHANNEL'),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Catalog
+    |--------------------------------------------------------------------------
+    |
+    | The models the app routes turns to, keyed by provider-facing model id.
+    | Prices are USD per million tokens (optional — metering prefers the
+    | provider-reported cost). `fallbacks` declares the failover chain for a
+    | model; alias provider entries are registered automatically so chains
+    | ride laravel/ai's native failover. `cheapest`/`smartest` feed the SDK's
+    | UseCheapestModel / UseSmartestModel attributes.
+    |
+    */
+
+    'catalog' => [
+        'provider' => 'openrouter',
+        'cheapest' => null,
+        'smartest' => null,
+        'models' => [
+            // 'google/gemini-3.5-flash' => [
+            //     'label' => 'Gemini 3.5 Flash',
+            //     'input_usd_per_million' => 0.30,
+            //     'output_usd_per_million' => 2.50,
+            //     'context_length' => 1048576,
+            //     'capabilities' => ['tools', 'vision', 'reasoning'],
+            //     'fallbacks' => ['deepseek/deepseek-v4-flash'],
+            // ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Approvals
+    |--------------------------------------------------------------------------
+    |
+    | The propose → confirm → execute pattern: proposals persist in
+    | `proposals_table`, executed plan steps claim exactly-once rows in
+    | `write_executions_table`, and proposed plans wait for their confirm
+    | turn in the plan cache store for `plan_ttl_seconds` (an abandoned plan
+    | quietly lapses). `auto_approve` lets a single non-destructive, undoable
+    | step skip the approval card; turn it off to always show the card.
+    |
+    */
+
+    'approvals' => [
+        'proposals_table' => 'ai_proposals',
+        'write_executions_table' => 'ai_write_executions',
+        'plan_cache_store' => env('AI_KIT_PLAN_CACHE_STORE'),
+        'plan_ttl_seconds' => (int) env('AI_KIT_PLAN_TTL_SECONDS', 3600),
+        'auto_approve' => true,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Safety
+    |--------------------------------------------------------------------------
+    |
+    | Kill switch, daily budget and concurrency state live in this cache
+    | store. Use a persistent shared store (redis, database) in production —
+    | an engaged kill switch must survive restarts. The daily budget resets
+    | at midnight in the given timezone (null = app timezone). A null
+    | daily_usd_limit or max_concurrent_turns disables that gate; a
+    | daily_usd_limit <= 0 reads as exhausted (an operator kill switch for
+    | budget-gated surfaces). `enabled` and `features` back the default
+    | config-driven SafetySettings — a feature missing from `features`
+    | counts as enabled. Apps with an operator-editable settings store
+    | rebind the SafetySettings contract instead of using these keys.
+    | `record_spend_from_usage` feeds each metered turn's cost from the
+    | usage module into the budget counter (requires the usage module).
+    |
+    */
+
+    'safety' => [
+        'cache_store' => env('AI_KIT_SAFETY_CACHE_STORE'),
+        'enabled' => env('AI_KIT_AI_ENABLED', true),
+        'features' => [
+            // 'chat' => true,
+        ],
+        'daily_usd_limit' => env('AI_KIT_DAILY_USD_LIMIT') !== null
+            ? (float) env('AI_KIT_DAILY_USD_LIMIT')
+            : null,
+        'timezone' => env('AI_KIT_BUDGET_TIMEZONE'),
+        'record_spend_from_usage' => true,
+        'max_concurrent_turns' => env('AI_KIT_MAX_CONCURRENT_TURNS') !== null
+            ? (int) env('AI_KIT_MAX_CONCURRENT_TURNS')
+            : 3,
+        'turn_ttl_seconds' => (int) env('AI_KIT_TURN_TTL_SECONDS', 600),
+    ],
+
+];

--- a/routes/console.php
+++ b/routes/console.php
@@ -19,9 +19,10 @@ Schedule::command('sitemap:generate')
     ->runInBackground();
 
 // ai-kit's pruner deletes conversations (and messages) idle beyond the
-// window; the App\Listeners\PruneChatAttachments listener cascades chat
-// attachments (rows + stored files) off its ConversationsPruning event.
-Schedule::command('ai-kit:prune-conversations --days=7')
+// window (ai-kit.conversations.retention_days); the
+// App\Listeners\PruneChatAttachments listener cascades chat attachments
+// (rows + stored files) off its ConversationsPruning event.
+Schedule::command('ai-kit:prune-conversations')
     ->daily()
     ->withoutOverlapping()
     ->runInBackground();

--- a/tests/Feature/Ai/Chat/ChatEndpointTest.php
+++ b/tests/Feature/Ai/Chat/ChatEndpointTest.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Models\Conversation;
 use Laravel\Ai\Models\ConversationMessage;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Saad\AiKit\Safety\BudgetGuard;
+use Saad\AiKit\Safety\KillSwitch;
 use Saad\AiKit\Usage\UsageEvent;
 
 beforeEach(function () {
@@ -327,6 +328,16 @@ it('answers 503 on every endpoint while the master ai kill switch is off', funct
     $settings->save();
 
     $this->postJson('/ai/chat', ['message' => 'مرحبا'])->assertServiceUnavailable();
+});
+
+it("answers 503 while ai-kit's cache kill switch is engaged, all settings toggles on", function () {
+    StudentAssistant::fake(['يجب ألا يظهر هذا الرد.']);
+
+    app(KillSwitch::class)->engage(reason: 'حادثة تشغيلية');
+
+    $this->postJson('/ai/chat', ['message' => 'مرحبا'])->assertServiceUnavailable();
+
+    StudentAssistant::assertNeverPrompted();
 });
 
 it('refuses politely without calling the model once the daily budget is spent', function () {

--- a/tests/Feature/Ai/Chat/PruneAiConversationsTest.php
+++ b/tests/Feature/Ai/Chat/PruneAiConversationsTest.php
@@ -9,7 +9,7 @@ use Laravel\Ai\Models\ConversationMessage;
 
 /**
  * Pruning is ai-kit's `ai-kit:prune-conversations` command (scheduled with
- * --days=7 in routes/console.php); the app's part is the
+ * the 7-day window pinned in config/ai-kit.php); the app's part is the
  * {@see \App\Listeners\PruneChatAttachments} listener cascading chat
  * attachments off the ConversationsPruning event.
  */

--- a/tests/Feature/Ai/SearchEndpointTest.php
+++ b/tests/Feature/Ai/SearchEndpointTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Page;
 use App\Settings\AiSettings;
+use Saad\AiKit\Safety\KillSwitch;
 
 beforeEach(function () {
     config()->set('ai.embeddings.driver', 'fake');
@@ -100,6 +101,16 @@ it('returns a feature-disabled response when the master ai kill switch is off', 
     $settings = app(AiSettings::class);
     $settings->ai_enabled = false;
     $settings->save();
+
+    $this->getJson(route('search', ['q' => 'البرمجة']))
+        ->assertServiceUnavailable()
+        ->assertJsonPath('enabled', false);
+});
+
+it("returns a feature-disabled response while ai-kit's cache kill switch is engaged for search", function () {
+    seedSearchablePage('الخطة الدراسية', 'تحتوي الخطة على مقررات البرمجة');
+
+    app(KillSwitch::class)->engage('search');
 
     $this->getJson(route('search', ['q' => 'البرمجة']))
         ->assertServiceUnavailable()

--- a/tests/Feature/Manage/AdminAssistantTest.php
+++ b/tests/Feature/Manage/AdminAssistantTest.php
@@ -18,6 +18,7 @@ use Laravel\Ai\Tools\Request as ToolRequest;
 use Saad\AiKit\Approvals\Proposal;
 use Saad\AiKit\Approvals\ProposalStatus;
 use Saad\AiKit\Safety\BudgetGuard;
+use Saad\AiKit\Safety\KillSwitch;
 use Saad\AiKit\Usage\UsageEvent;
 
 beforeEach(function () {
@@ -173,6 +174,18 @@ describe('authorization and gating', function () {
             ->postJson(route('manage.assistant.send'), ['message' => 'مرحبا'])
             ->assertServiceUnavailable()
             ->assertJsonPath('message', fn (string $message) => str_contains($message, 'الذكاء الاصطناعي'));
+
+        AdminAssistant::assertNeverPrompted();
+    });
+
+    it("answers 503 on send while ai-kit's cache kill switch is engaged, both settings toggles on", function () {
+        AdminAssistant::fake(['يجب ألا يظهر هذا الرد.']);
+
+        app(KillSwitch::class)->engage('admin_assistant', 'حادثة تشغيلية');
+
+        $this->actingAs($this->admin)
+            ->postJson(route('manage.assistant.send'), ['message' => 'مرحبا'])
+            ->assertServiceUnavailable();
 
         AdminAssistant::assertNeverPrompted();
     });

--- a/tests/Feature/Telegram/AiChatHandlerTest.php
+++ b/tests/Feature/Telegram/AiChatHandlerTest.php
@@ -22,6 +22,7 @@ use Laravel\Ai\Models\Conversation;
 use Laravel\Ai\Models\ConversationMessage;
 use Saad\AiKit\Conversations\ConversationOwnership;
 use Saad\AiKit\Safety\BudgetGuard;
+use Saad\AiKit\Safety\KillSwitch;
 use Saad\AiKit\Usage\UsageEvent;
 use Telegram\Bot\Objects\Message;
 use Tests\Fakes\FakeTelegramApi;
@@ -43,6 +44,7 @@ function aiChatHandler(FakeTelegramApi $api): AiChatHandler
     return new AiChatHandler(
         $api,
         app(AiSettings::class),
+        app(KillSwitch::class),
         app(BudgetGuard::class),
         app(ChatAttachmentTextExtractor::class),
         app(AttachmentContext::class),
@@ -118,6 +120,22 @@ it('stays silent while the global telegram ai toggle is off', function () {
     $settings = app(AiSettings::class);
     $settings->telegram_ai_enabled = false;
     $settings->save();
+
+    $api = new FakeTelegramApi;
+
+    aiChatHandler($api)->handle(aiChatMessage());
+
+    StudentAssistant::assertNeverPrompted();
+
+    expect($api->sentMessages)->toBe([]);
+});
+
+it("stays silent while ai-kit's cache kill switch is engaged for telegram", function () {
+    StudentAssistant::fake(['يجب ألا يظهر هذا الرد.']);
+
+    activatedChat();
+
+    app(KillSwitch::class)->engage('telegram');
 
     $api = new FakeTelegramApi;
 


### PR DESCRIPTION
Closes the two gaps the post-migration audit flagged after PR #127.

## What changed

**Published + pinned `config/ai-kit.php`.** The kit's defaults no longer apply invisibly; `conversations.retention_days` is pinned to 7 and the scheduled `ai-kit:prune-conversations` drops its `--days=7` override so the window has one source of truth.

**The kit's kill-switch seam is now live.** Before this, `KitSafetySettings` backed the kit's `KillSwitch`/`TurnGuard`, but no uqucc call site ever went through them — every gate paired `AiSettings::isFeatureEnabled()` with `BudgetGuard` by hand, and engaging the kit's cache switch did nothing.

- Turn entries — public chat `send`, attachment upload, admin assistant `send` — gate through `TurnGuard::check(scope)`: operator toggles + cache kill switch + daily budget in one call.
- Read/probe endpoints — chat `show`, admin `index`/`show`/`confirm`/`reject`, public search — and the two tool-gating traits (`GatedByAiSettings`, `GatedByAdminAssistant`) consult `KillSwitch::engaged(scope)` and never the budget (reading a stored thread costs nothing).
- The Telegram handler's silent feature gates do the same via an injected `KillSwitch`.

Every existing Arabic message is byte-identical (`AiKilledException` maps back onto each surface's own disabled response; budget/other reasons render `userFacingReason()`, same strings as before). The only new behaviour: `app(KillSwitch::class)->engage()` — global or per scope, e.g. from tinker during an incident — now actually stops every surface, and `release()` restores it.

**Audit follow-up:** `AuthorPageFromDocumentAction` constructor-injects `PageAuthor` + `BudgetGuard` instead of service-locating them (actions are container-resolved).

## Deliberately out of scope

Background pipeline gates (page copilot, page/quiz authoring, vision extractors, corpus ingestion) stay on `AiSettings` directly: they read the same settings store the kill switch consults, carry bespoke disabled-reason UX, and are already budget-gated through the kit's `BudgetGuard`.

## Tests

Four new tests prove the cache switch gates chat, search, the admin assistant, and Telegram with all settings toggles on. Full suite: **1171 passed** (+4 over main), 2 pre-existing homepage-404 failures unrelated to AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016apbZ57VK5jR6VUjLgpNyw