### PR TITLE
fix(deploy): give Chromium a fontconfig config so screenshots render text

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -51,6 +51,23 @@ cmds = [
 cmd = "/assets/start.sh"
 
 [staticAssets]
+# Fontconfig has no config of its own in this image: the Nix `fontconfig` package
+# ships the library, not /etc/fonts/fonts.conf. Without a config Chromium cannot
+# initialise its text stack at all — it shapes every run to zero glyphs and every
+# screenshot comes out with the layout drawn and no text in it, webfonts included
+# (`TextRunHarfBuzz error … font: '', glyph_count: 0`). FONTCONFIG_FILE below
+# points at this file.
+"fonts.conf" = '''
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <dir>/root/.nix-profile/share/fonts</dir>
+  <dir>/nix/var/nix/profiles/default/share/fonts</dir>
+  <dir>/app/resources/fonts</dir>
+  <cachedir>/tmp/.cache/fontconfig</cachedir>
+</fontconfig>
+'''
+
 "start.sh" = '''
 #!/bin/bash
 set -e
@@ -63,6 +80,12 @@ export PUPPETEER_EXECUTABLE_PATH=$(readlink -f "$(which chromium)")
 export CHROME_PATH=$(readlink -f "$(which chromium)")
 export NODE_BINARY=$(readlink -f "$(which node)")
 export NODE_PATH=$(npm root -g)
+
+# --- Fontconfig: without this Chromium renders every screenshot text-less
+export FONTCONFIG_FILE=/assets/fonts.conf
+mkdir -p /tmp/.cache/fontconfig
+chmod -R 777 /tmp/.cache/fontconfig
+fc-cache -f || true
 
 # --- ensure Laravel writable paths (volume may be empty on first boot)
 mkdir -p /app/storage/framework/{cache,sessions,views} \
@@ -226,7 +249,7 @@ stderr_logfile=/var/log/worker-telegram-bot.log
 stdout_logfile_maxbytes=10MB
 stderr_logfile_maxbytes=10MB
 stopwaitsecs=3600
-environment=PUPPETEER_SKIP_DOWNLOAD="true",NODE_PATH="%(ENV_NODE_PATH)s",CHROME_PATH="%(ENV_CHROME_PATH)s"
+environment=PUPPETEER_SKIP_DOWNLOAD="true",NODE_PATH="%(ENV_NODE_PATH)s",CHROME_PATH="%(ENV_CHROME_PATH)s",FONTCONFIG_FILE="%(ENV_FONTCONFIG_FILE)s"
 '''
 
 "php-fpm.conf" = '''
@@ -264,6 +287,8 @@ env[PUPPETEER_SKIP_DOWNLOAD] = true
 env[NODE_PATH] = $NODE_PATH
 env[CHROME_PATH] = $CHROME_PATH
 env[NODE_BINARY] = $NODE_BINARY
+; Chromium renders text-less screenshots without a fontconfig config
+env[FONTCONFIG_FILE] = $FONTCONFIG_FILE
 ; Chromium needs these directories to be writable
 env[HOME] = /tmp
 env[XDG_CONFIG_HOME] = /tmp/.config


### PR DESCRIPTION
## The bug

The image installs the `fontconfig` package, but the Nix package ships the library only — it never creates `/etc/fonts/fonts.conf`, and nothing pointed `FONTCONFIG_FILE` anywhere. With no config, fontconfig fails to initialise and Chromium's text stack goes with it: every run shapes to zero glyphs, so a screenshot comes back with the full layout drawn and **no text in it at all**.

Webfonts don't save it — the woff2 files download `200 OK` and still render nothing:

```
TextRunHarfBuzz error … range: {5,9}, rtl: 0, script: -1, font: '', glyph_count: 0
```

`fc-list` in the container confirms it: `Fontconfig error: Cannot load default config file`.

## Blast radius

This silently broke **every** Browsershot capture, not just the new quiz card:

- The daily-quiz image card renders blank.
- **OG images too.** `/_og-image` only still looks correct because `OgImageService` caches to `storage/app/public/screenshots`, so the served files predate the breakage. A forced uncached render comes back text-less.

## The fix

- A `fonts.conf` static asset pointing fontconfig at the Nix profile font dirs and `resources/fonts`, with a writable cachedir under `/tmp`.
- `export FONTCONFIG_FILE=/assets/fonts.conf` in `start.sh`, before `exec supervisord`, so every supervisor child inherits it.
- Declared in the `php-fpm.conf` and telegram-bot supervisor environments alongside the existing `CHROME_PATH` / `NODE_PATH` vars.

No application code changes — the quiz renderer was correct all along.

## Verification

In the prod container, with `FONTCONFIG_FILE` set and the **unmodified, committed** `QuizImageRenderer`, the card renders correctly (Arabic, Latin and code) in 2.1s. Test post delivered to a DM; quiz status left `ready` with 0 `QuizPost` rows.

## After merge

The cached blank OG images should be cleared so they regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)