### PR TITLE
Let the group vote on tomorrow's quiz topic, without breaking the rotation

### DIFF
--- a/app/Ai/Admin/Actions/Quiz/ListQuizTopicsAction.php
+++ b/app/Ai/Admin/Actions/Quiz/ListQuizTopicsAction.php
@@ -11,7 +11,9 @@ use Illuminate\Contracts\JsonSchema\JsonSchema;
 /**
  * The admin-curated themes the daily quiz generates from, each with its id,
  * name, optional prompt hint, whether it is a weekly major-spotlight topic,
- * whether it is active, and when it was last used. Mirrors the topic list on
+ * whether it is active, when it was last used, and whether the running
+ * rotation cycle still owes it a turn — which is also what decides whether it
+ * can appear on the group's topic ballot. Mirrors the topic list on
  * {@see \App\Http\Controllers\Manage\QuizController::index()}. Use the returned
  * ids for update_quiz_topic and delete_quiz_topic. Read-only.
  */
@@ -35,7 +37,8 @@ class ListQuizTopicsAction extends AdminAction
     public function description(): string
     {
         return 'List the daily-quiz topics the questions are generated from — id, name, prompt hint, '
-            .'whether it is a weekly spotlight topic, whether it is active, and when it was last used. '
+            .'whether it is a weekly spotlight topic, whether it is active, when it was last used, and '
+            .'whether the running rotation cycle still owes it a turn. '
             .'Use the returned ids for update_quiz_topic and delete_quiz_topic. Read-only.';
     }
 
@@ -63,17 +66,18 @@ class ListQuizTopicsAction extends AdminAction
         }
 
         $lines = $topics->map(fn (QuizTopic $topic): string => sprintf(
-            '- id=%d | %s | %s | %s | آخر استخدام: %s%s',
+            '- id=%d | %s | %s | %s | آخر استخدام: %s | الدورة: %s%s',
             $topic->id,
             $topic->name,
             $topic->is_active ? 'مفعّل' : 'معطّل',
             $topic->is_spotlight ? 'يوم تخصص' : 'عام',
             $topic->last_used_at?->toDateString() ?? 'لم يُستخدم',
+            $topic->cycle_used_at === null ? 'بانتظار دوره' : 'أخذ دوره',
             filled($topic->prompt_hint) ? ' | توجيه: '.$topic->prompt_hint : '',
         ));
 
         return ActionResult::text(
-            "مواضيع سؤال اليوم (id | الاسم | الحالة | النوع | آخر استخدام):\n".$lines->implode("\n"),
+            "مواضيع سؤال اليوم (id | الاسم | الحالة | النوع | آخر استخدام | الدورة):\n".$lines->implode("\n"),
         );
     }
 }

--- a/app/Ai/Quiz/QuizAuthor.php
+++ b/app/Ai/Quiz/QuizAuthor.php
@@ -4,6 +4,7 @@ namespace App\Ai\Quiz;
 
 use App\Models\DailyQuiz;
 use App\Models\QuizTopic;
+use App\Services\Quiz\QuizTopicVote;
 use App\Settings\AiSettings;
 use App\Support\QuizContentHtml;
 use Carbon\CarbonInterface;
@@ -165,6 +166,7 @@ class QuizAuthor
     public function __construct(
         private readonly AiSettings $settings,
         private readonly BudgetGuard $budget,
+        private readonly QuizTopicVote $topicVote,
     ) {}
 
     /**
@@ -188,8 +190,9 @@ class QuizAuthor
      * Generate the quiz for the given day and store it as `ready`. Throws
      * with an operator-facing Arabic message on any refusal.
      *
-     * Pass an explicit `$topic` to force that theme; otherwise the topic is
-     * picked automatically (least-recently-used, spotlight-aware). When a
+     * Pass an explicit `$topic` to force that theme; otherwise the day's topic
+     * vote decides it ({@see QuizTopicVote}), and failing that the automatic
+     * pick does (least-recently-used within the cycle, spotlight-aware). When a
      * `ready` question already exists for the day, `$replace` regenerates it —
      * the old one is dropped only after the new question is authored, so a
      * generation failure leaves the existing question untouched.
@@ -216,7 +219,12 @@ class QuizAuthor
             }
         }
 
-        $topic ??= QuizTopic::pickForDate($date);
+        // Always settle the day's ballot, even when an admin has already named
+        // the topic: leaving a vote open past the question it was about is
+        // worse than a vote that turned out not to decide anything.
+        $voted = $this->topicVote->resolve($date);
+
+        $topic ??= $voted ?? QuizTopic::pickForDate($date);
 
         if ($topic === null) {
             throw new RuntimeException('لا توجد مواضيع مفعّلة — أضف مواضيع من صفحة سؤال اليوم أولاً.');
@@ -238,7 +246,7 @@ class QuizAuthor
             'status' => DailyQuiz::STATUS_READY,
         ]);
 
-        $topic->update(['last_used_at' => now()]);
+        $topic->markUsed();
 
         return $quiz;
     }

--- a/app/Http/Controllers/Manage/QuizController.php
+++ b/app/Http/Controllers/Manage/QuizController.php
@@ -329,6 +329,7 @@ class QuizController extends Controller
                 'is_spotlight' => $topic->is_spotlight,
                 'is_active' => $topic->is_active,
                 'last_used_at' => $topic->last_used_at?->toISOString(),
+                'awaiting_turn' => $topic->cycle_used_at === null,
             ])
             ->toBase();
     }

--- a/app/Models/QuizTopic.php
+++ b/app/Models/QuizTopic.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -14,6 +15,13 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * Regular topics are foundational/cross-major; topics flagged `is_spotlight`
  * are major-specific and only picked on the weekly spotlight day, so the
  * mixed audience meets them at a predictable, limited cadence.
+ *
+ * Topics rotate in cycles: `cycle_used_at` is stamped when a topic supplies a
+ * question and cleared for the whole pool only once every topic in it has had
+ * its turn. So no topic can be skipped, however tomorrow's topic is chosen —
+ * least-recently-used here, or the group's vote in
+ * {@see \App\Services\Quiz\QuizTopicVote}, which only ever offers topics the
+ * running cycle still owes.
  */
 class QuizTopic extends Model
 {
@@ -32,6 +40,7 @@ class QuizTopic extends Model
         'is_spotlight',
         'is_active',
         'last_used_at',
+        'cycle_used_at',
     ];
 
     protected function casts(): array
