### PR TITLE
Shuffle quiz options to remove model ordering bias

### DIFF
--- a/app/Ai/Quiz/QuizAuthor.php
+++ b/app/Ai/Quiz/QuizAuthor.php
@@ -140,7 +140,7 @@ class QuizAuthor
         - اختبار أخير: هل التلميح الثاني أوضح فعلاً من الأول بدرجة ملموسة؟ إن كانا في القوة نفسها فقد فشلا معاً.
 
         الإرسال والحدود:
-        - أرسل سؤالك باستدعاء الأداة submit_quiz_question فقط — لا تكتب الناتج نصاً عادياً ولا JSON. حقولها: question، body، options (مصفوفة من أربعة خيارات)، correct_option (رقم من 0 إلى 3، ونوّع موضعه)، explanation، hint، obvious_hint.
+        - أرسل سؤالك باستدعاء الأداة submit_quiz_question فقط — لا تكتب الناتج نصاً عادياً ولا JSON. حقولها: question، body، options (مصفوفة من أربعة خيارات)، correct_option (رقم من 0 إلى 3)، explanation، hint، obvious_hint.
         - إن أعادت الأداة قائمة مشاكل فعالجها كلها ثم استدعِها مرة أخرى، وكرّر حتى تُقبل. وبمجرد قبولها توقّف ولا تُجرِ تعديلاً إضافياً.
         - الحدود القصوى: السؤال 300 حرف، body 700 حرف، كل خيار 100 حرف، الشرح 200 حرف، وكل تلميح 120 حرف. body اختياري: أرسله "" عند عدم الحاجة لكود أو مقدمة.
         - الشرح جملة أو جملتان تشرحان لماذا الإجابة صحيحة — يظهر للطالب بعد إجابته.
@@ -206,7 +206,7 @@ class QuizAuthor
             throw new RuntimeException('لا توجد مواضيع مفعّلة — أضف مواضيع من صفحة سؤال اليوم أولاً.');
         }
 
-        $decoded = $this->generateQuestion($topic);
+        $decoded = $this->shuffleOptions($this->generateQuestion($topic));
 
         $existing?->delete();
 
@@ -249,6 +249,28 @@ class QuizAuthor
         }
 
         throw new RuntimeException('تعذّر توليد سؤال صالح: '.$lastError?->getMessage());
+    }
+
+    /**
+     * Randomize the option order so the stored position of the correct answer
+     * is independent of the model. The model is never told where to place it,
+     * so any residual ordering bias in its output is dissolved here; the
+     * correct answer is tracked by value and its index remapped afterward.
+     *
+     * @param  array{question: string, body: string|null, options: array<int, string>, correct_option: int, explanation: string|null, hint: string|null, obvious_hint: string|null}  $question
+     * @return array{question: string, body: string|null, options: array<int, string>, correct_option: int, explanation: string|null, hint: string|null, obvious_hint: string|null}
+     */
+    private function shuffleOptions(array $question): array
+    {
+        $correctValue = $question['options'][$question['correct_option']];
+
+        $options = $question['options'];
+        shuffle($options);
+
+        $question['options'] = $options;
+        $question['correct_option'] = (int) array_search($correctValue, $options, true);
+
+        return $question;
     }
 
     private function buildPrompt(QuizTopic $topic): string