@@ -40,6 +49,7 @@ class QuizTopic extends Model
             'is_spotlight' => 'boolean',
             'is_active' => 'boolean',
             'last_used_at' => 'datetime',
+            'cycle_used_at' => 'datetime',
         ];
     }
 
@@ -58,24 +68,63 @@ class QuizTopic extends Model
     }
 
     /**
-     * The topic to generate from on the given day: least-recently-used among
-     * spotlight topics on the spotlight weekday (falling back to regular
-     * topics when none exist), least-recently-used regular topic otherwise.
+     * Every active topic eligible on the given day, least-recently-used first:
+     * the spotlight topics on the spotlight weekday and the regular ones
+     * otherwise, each falling back to the other pool when its own is empty.
+     *
+     * @return Collection<int, self>
      */
-    public static function pickForDate(CarbonInterface $date): ?self
+    public static function poolForDate(CarbonInterface $date): Collection
     {
-        $spotlightDay = $date->dayOfWeek === self::SPOTLIGHT_WEEKDAY;
-
-        $pick = fn (bool $spotlight): ?self => static::query()
+        $pool = fn (bool $spotlight): Collection => static::query()
             ->active()
             ->where('is_spotlight', $spotlight)
             ->orderByRaw('last_used_at is not null')
             ->orderBy('last_used_at')
             ->orderBy('id')
-            ->first();
+            ->get();
 
-        return $spotlightDay
-            ? ($pick(true) ?? $pick(false))
-            : ($pick(false) ?? $pick(true));
+        $preferred = $pool($date->dayOfWeek === self::SPOTLIGHT_WEEKDAY);
+
+        return $preferred->isNotEmpty()
+            ? $preferred
+            : $pool($date->dayOfWeek !== self::SPOTLIGHT_WEEKDAY);
+    }
+
+    /**
+     * What the day's pool still owes the running cycle, least-recently-used
+     * first. Exhausting the pool starts the next cycle right here — the only
+     * place the marks are cleared, so "nothing left to cover" and "everything
+     * is available again" can never disagree.
+     *
+     * @return Collection<int, self>
+     */
+    public static function cycleCandidates(CarbonInterface $date): Collection
+    {
+        $pool = static::poolForDate($date);
+        $pending = $pool->filter(fn (self $topic): bool => $topic->cycle_used_at === null)->values();
+
+        if ($pending->isNotEmpty() || $pool->isEmpty()) {
+            return $pending;
+        }
+
+        static::query()->whereKey($pool->modelKeys())->update(['cycle_used_at' => null]);
+
+        return $pool->each(fn (self $topic) => $topic->setAttribute('cycle_used_at', null))->values();
+    }
+
+    /**
+     * The topic to generate from on the given day when nothing else decided
+     * it: the least-recently-used one the cycle has not covered yet.
+     */
+    public static function pickForDate(CarbonInterface $date): ?self
+    {
+        return static::cycleCandidates($date)->first();
+    }
+
+    /** Record that this topic supplied a question, and spend its cycle turn. */
+    public function markUsed(): void
+    {
+        $this->update(['last_used_at' => now(), 'cycle_used_at' => now()]);
     }
 }

--- a/app/Models/QuizTopicPoll.php
+++ b/app/Models/QuizTopicPoll.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Collection;
+
+/**
+ * The group's vote on what tomorrow's question should be about: a plain
+ * Telegram poll listing four topics the current cycle has not covered yet,
+ * posted right under the day's question and tallied when the next question is
+ * generated ({@see \App\Services\Quiz\QuizTopicVote}).
+ *
+ * The illusion is only in the framing — every topic on a ballot is one the
+ * cycle would have reached anyway, so voting decides the order, never whether
+ * a topic gets its turn.
+ */
+class QuizTopicPoll extends Model
+{
+    /** @use HasFactory<\Database\Factories\QuizTopicPollFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'quiz_date',
+        'topic_ids',
+        'posts',
+        'quiz_topic_id',
+        'closed_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'quiz_date' => 'date',
+            'topic_ids' => 'array',
+            'posts' => 'array',
+            'closed_at' => 'datetime',
+        ];
+    }
+
+    /** The topic the vote settled on — null until the poll is tallied. */
+    public function topic(): BelongsTo
+    {
+        return $this->belongsTo(QuizTopic::class, 'quiz_topic_id');
+    }
+
+    public static function forDate(CarbonInterface $date): ?self
+    {
+        return static::query()->whereDate('quiz_date', $date)->first();
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->closed_at !== null;
+    }
+
+    /**
+     * The ballot as topic models, in the poll's own option order — so option N
+     * maps back to a topic. A topic an admin deleted meanwhile becomes a null
+     * in its slot rather than disappearing, because dropping it would shift
+     * every later option onto the wrong topic.
+     *
+     * @return Collection<int, QuizTopic|null>
+     */
+    public function ballot(): Collection
+    {
+        $topics = QuizTopic::query()->findMany($this->topic_ids)->keyBy('id');
+
+        return collect($this->topic_ids)
+            ->map(fn (int $id): ?QuizTopic => $topics->get($id))
+            ->values();
+    }
+}

--- a/app/Services/Quiz/QuizPoster.php
+++ b/app/Services/Quiz/QuizPoster.php
@@ -16,8 +16,9 @@ use Telegram\Bot\FileUpload\InputFile;
 /**
  * Everything the bot sends to the groups for the daily quiz: one quiz poll
  * per configured group (non-anonymous quiz polls, so votes arrive as
- * attributable `poll_answer` updates that map back to one shared quiz) and
- * the weekly winners announcement.
+ * attributable `poll_answer` updates that map back to one shared quiz), the
+ * ballot for tomorrow's topic that follows it ({@see QuizTopicVote}) and the
+ * weekly winners announcement.
  *
  * The Api client is built lazily so the service can be container-resolved in
  * environments without a bot token; tests pass a FakeTelegramApi instead.
@@ -40,6 +41,8 @@ class QuizPoster
     private ?Api $telegram;
 
     private ?QuizImageRenderer $imageRenderer;
+
+    private ?QuizTopicVote $topicVote = null;
 
     public function __construct(
         private readonly QuizSettings $settings,
@@ -133,7 +136,33 @@ class QuizPoster
             'posted_at' => now(),
         ]);
 
+        $this->rollTopicVote($quiz);
+
         return $quiz->refresh();
+    }
+
+    /**
+     * Retire the ballot this day was decided by and hand the group the next
+     * one, while today's question is fresh in front of them.
+     *
+     * Settling the outgoing ballot here matters even though generation
+     * normally does it: a question written by hand in the panel never asks the
+     * vote anything, and its ballot would otherwise stay open in the group
+     * forever. Best-effort on purpose — the vote is a flourish, and a question
+     * that reached the group has already succeeded. See {@see QuizTopicVote}
+     * for the ordinary reasons a new ballot is declined.
+     */
+    private function rollTopicVote(DailyQuiz $quiz): void
+    {
+        try {
+            $this->topicVote()->resolve($quiz->quiz_date);
+            $this->topicVote()->open($quiz->quiz_date->copy()->addDay());
+        } catch (\Throwable $exception) {
+            Log::warning('Failed to roll the topic vote forward', [
+                'quiz_id' => $quiz->id,
+                'message' => $exception->getMessage(),
+            ]);
+        }
     }
 
     /**
@@ -160,6 +189,12 @@ class QuizPoster
     private function imageRenderer(): QuizImageRenderer
     {
         return $this->imageRenderer ??= app(QuizImageRenderer::class);
+    }
+
+    /** Built on our own Api client, so the vote reaches the same groups. */
+    private function topicVote(): QuizTopicVote
+    {
+        return $this->topicVote ??= new QuizTopicVote($this->settings, $this->telegram());
     }
 
     /**

--- a/app/Services/Quiz/QuizTopicVote.php
+++ b/app/Services/Quiz/QuizTopicVote.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace App\Services\Quiz;
+
+use App\Models\DailyQuiz;
+use App\Models\QuizTopic;
+use App\Models\QuizTopicPoll;
+use App\Settings\QuizSettings;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Log;
+use Telegram\Bot\Api;
+use Throwable;
+
+/**
+ * Lets the group pick tomorrow's topic — an illusion of choice with no way to
+ * cheat the rotation. The ballot only ever lists topics the running cycle
+ * still owes ({@see QuizTopic::cycleCandidates()}), so a vote reorders the
+ * cycle and never decides whether a topic is covered at all.
+ *
+ * Two moments, a day apart: {@see self::open()} posts the ballot right under
+ * the day's question, and {@see self::resolve()} stops the polls when the next
+ * question is generated and returns what the group asked for.
+ *
+ * The vote is deliberately skipped — silently, with the ordinary
+ * least-recently-used pick taking over — whenever offering it would be a lie:
+ *  - fewer than {@see self::BALLOT_SIZE} topics are left in the cycle, since
+ *    filling the last slots would mean offering a topic that is already
+ *    covered while topics that are not go unasked;
+ *  - the day already has a question, so its topic is settled;
+ *  - a ballot for that day already went out.
+ *
+ * The Api client is built lazily so the service can be container-resolved in
+ * environments without a bot token; tests pass a FakeTelegramApi instead.
+ */
+class QuizTopicVote
+{
+    /** How many topics a ballot lists — and the minimum the cycle must owe. */
+    public const BALLOT_SIZE = 4;
+
+    public const QUESTION = '🗳 موضوع سؤال الغد بين أيديكم — صوّتوا!';
+
+    /** Telegram's hard cap on one poll option. */
+    private const MAX_OPTION_CHARS = 100;
+
+    private ?Api $telegram;
+
+    public function __construct(
+        private readonly QuizSettings $settings,
+        ?Api $telegram = null,
+    ) {
+        $this->telegram = $telegram;
+    }
+
+    /**
+     * Put tomorrow's topic to the group, in every configured chat. Returns the
+     * recorded ballot, or null when the vote was skipped or no chat took it —
+     * either way the day still gets a topic, just without asking.
+     */
+    public function open(CarbonInterface $date): ?QuizTopicPoll
+    {
+        if (! $this->settings->isConfigured()) {
+            return null;
+        }
+
+        if (QuizTopicPoll::forDate($date) !== null || DailyQuiz::forDate($date) !== null) {
+            return null;
+        }
+
+        $ballot = $this->ballotFor($date);
+
+        if ($ballot === null) {
+            return null;
+        }
+
+        $posts = $this->send($ballot);
+
+        if ($posts === []) {
+            return null;
+        }
+
+        return QuizTopicPoll::create([
+            'quiz_date' => $date,
+            'topic_ids' => $ballot->modelKeys(),
+            'posts' => $posts,
+        ]);
+    }
+
+    /**
+     * Close the day's ballot and report what won, or null when there was no
+     * ballot, nobody voted, or the winning topic is gone. Idempotent: a poll
+     * that was already tallied answers from its stored result, so regenerating
+     * a question never re-reads votes that are no longer being cast.
+     */
+    public function resolve(CarbonInterface $date): ?QuizTopic
+    {
+        $poll = QuizTopicPoll::forDate($date);
+
+        if ($poll === null) {
+            return null;
+        }
+
+        if ($poll->isClosed()) {
+            return $poll->topic?->is_active === true ? $poll->topic : null;
+        }
+
+        $winner = $this->tally($poll);
+
+        $poll->update([
+            'quiz_topic_id' => $winner?->id,
+            'closed_at' => now(),
+        ]);
+
+        return $winner;
+    }
+
+    /**
+     * The four topics to offer, in least-recently-used order so a tie is
+     * broken exactly the way the automatic pick would have — or null when the
+     * cycle no longer owes enough topics to fill a ballot honestly.
+     *
+     * @return Collection<int, QuizTopic>|null
+     */
+    private function ballotFor(CarbonInterface $date): ?Collection
+    {
+        $candidates = QuizTopic::cycleCandidates($date)
+            ->unique(fn (QuizTopic $topic): string => $this->optionText($topic))
+            ->values();
+
+        if ($candidates->count() < self::BALLOT_SIZE) {
+            return null;
+        }
+
+        $chosen = $candidates->random(self::BALLOT_SIZE)->modelKeys();
+
+        return $candidates
+            ->filter(fn (QuizTopic $topic): bool => in_array($topic->id, $chosen, true))
+            ->values();
+    }
+
+    /**
+     * Send the ballot to every configured chat, returning one delivery receipt
+     * per chat that took it. A chat that refuses is logged and skipped — the
+     * vote still counts wherever it landed.
+     *
+     * @param  Collection<int, QuizTopic>  $ballot
+     * @return array<int, array{chat_id: int, message_id: int, message_thread_id: int|null, telegram_poll_id: string|null}>
+     */
+    private function send(Collection $ballot): array
+    {
+        $params = [
+            'question' => self::QUESTION,
+            'options' => $ballot->map(fn (QuizTopic $topic): string => $this->optionText($topic))->all(),
+            'is_anonymous' => true,
+        ];
+
+        $posts = [];
+
+        foreach ($this->settings->targets() as $target) {
+            try {
+                $message = $this->telegram()->sendPoll($target->apply($params));
+
+                $posts[] = [
+                    'chat_id' => $message->getChat()->getId(),
+                    'message_id' => $message->getMessageId(),
+                    'message_thread_id' => $target->threadId,
+                    'telegram_poll_id' => $message->getPoll()?->getId(),
+                ];
+            } catch (Throwable $exception) {
+                Log::warning('Failed to post the topic vote to chat', [
+                    'chat_id' => $target->chatId,
+                    'message' => $exception->getMessage(),
+                ]);
+            }
+        }
+
+        return $posts;
+    }
+
+    /**
+     * Stop the ballot everywhere and add the votes up across chats — one vote
+     * is one vote wherever it was cast, the same way the leaderboard treats
+     * every group as one room. Null when nothing was cast or the winning
+     * option's topic has since been deleted or deactivated.
+     */
+    private function tally(QuizTopicPoll $poll): ?QuizTopic
+    {
+        $totals = array_fill(0, count($poll->topic_ids), 0);
+
+        foreach ($poll->posts as $post) {
+            foreach ($this->stop($post) as $index => $votes) {
+                if (array_key_exists($index, $totals)) {
+                    $totals[$index] += $votes;
+                }
+            }
+        }
+
+        if (max($totals) === 0) {
+            return null;
+        }
+
+        // array_search takes the first maximum, and the ballot is ordered
+        // least-recently-used first — so a tie goes to the topic that has
+        // waited longest, exactly as the automatic pick would have chosen.
+        $winner = $poll->ballot()->get((int) array_search(max($totals), $totals, true));
+
+        return $winner?->is_active === true ? $winner : null;
+    }
+
+    /**
+     * Close one chat's copy of the ballot and read its final counts, indexed by
+     * option. A poll Telegram already closed — or a message someone deleted —
+     * just makes the call throw; that chat's votes are lost rather than the
+     * whole tally.
+     *
+     * @param  array<string, mixed>  $post
+     * @return array<int, int>
+     */
+    private function stop(array $post): array
+    {
+        try {
+            $params = [
+                'chat_id' => $post['chat_id'],
+                'message_id' => $post['message_id'],
+            ];
+
+            $result = $this->telegram()->stopPoll($params);
+
+            return collect($result->getOptions() ?? [])
+                ->map(fn ($option): int => (int) $option->getVoterCount())
+                ->values()
+                ->all();
+        } catch (Throwable $exception) {
+            Log::warning('Failed to stop the topic vote poll', [
+                'chat_id' => $post['chat_id'] ?? null,
+                'message' => $exception->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+
+    private function optionText(QuizTopic $topic): string
+    {
+        return mb_substr(trim($topic->name), 0, self::MAX_OPTION_CHARS);
+    }
+
+    private function telegram(): Api
+    {
+        return $this->telegram ??= new Api((string) config('services.telegram.token'), false);
+    }
+}

--- a/database/factories/QuizTopicFactory.php
+++ b/database/factories/QuizTopicFactory.php
@@ -17,7 +17,17 @@ class QuizTopicFactory extends Factory
             'is_spotlight' => false,
             'is_active' => true,
             'last_used_at' => null,
+            'cycle_used_at' => null,
         ];
+    }
+
+    /** A topic the running rotation cycle has already covered. */
+    public function usedThisCycle(): static
+    {
+        return $this->state(fn (): array => [
+            'last_used_at' => now(),
+            'cycle_used_at' => now(),
+        ]);
     }
 
     public function spotlight(): static

--- a/database/factories/QuizTopicPollFactory.php
+++ b/database/factories/QuizTopicPollFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\QuizTopic;
+use App\Models\QuizTopicPoll;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<QuizTopicPoll>
+ */
+class QuizTopicPollFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'quiz_date' => today()->addDay(),
+            // A closure so a ballot handed explicit topics never also conjures
+            // four throwaway ones.
+            'topic_ids' => fn (): array => QuizTopic::factory()->count(4)->create()->modelKeys(),
+            'posts' => [[
+                'chat_id' => -100200300,
+                'message_id' => 4242,
+                'message_thread_id' => null,
+                'telegram_poll_id' => '9001',
+            ]],
+            'quiz_topic_id' => null,
+            'closed_at' => null,
+        ];
+    }
+
+    /** A ballot listing exactly these topics, in this order. */
+    public function forTopics(iterable $topics): static
+    {
+        return $this->state(fn (): array => [
+            'topic_ids' => collect($topics)->map(fn (QuizTopic $topic): int => $topic->id)->all(),
+        ]);
+    }
+
+    /** A ballot delivered to these chats, one poll message each. */
+    public function inChats(int ...$chatIds): static
+    {
+        return $this->state(fn (): array => [
+            'posts' => collect($chatIds)
+                ->values()
+                ->map(fn (int $chatId, int $index): array => [
+                    'chat_id' => $chatId,
+                    'message_id' => 4242 + $index,
+                    'message_thread_id' => null,
+                    'telegram_poll_id' => (string) (9001 + $index),
+                ])
+                ->all(),
+        ]);
+    }
+}