--- a/tests/Feature/Quiz/QuizGenerationTest.php
+++ b/tests/Feature/Quiz/QuizGenerationTest.php
@@ -57,8 +57,8 @@ it('generates a ready quiz from the least-recently-used active topic', function 
         ->and($quiz->status)->toBe(DailyQuiz::STATUS_READY)
         ->and($quiz->quiz_topic_id)->toBe($neverUsed->id)
         ->and($quiz->question)->toBe('ما البوابة المنطقية التي تعكس قيمة المدخل؟')
-        ->and($quiz->options)->toBe(['AND', 'OR', 'NOT', 'XOR'])
-        ->and($quiz->correct_option)->toBe(2)
+        ->and($quiz->options)->toEqualCanonicalizing(['AND', 'OR', 'NOT', 'XOR'])
+        ->and($quiz->options[$quiz->correct_option])->toBe('NOT')
         ->and($quiz->explanation)->not->toBeNull()
         ->and($quiz->hint)->toBe('فكّر في العملية التي تقلب القيمة.')
         ->and($quiz->obvious_hint)->toBe('البوابة التي تحوّل 1 إلى 0.')
@@ -354,7 +354,7 @@ it('corrects duplicated options within the same run', function () {
     $this->artisan('quiz:generate')->assertExitCode(0);
 
     expect(DailyQuiz::query()->count())->toBe(1)
-        ->and(DailyQuiz::forDate(today())->options)->toBe(['AND', 'OR', 'NOT', 'XOR']);
+        ->and(DailyQuiz::forDate(today())->options)->toEqualCanonicalizing(['AND', 'OR', 'NOT', 'XOR']);
 });
 
 it('gives up when the correct option stays much longer than the distractors', function () {
@@ -380,7 +380,7 @@ it('corrects a lopsided correct option within the same run', function () {
     $this->artisan('quiz:generate')->assertExitCode(0);
 
     expect(DailyQuiz::query()->count())->toBe(1)
-        ->and(DailyQuiz::forDate(today())->options)->toBe(['AND', 'OR', 'NOT', 'XOR']);
+        ->and(DailyQuiz::forDate(today())->options)->toEqualCanonicalizing(['AND', 'OR', 'NOT', 'XOR']);
 });
 
 it('ignores a trailing assistant message after the question is accepted', function () {
@@ -416,6 +416,23 @@ it('avoids spotlight topics on regular days while regular topics exist', functio
     $this->artisan('quiz:generate', ['--date' => $sunday->toDateString()])->assertExitCode(0);
 
     expect(DailyQuiz::forDate($sunday)->quiz_topic_id)->toBe($regular->id);
+});
+
+it('shuffles the option order independently of the model', function () {
+    $topic = QuizTopic::factory()->create();
+
+    $positions = collect(range(1, 40))->map(function (int $offset) use ($topic): int {
+        QuizAuthoringAgent::fake([quizToolCall()]);
+
+        $quiz = app(QuizAuthor::class)->generateForDate(today()->addDays($offset), $topic);
+
+        expect($quiz->options)->toEqualCanonicalizing(['AND', 'OR', 'NOT', 'XOR'])
+            ->and($quiz->options[$quiz->correct_option])->toBe('NOT');
+
+        return $quiz->correct_option;
+    });
+
+    expect($positions->unique()->count())->toBeGreaterThan(1);
 });
 
 it('lists recent questions in the prompt so the model avoids repeats', function () {


### PR DESCRIPTION
## Summary
Randomizes the order of quiz answer options after generation to eliminate any inherent ordering bias from the AI model, ensuring the correct answer position is independent of the model's output.

## Key Changes
- Added `shuffleOptions()` method that randomizes option order while tracking the correct answer by value rather than position
- Updated `generateForDate()` to shuffle options after question generation
- Updated prompt documentation to remove outdated instruction about varying correct answer position (now handled automatically)
- Updated tests to verify options are present (order-agnostic) and that correct answer is tracked by value
- Added new test verifying that correct answer position varies across multiple generations

## Implementation Details
The `shuffleOptions()` method:
- Extracts the correct answer value before shuffling
- Randomizes the options array
- Remaps `correct_option` index to the new position of the correct answer value
- Ensures the stored position is independent of any model bias while maintaining answer correctness

This approach decouples the model's output format from the final quiz structure, improving fairness and reducing potential biases in how the model positions correct answers.

https://claude.ai/code/session_014UE35QPBw68xh5NhxDCGLC