--- a/database/migrations/2026_08_19_130000_add_cycle_used_at_to_quiz_topics_table.php
+++ b/database/migrations/2026_08_19_130000_add_cycle_used_at_to_quiz_topics_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Marks a topic as already covered by the current rotation cycle. `last_used_at`
+ * alone cannot say that: it survives forever, while this is cleared for the
+ * whole pool the moment every topic in it has had a turn — which is what lets
+ * the group vote on tomorrow's topic without any topic being skipped.
+ *
+ * Left null for existing topics on purpose: the first cycle starts now.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('quiz_topics', function (Blueprint $table) {
+            $table->timestamp('cycle_used_at')->nullable()->after('last_used_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('quiz_topics', function (Blueprint $table) {
+            $table->dropColumn('cycle_used_at');
+        });
+    }
+};

--- a/database/migrations/2026_08_19_130001_create_quiz_topic_polls_table.php
+++ b/database/migrations/2026_08_19_130001_create_quiz_topic_polls_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * One "which topic should tomorrow's question be about?" vote — the ballot that
+ * goes out right under the day's question and is tallied when tomorrow's
+ * question is generated. One row per decided day.
+ *
+ * `posts` holds the delivery receipts (chat, message, poll id) rather than a
+ * child table: they are opaque handles used only to stop the polls again as a
+ * set, never queried on their own.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('quiz_topic_polls', function (Blueprint $table) {
+            $table->id();
+            $table->date('quiz_date')->unique();
+            $table->json('topic_ids');
+            $table->json('posts');
+            $table->foreignId('quiz_topic_id')->nullable()->constrained()->nullOnDelete();
+            $table->timestamp('closed_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('quiz_topic_polls');
+    }
+};

--- a/resources/js/components/manage/quiz/types.ts
+++ b/resources/js/components/manage/quiz/types.ts
@@ -47,6 +47,8 @@ export interface Topic {
     is_spotlight: boolean;
     is_active: boolean;
     last_used_at: string | null;
+    /** True while the running rotation cycle still owes this topic a turn — the pool the group's topic vote draws its ballot from. */
+    awaiting_turn: boolean;
 }
 
 /** Length caps, mirrored from the authoring constants server-side. */

--- a/resources/js/pages/manage/quiz/Index.vue
+++ b/resources/js/pages/manage/quiz/Index.vue
@@ -508,6 +508,13 @@ const chatIdsError = computed(() => {
                             <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
                                 <span class="font-medium" :class="topic.is_active ? '' : 'text-muted-foreground line-through'">{{ topic.name }}</span>
                                 <Badge v-if="topic.is_spotlight" variant="secondary">يوم التخصص</Badge>
+                                <Badge
+                                    v-if="topic.is_active && topic.awaiting_turn"
+                                    variant="outline"
+                                    title="لم يأخذ دوره في الدورة الحالية — وحده هذا النوع يظهر في تصويت المجموعة على موضوع الغد"
+                                >
+                                    بانتظار دوره
+                                </Badge>
                             </div>
                             <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
                                 <span v-if="topic.prompt_hint" class="max-w-md truncate">{{ topic.prompt_hint }}</span>

--- a/tests/Fakes/FakeTelegramApi.php
+++ b/tests/Fakes/FakeTelegramApi.php
@@ -56,6 +56,15 @@ class FakeTelegramApi extends Api
     /** Error setMessageReaction should always fail with, when set. */
     public ?string $reactionError = null;
 
+    /**
+     * Final per-option voter counts stopPoll() should report, keyed by the
+     * poll message id. A message id not listed here stops with no options at
+     * all, the way a poll nobody could vote in would.
+     *
+     * @var array<int, array<int, int>>
+     */
+    public array $pollResults = [];
+
     /** Chat-member status per telegram user id (default 'member'). */
     /** @var array<int|string, string> */
     public array $chatMemberStatuses = [];
@@ -103,7 +112,17 @@ class FakeTelegramApi extends Api
     {
         $this->stoppedPolls[] = $params;
 
-        return new \Telegram\Bot\Objects\Poll(['id' => (string) ($params['message_id'] ?? 0), 'is_closed' => true]);
+        $counts = $this->pollResults[(int) ($params['message_id'] ?? 0)] ?? [];
+
+        return new \Telegram\Bot\Objects\Poll([
+            'id' => (string) ($params['message_id'] ?? 0),
+            'is_closed' => true,
+            'options' => array_map(
+                static fn (int $index, int $votes): array => ['text' => (string) ($index + 1), 'voter_count' => $votes],
+                array_keys($counts),
+                array_values($counts),
+            ),
+        ]);
     }
 
     public function pinChatMessage(array $params): bool

--- a/tests/Feature/Quiz/QuizTopicVoteTest.php
+++ b/tests/Feature/Quiz/QuizTopicVoteTest.php
@@ -1,0 +1,369 @@
+<?php
+
+use App\Ai\Quiz\QuizAuthor;
+use App\Ai\Quiz\QuizAuthoringAgent;
+use App\Models\DailyQuiz;
+use App\Models\QuizTopic;
+use App\Models\QuizTopicPoll;
+use App\Services\Quiz\QuizImageRenderer;
+use App\Services\Quiz\QuizPoster;
+use App\Services\Quiz\QuizSchedule;
+use App\Services\Quiz\QuizTopicVote;
+use App\Settings\AiSettings;
+use App\Settings\QuizSettings;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Tests\Fakes\FakeTelegramApi;
+
+beforeEach(function () {
+    $this->travelTo(today()->setTimeFromTimeString(QuizSchedule::DEFAULT_POST_TIME));
+    Cache::flush();
+
+    config()->set('ai.providers.openrouter.key', 'test-key');
+
+    $ai = app(AiSettings::class);
+    $ai->ai_enabled = true;
+    $ai->daily_budget_usd = 5.0;
+    $ai->save();
+
+    $settings = app(QuizSettings::class);
+    $settings->enabled = true;
+    $settings->chat_ids = ['-100200300'];
+    $settings->save();
+
+    $this->app->instance(QuizImageRenderer::class, new class extends QuizImageRenderer
+    {
+        public function render(DailyQuiz $quiz): string
+        {
+            return 'fake-png-bytes';
+        }
+    });
+
+    $this->fake = new FakeTelegramApi;
+    $this->app->bind(QuizPoster::class, fn (): QuizPoster => new QuizPoster(app(QuizSettings::class), $this->fake));
+    // The tally runs at generation time, so the author's vote service needs the
+    // same fake the poster writes ballots with.
+    $this->app->bind(QuizTopicVote::class, fn (): QuizTopicVote => new QuizTopicVote(app(QuizSettings::class), $this->fake));
+});
+
+function topicVoteQuestion(): ToolCall
+{
+    return new ToolCall('call_1', 'submit_quiz_question', [
+        'question' => 'ما البوابة المنطقية التي تعكس قيمة المدخل؟',
+        'options' => ['AND', 'OR', 'NOT', 'XOR'],
+        'correct_option' => 2,
+        'explanation' => 'بوابة NOT تُخرج عكس قيمة المدخل دائماً.',
+    ]);
+}
+
+/** Every ballot the bot sent, as raw sendPoll parameters. */
+function sentBallots(FakeTelegramApi $fake): array
+{
+    return array_values(array_filter(
+        $fake->sentPolls,
+        static fn (array $params): bool => ($params['question'] ?? null) === QuizTopicVote::QUESTION,
+    ));
+}
+
+describe('opening the ballot', function () {
+    it('puts four of the cycle\'s remaining topics to a vote under the question', function () {
+        QuizTopic::factory()->count(6)->create();
+        DailyQuiz::factory()->create(['quiz_date' => today()]);
+
+        $this->artisan('quiz:post')->assertExitCode(0);
+
+        $ballots = sentBallots($this->fake);
+
+        expect($ballots)->toHaveCount(1)
+            ->and($ballots[0]['chat_id'])->toBe(-100200300)
+            ->and($ballots[0]['options'])->toHaveCount(4)
+            ->and($ballots[0]['is_anonymous'])->toBeTrue()
+            ->and($ballots[0])->not->toHaveKey('type');
+
+        $poll = QuizTopicPoll::forDate(today()->addDay());
+
+        expect($poll)->not->toBeNull()
+            ->and($poll->topic_ids)->toHaveCount(4)
+            ->and($poll->closed_at)->toBeNull()
+            ->and($poll->quiz_topic_id)->toBeNull()
+            ->and($poll->posts)->toHaveCount(1)
+            ->and($ballots[0]['options'])->toBe($poll->ballot()->pluck('name')->all());
+    });
+
+    it('sends the ballot only after the question itself', function () {
+        QuizTopic::factory()->count(6)->create();
+        DailyQuiz::factory()->create(['quiz_date' => today()]);
+
+        $this->artisan('quiz:post')->assertExitCode(0);
+
+        expect($this->fake->sentPolls)->toHaveCount(2)
+            ->and($this->fake->sentPolls[0]['question'])->toBe(QuizPoster::POLL_QUESTION)
+            ->and($this->fake->sentPolls[1]['question'])->toBe(QuizTopicVote::QUESTION);
+    });
+
+    it('offers only topics the running cycle still owes', function () {
+        QuizTopic::factory()->count(3)->usedThisCycle()->create();
+        $pending = QuizTopic::factory()->count(4)->create();
+
+        DailyQuiz::factory()->create(['quiz_date' => today()]);
+
+        $this->artisan('quiz:post')->assertExitCode(0);
+
+        expect(QuizTopicPoll::forDate(today()->addDay())->topic_ids)
+            ->toEqualCanonicalizing($pending->modelKeys());
+    });
+
+    it('skips the vote when the cycle owes fewer topics than a ballot holds', function (int $pending) {
+        QuizTopic::factory()->count(5)->usedThisCycle()->create();
+        QuizTopic::factory()->count($pending)->create();
+
+        DailyQuiz::factory()->create(['quiz_date' => today()]);
+
+        $this->artisan('quiz:post')->assertExitCode(0);
+
+        expect(sentBallots($this->fake))->toBeEmpty()
+            ->and(QuizTopicPoll::query()->count())->toBe(0);
+    })->with([
+        'one left' => [1],
+        'three left' => [3],
+    ]);
+
+    it('skips the vote when tomorrow\'s question is already written', function () {
+        QuizTopic::factory()->count(6)->create();
+
+        DailyQuiz::factory()->create(['quiz_date' => today()]);
+        DailyQuiz::factory()->create(['quiz_date' => today()->addDay()]);
+
+        $this->artisan('quiz:post')->assertExitCode(0);
+
+        expect(sentBallots($this->fake))->toBeEmpty()
+            ->and(QuizTopicPoll::query()->count())->toBe(0);
+    });
+
+    it('never opens a second ballot for the same day when the question is re-posted', function () {
+        QuizTopic::factory()->count(6)->create();
+        DailyQuiz::factory()->create(['quiz_date' => today()]);
+
+        $this->artisan('quiz:post')->assertExitCode(0);
+        $this->artisan('quiz:post', ['--force' => true])->assertExitCode(0);
+
+        expect(sentBallots($this->fake))->toHaveCount(1)
+            ->and(QuizTopicPoll::query()->count())->toBe(1);
+    });
+
+    it('offers spotlight topics when tomorrow is the spotlight day', function () {
+        $this->travelTo(today()->next(CarbonInterface::TUESDAY)->setTimeFromTimeString(QuizSchedule::DEFAULT_POST_TIME));
+
+        QuizTopic::factory()->count(5)->create();
+        $spotlight = QuizTopic::factory()->count(4)->spotlight()->create();
+
+        DailyQuiz::factory()->create(['quiz_date' => today()]);
+
+        $this->artisan('quiz:post')->assertExitCode(0);
+
+        expect(QuizTopicPoll::forDate(today()->addDay())->topic_ids)
+            ->toEqualCanonicalizing($spotlight->modelKeys());
+    });
+
+    it('sends the ballot into the same forum topic as the question', function () {
+        $settings = app(QuizSettings::class);
+        $settings->chat_ids = ['-100200300:42'];
+        $settings->save();
+
+        QuizTopic::factory()->count(6)->create();
+        DailyQuiz::factory()->create(['quiz_date' => today()]);
+
+        $this->artisan('quiz:post')->assertExitCode(0);
+
+        expect(sentBallots($this->fake)[0]['message_thread_id'])->toBe(42)
+            ->and(QuizTopicPoll::forDate(today()->addDay())->posts[0]['message_thread_id'])->toBe(42);
+    });
+
+    it('still counts the question as posted when the ballot cannot be sent', function () {
+        $flaky = new class extends FakeTelegramApi
+        {
+            public function sendPoll(array $params): \Telegram\Bot\Objects\Message
+            {
+                if (($params['question'] ?? null) === QuizTopicVote::QUESTION) {
+                    throw new RuntimeException('Forbidden: polls are restricted in this chat');
+                }
+
+                return parent::sendPoll($params);
+            }
+        };
+
+        $this->app->bind(QuizPoster::class, fn (): QuizPoster => new QuizPoster(app(QuizSettings::class), $flaky));
+
+        QuizTopic::factory()->count(6)->create();
+        $quiz = DailyQuiz::factory()->create(['quiz_date' => today()]);
+
+        $this->artisan('quiz:post')->assertExitCode(0);
+
+        expect($quiz->refresh()->status)->toBe(DailyQuiz::STATUS_POSTED)
+            ->and(QuizTopicPoll::query()->count())->toBe(0);
+    });
+});
+
+describe('tallying the ballot', function () {
+    it('generates the question from the topic the group voted for', function () {
+        $topics = QuizTopic::factory()->count(4)->create();
+        $poll = QuizTopicPoll::factory()->forTopics($topics)->create(['quiz_date' => today()]);
+
+        $this->fake->pollResults = [4242 => [1, 9, 2, 0]];
+
+        QuizAuthoringAgent::fake([topicVoteQuestion()]);
+
+        $this->artisan('quiz:generate')->assertExitCode(0);
+
+        $poll->refresh();
+
+        expect(DailyQuiz::forDate(today())->quiz_topic_id)->toBe($topics[1]->id)
+            ->and($poll->quiz_topic_id)->toBe($topics[1]->id)
+            ->and($poll->closed_at)->not->toBeNull()
+            ->and($this->fake->stoppedPolls)->toHaveCount(1)
+            ->and($topics[1]->refresh()->cycle_used_at)->not->toBeNull();
+    });
+
+    it('adds the votes up across every group the ballot reached', function () {
+        $topics = QuizTopic::factory()->count(4)->create();
+        QuizTopicPoll::factory()
+            ->forTopics($topics)
+            ->inChats(-100200300, -100400500)
+            ->create(['quiz_date' => today()]);
+
+        // Option 1 leads in the first group, but option 2 wins the room.
+        $this->fake->pollResults = [4242 => [4, 1, 0, 0], 4243 => [0, 5, 0, 0]];
+
+        QuizAuthoringAgent::fake([topicVoteQuestion()]);
+
+        $this->artisan('quiz:generate')->assertExitCode(0);
+
+        expect(DailyQuiz::forDate(today())->quiz_topic_id)->toBe($topics[1]->id)
+            ->and($this->fake->stoppedPolls)->toHaveCount(2);
+    });
+
+    it('gives a tie to the topic that has waited longest', function () {
+        $topics = QuizTopic::factory()->count(4)->create();
+        QuizTopicPoll::factory()->forTopics($topics)->create(['quiz_date' => today()]);
+
+        $this->fake->pollResults = [4242 => [5, 5, 0, 0]];
+
+        QuizAuthoringAgent::fake([topicVoteQuestion()]);
+
+        $this->artisan('quiz:generate')->assertExitCode(0);
+
+        expect(DailyQuiz::forDate(today())->quiz_topic_id)->toBe($topics[0]->id);
+    });
+
+    it('falls back to the automatic pick when nobody voted', function () {
+        $stale = QuizTopic::factory()->usedThisCycle()->create(['last_used_at' => now()->subDay()]);
+        $topics = QuizTopic::factory()->count(4)->create();
+
+        QuizTopicPoll::factory()->forTopics($topics)->create(['quiz_date' => today()]);
+
+        QuizAuthoringAgent::fake([topicVoteQuestion()]);
+
+        $this->artisan('quiz:generate')->assertExitCode(0);
+
+        $poll = QuizTopicPoll::forDate(today());
+
+        expect(DailyQuiz::forDate(today())->quiz_topic_id)->toBe($topics[0]->id)
+            ->and(DailyQuiz::forDate(today())->quiz_topic_id)->not->toBe($stale->id)
+            ->and($poll->closed_at)->not->toBeNull()
+            ->and($poll->quiz_topic_id)->toBeNull();
+    });
+
+    it('falls back to the automatic pick when the winning topic was deactivated', function () {
+        $topics = QuizTopic::factory()->count(4)->create();
+        QuizTopicPoll::factory()->forTopics($topics)->create(['quiz_date' => today()]);
+
+        $topics[1]->update(['is_active' => false]);
+        $this->fake->pollResults = [4242 => [0, 9, 0, 0]];
+
+        QuizAuthoringAgent::fake([topicVoteQuestion()]);
+
+        $this->artisan('quiz:generate')->assertExitCode(0);
+
+        expect(DailyQuiz::forDate(today())->quiz_topic_id)->toBe($topics[0]->id);
+    });
+
+    it('reuses a settled result instead of re-reading a closed ballot', function () {
+        $topics = QuizTopic::factory()->count(4)->create();
+        QuizTopicPoll::factory()->forTopics($topics)->create([
+            'quiz_date' => today(),
+            'quiz_topic_id' => $topics[2]->id,
+            'closed_at' => now()->subHour(),
+        ]);
+
+        QuizAuthoringAgent::fake([topicVoteQuestion()]);
+
+        $this->artisan('quiz:generate')->assertExitCode(0);
+
+        expect(DailyQuiz::forDate(today())->quiz_topic_id)->toBe($topics[2]->id)
+            ->and($this->fake->stoppedPolls)->toBeEmpty();
+    });
+
+    it('settles a still-open ballot when the day\'s question goes out unasked', function () {
+        $topics = QuizTopic::factory()->count(4)->create();
+        QuizTopicPoll::factory()->forTopics($topics)->create(['quiz_date' => today()]);
+
+        // Written by hand in the panel, so generation never tallied anything.
+        DailyQuiz::factory()->create(['quiz_date' => today()]);
+
+        $this->artisan('quiz:post')->assertExitCode(0);
+
+        expect(QuizTopicPoll::forDate(today())->closed_at)->not->toBeNull()
+            ->and(collect($this->fake->stoppedPolls)->pluck('message_id')->all())->toContain(4242);
+    });
+
+    it('closes the ballot even when an admin names the topic themselves', function () {
+        $topics = QuizTopic::factory()->count(4)->create();
+        $chosen = QuizTopic::factory()->create(['name' => 'موضوع مختار']);
+
+        QuizTopicPoll::factory()->forTopics($topics)->create(['quiz_date' => today()]);
+
+        $this->fake->pollResults = [4242 => [0, 9, 0, 0]];
+
+        QuizAuthoringAgent::fake([topicVoteQuestion()]);
+
+        $quiz = app(QuizAuthor::class)->generateForDate(today(), $chosen);
+
+        expect($quiz->quiz_topic_id)->toBe($chosen->id)
+            ->and(QuizTopicPoll::forDate(today())->closed_at)->not->toBeNull();
+    });
+});
+
+describe('the rotation cycle', function () {
+    it('covers every topic before any topic repeats', function () {
+        $topics = QuizTopic::factory()->count(5)->create();
+
+        $picked = collect(range(1, 5))->map(function (): int {
+            $topic = QuizTopic::pickForDate(today());
+            $topic->markUsed();
+
+            return $topic->id;
+        });
+
+        expect($picked->unique())->toHaveCount(5)
+            ->and($picked->sort()->values()->all())->toBe($topics->modelKeys());
+    });
+
+    it('starts a fresh cycle once the pool is spent', function () {
+        QuizTopic::factory()->count(3)->usedThisCycle()->create();
+
+        expect(QuizTopic::pickForDate(today()))->not->toBeNull()
+            ->and(QuizTopic::query()->whereNotNull('cycle_used_at')->count())->toBe(0);
+    });
+
+    it('keeps the two pools on their own cycles', function () {
+        QuizTopic::factory()->count(2)->usedThisCycle()->create();
+        $spotlight = QuizTopic::factory()->count(2)->spotlight()->create();
+
+        $wednesday = today()->next(CarbonInterface::WEDNESDAY);
+
+        expect(QuizTopic::cycleCandidates($wednesday)->modelKeys())->toEqualCanonicalizing($spotlight->modelKeys())
+            // The spent regular pool is untouched until a regular day asks for it.
+            ->and(QuizTopic::query()->whereNotNull('cycle_used_at')->count())->toBe(2);
+    });
+});


### PR DESCRIPTION
## What

The daily question now carries a second poll under it: four topics for tomorrow, for the group to choose between.

The choice is real but bounded. The ballot only ever lists topics the running rotation cycle has not covered yet, so a vote reorders the cycle and can never leave a topic unasked.

## How it works

**Posting time** — right after the question's quiz poll, `QuizPoster` sends a plain anonymous poll of 4 candidate topics for tomorrow.

**Generation time** (05:00 next day, or the inline fallback at posting time) — `QuizAuthor` stops those polls, sums the votes across every configured group, and generates from the winner. `stopPoll` returns the final counts synchronously, so no new webhook update handling was needed.

## The rotation guarantee

New `quiz_topics.cycle_used_at`. A topic is stamped when it supplies a question; the marks are cleared for the whole pool only once **every** topic in it has had a turn (`QuizTopic::cycleCandidates()`). Both the vote and the automatic least-recently-used pick draw from that one pool, so they cannot disagree. Spotlight topics keep their own cycle, and a Wednesday ballot offers spotlight topics.

## When the vote is skipped

Silently, with the automatic pick taking over:

- **Fewer than 4 topics left in the cycle.** Filling the last slots would mean offering an already-covered topic while uncovered ones go unasked. The threshold equals the ballot size and lives in `QuizTopicVote::BALLOT_SIZE`.
- **The day already has a question** — generated ahead of time or written by hand.
- **A ballot for that day already went out** — so a `--force` re-post doesn't double-ask.

Ties go to the topic that has waited longest, which is the same answer the automatic pick would give. Zero votes, or a winner an admin deactivated meanwhile, falls back to the automatic pick. A ballot that fails to send is logged and never fails the question post.

## Worth a reviewer's attention

- **Posting settles the outgoing ballot too**, not just generation. A question written by hand in the panel never asks the vote anything, and its ballot would otherwise stay open in the group forever.
- **`quiz_topic_polls.posts` is a JSON column, not a child table.** Unlike `quiz_posts` (which backs relational vote lookups and reminder replies), these are opaque delivery receipts read only as a set, to stop the polls again.
- **`QuizTopicPoll::ballot()` keeps deleted topics as nulls in their slot** rather than dropping them — filtering would shift every later option onto the wrong topic.
- **Existing topics start with a null cycle mark**, i.e. the first cycle begins at deploy. No backfill.
- The panel and `list_quiz_topics` now show which topics the cycle still owes, so the rule deciding ballot eligibility isn't invisible to admins.

## Testing

`tests/Feature/Quiz/QuizTopicVoteTest.php` — 21 tests over opening the ballot, tallying it (cross-group sums, ties, no votes, deactivated winner, idempotent re-reads), and the cycle itself.

Gates: `php artisan test` (1197 pass), `npm test`, `vue-tsc`, `npm run build:ssr` all clean. The two `PublicRoutesTest` failures in a full run are pre-existing on `main` — confirmed against a stashed tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)