### PR TITLE
Kit 0.7.3 + resumable turns: TurnBuffer on both chat surfaces

### DIFF
--- a/app/Http/Controllers/Ai/ChatController.php
+++ b/app/Http/Controllers/Ai/ChatController.php
@@ -2,22 +2,21 @@
 
 namespace App\Http\Controllers\Ai;
 
-use App\Ai\Agents\StudentAssistant;
 use App\Ai\Chat\AnswerLinkGuard;
 use App\Ai\Chat\AttachmentContext;
 use App\Ai\Chat\CategoryContext;
 use App\Ai\Chat\CitationExtractor;
 use App\Ai\Chat\SessionOwner;
-use App\Ai\Chat\StreamingAnswerLinkGuard;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Ai\ChatMessageRequest;
+use App\Jobs\Ai\GenerateChatReply;
 use App\Models\Ai\ChatAttachment;
 use App\Settings\AiSettings;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
 use Laravel\Ai\Models\ConversationMessage;
 use Saad\AiKit\Conversations\ConversationContent;
 use Saad\AiKit\Conversations\ConversationOwnership;
@@ -26,21 +25,32 @@ use Saad\AiKit\Safety\Exceptions\AiUnavailableException;
 use Saad\AiKit\Safety\KillSwitch;
 use Saad\AiKit\Safety\TurnGuard;
 use Saad\AiKit\Streaming\SseStream;
-use Saad\AiKit\Streaming\StreamEventMapper;
-use Saad\AiKit\Streaming\StreamResult;
+use Saad\AiKit\Streaming\TurnBuffer;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Throwable;
 
 /**
  * The anonymous student-assistant chat API. Visitors have no accounts, so a
  * conversation belongs to the SESSION that started it (SessionOwner wraps the
  * session id as the laravel/ai conversation participant).
  *
- * POST /ai/chat answers as a Server-Sent-Events stream — TRUE streaming: the
- * LLM call runs inside the request and each model text delta is flushed as a
- * `delta` event, followed by `citations` (pages the turn's content tools
- * consulted), then `done`, or `error`. Pre-flight failures (feature toggle,
- * budget, daily quota) answer as plain JSON before any stream starts.
+ * ── Resumable turns ── The reply no longer generates inside the request.
+ * POST /ai/chat opens a durable {@see TurnBuffer} turn, queues
+ * {@see GenerateChatReply} to fold the model stream into it, and then TAILS
+ * that buffer as Server-Sent Events. What the client reads is unchanged —
+ * `turn`, then `reasoning` / `delta` / `tool` / `citations` and one terminal
+ * `done` or `error` — but every frame now carries an `id:` line (its buffer
+ * sequence number), and the reply keeps generating whether or not anyone is
+ * listening. So a visitor who loses signal, backgrounds the tab or reloads
+ * reconnects to {@see stream()} with `?cursor=<last seq>` and picks the SAME
+ * turn up where it stopped, instead of losing a half-written answer.
+ *
+ * The leading `turn {id}` frame is what makes that possible: it is the handle
+ * the client stores and re-issues. It replays on a resume too (it is buffer
+ * seq 1), which the client treats as the no-op it is.
+ *
+ * Because generation is decoupled from the socket, hanging up no longer stops
+ * it — so the visitor's stop button flags the turn through {@see cancel()},
+ * and the job finishes early with whatever it had.
  *
  * ai-kit v0.5.0's `reasoning` and `tool` events are on by default here too,
  * deliberately: the page renders them as a collapsible thinking block and as
@@ -52,22 +62,27 @@ use Throwable;
  * Layered gates, in order: ai-kit's TurnGuard (503) — the assistant toggle
  * via the operator's AiSettings, the kit's cache kill switch, and the daily
  * spend budget in one call — → the `ai-chat` burst limiter on the route
- * (429) → the operator's per-session daily message quota (429).
+ * (429) → the operator's per-session daily message quota (429). The queued
+ * job re-checks the kill switch on its way out of the queue, which is where
+ * the money is actually spent.
  */
 class ChatController extends Controller
 {
     /** Usage feature label for assistant chat turns (ai-kit usage module). */
-    private const FEATURE = 'assistant';
+    private const FEATURE = GenerateChatReply::FEATURE;
 
     /**
-     * POST /ai/chat (name: ai.chat.send) — run one assistant turn as SSE.
+     * POST /ai/chat (name: ai.chat.send) — open one assistant turn and stream
+     * it. Pre-flight failures (feature toggle, budget, daily quota) answer as
+     * plain JSON before any turn is opened, so a refused visitor is never
+     * charged a turn id.
      */
     public function send(
         ChatMessageRequest $request,
         AiSettings $settings,
         TurnGuard $guard,
         ConversationOwnership $ownership,
-        CitationExtractor $citations,
+        TurnBuffer $buffer,
         AttachmentContext $attachmentContext,
         CategoryContext $categoryContext,
     ): JsonResponse|StreamedResponse {
@@ -92,11 +107,61 @@ class ChatController extends Controller
 
         $prompt = $categoryContext->wrap($attachmentContext->wrap($question, $attachments), $question);
 
-        return response()->stream(
-            fn () => $this->streamTurn($prompt, $sessionId, $conversationId, $attachments, $citations),
-            200,
-            SseStream::headers(),
+        $turnId = (string) Str::uuid7();
+
+        // `session_id` is what {@see stream()} and {@see cancel()} read back to
+        // refuse a foreign turn; the conversation id is recorded for whatever
+        // reads the turn back, while the one the reply actually resolves rides
+        // the terminal `done`.
+        $buffer->start($turnId, [
+            'session_id' => $sessionId,
+            'conversation_id' => $conversationId,
+        ]);
+
+        // The handle the client stores so it can resume this turn. Appended
+        // BEFORE the job is dispatched, so it is seq 1 and no worker can be
+        // appending concurrently — the buffer's single-writer rule holds.
+        $buffer->append($turnId, 'turn', ['id' => $turnId]);
+
+        GenerateChatReply::dispatch(
+            turnId: $turnId,
+            sessionId: $sessionId,
+            prompt: $prompt,
+            conversationId: $conversationId,
+            attachmentIds: array_map('strval', $attachments->modelKeys()),
         );
+
+        return $this->tail($buffer, $turnId);
+    }
+
+    /**
+     * GET /ai/chat/turns/{turn}/stream (name: ai.chat.stream) — resume a turn
+     * from `?cursor=<last seq>` (or `Last-Event-ID`). Replaying costs nothing
+     * and spends nothing, so only ownership gates it; an unknown or expired
+     * turn is a 404 so the client stops retrying rather than looping.
+     */
+    public function stream(Request $request, TurnBuffer $buffer, string $turn): StreamedResponse
+    {
+        $this->ownedTurn($buffer, $turn, $request->session()->getId());
+
+        $after = max(0, (int) $request->query('cursor', $request->header('Last-Event-ID', '0')));
+
+        return $this->tail($buffer, $turn, $after);
+    }
+
+    /**
+     * POST /ai/chat/turns/{turn}/cancel (name: ai.chat.cancel) — the visitor
+     * pressed stop. Generation runs in a queued job now, so hanging up the SSE
+     * connection no longer ends it: flag the turn instead and the job finishes
+     * early with whatever it had streamed.
+     */
+    public function cancel(Request $request, TurnBuffer $buffer, string $turn): JsonResponse
+    {
+        $this->ownedTurn($buffer, $turn, $request->session()->getId());
+
+        $buffer->cancel($turn);
+
+        return response()->json(['cancelled' => true]);
     }
 
     /**
@@ -146,68 +211,43 @@ class ChatController extends Controller
     }
 
     /**
-     * Run the turn against the model and emit the SSE events, folded through
-     * ai-kit's StreamEventMapper (the link guard rides the text pipeline,
-     * citations ride beforeDone). Runs inside the streamed response, so every
-     * outcome — including a thrown provider error — must land as an event
-     * the client understands.
-     *
-     * @param  EloquentCollection<int, ChatAttachment>  $attachments
+     * Tail one turn's durable buffer as SSE — the ONE streaming response this
+     * controller produces, whether the turn was just opened by {@see send()}
+     * or is being resumed by {@see stream()}. The frame writing, the poll
+     * loop, the deadline and the keepalive comments are all the kit's,
+     * configured under `ai-kit.streaming`; nothing app-specific is folded in
+     * at emit time, because the terminal `done` already carries the
+     * conversation id the client needs.
      */
-    private function streamTurn(
-        string $prompt,
-        string $sessionId,
-        ?string $conversationId,
-        EloquentCollection $attachments,
-        CitationExtractor $citations,
-    ): void {
-        $sse = new SseStream;
-        $sse->extendTimeLimit((int) config('ai.chat.timeout', 60) + 30);
+    private function tail(TurnBuffer $buffer, string $turnId, int $after = 0): StreamedResponse
+    {
+        return response()->stream(function () use ($buffer, $turnId, $after): void {
+            $sse = app(SseStream::class);
 
-        // ai-kit's usage module records the turn (exact provider cost,
-        // tokens, timings) automatically; the label is all it needs.
-        Context::add(config('ai-kit.usage.feature_context_key'), self::FEATURE);
+            // The tail outlives a single model call: it holds the connection
+            // until the turn drains or the kit's own ceiling closes it (the
+            // client then reconnects with its last id).
+            $sse->extendTimeLimit((int) config('ai-kit.streaming.max_stream_seconds', 180) + 30);
 
-        $owner = new SessionOwner($sessionId);
+            $buffer->tail($turnId, $after, $sse);
+        }, 200, SseStream::headers());
+    }
 
-        $agent = StudentAssistant::make();
-        $agent = $conversationId !== null
-            ? $agent->continue($conversationId, $owner)
-            : $agent->forUser($owner);
+    /**
+     * The turn record, or a 404 — for an unknown or expired turn, and equally
+     * for one belonging to another session. Both are 404 rather than 403: a
+     * visitor has no business learning that someone else's turn id exists.
+     *
+     * @return array<string, mixed>
+     */
+    private function ownedTurn(TurnBuffer $buffer, string $turnId, string $sessionId): array
+    {
+        $record = $buffer->get($turnId);
 
-        try {
-            $response = $agent->stream($prompt);
+        abort_if($record === null, 404);
+        abort_unless(($record['meta']['session_id'] ?? null) === $sessionId, 404);
 
-            (new StreamEventMapper)
-                ->transformText(new StreamingAnswerLinkGuard(app(AnswerLinkGuard::class)))
-                ->onError(fn (): string => $this->genericErrorMessage())
-                ->beforeDone(function (StreamResult $result, callable $emit) use ($citations): void {
-                    $items = $citations->extract($result->toolResults);
-
-                    if ($items !== []) {
-                        $emit('citations', ['items' => $items]);
-                    }
-                })
-                ->doneUsing(function () use ($response, $conversationId, $attachments): array {
-                    $finalConversationId = $response->conversationId ?? $conversationId;
-
-                    if ($finalConversationId !== null && $attachments->isNotEmpty()) {
-                        ChatAttachment::query()
-                            ->whereKey($attachments->modelKeys())
-                            ->update(['conversation_id' => $finalConversationId]);
-                    }
-
-                    return [
-                        'conversation_id' => $finalConversationId,
-                        'message_id' => $this->latestAssistantMessageId($finalConversationId),
-                    ];
-                })
-                ->run($response, fn (string $event, array $data) => $sse->emit($event, $data));
-        } catch (Throwable $exception) {
-            report($exception);
-
-            $sse->emit('error', ['message' => $this->genericErrorMessage()]);
-        }
+        return $record;
     }
 
     /**
@@ -267,26 +307,8 @@ class ChatController extends Controller
             ->get();
     }
 
-    private function latestAssistantMessageId(?string $conversationId): ?string
-    {
-        if ($conversationId === null) {
-            return null;
-        }
-
-        return ConversationMessage::query()
-            ->where('conversation_id', $conversationId)
-            ->where('role', 'assistant')
-            ->orderByDesc('id')
-            ->value('id');
-    }
-
     private function disabledResponse(): JsonResponse
     {
         return response()->json(['message' => 'المساعد الذكي غير متاح حالياً.'], 503);
-    }
-
-    private function genericErrorMessage(): string
-    {
-        return 'حدث خطأ أثناء توليد الرد. حاول مرة أخرى.';
     }
 }

--- a/app/Http/Controllers/Manage/AdminAssistantController.php
+++ b/app/Http/Controllers/Manage/AdminAssistantController.php
@@ -2,21 +2,21 @@
 
 namespace App\Http\Controllers\Manage;
 
-use App\Ai\Admin\AdminAssistant;
 use App\Ai\Admin\AdminOwner;
 use App\Ai\Admin\AssistantCards;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Manage\AdminAssistantDecisionRequest;
 use App\Http\Requests\Manage\AdminAssistantMessageRequest;
+use App\Jobs\Ai\GenerateAdminAssistantReply;
 use App\Models\User;
 use App\Settings\AiSettings;
+use Closure;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
 use InvalidArgumentException;
-use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Models\ConversationMessage;
 use Saad\AiKit\Approvals\Classified\ResumeDecisions;
 use Saad\AiKit\Conversations\ConversationContent;
@@ -26,19 +26,33 @@ use Saad\AiKit\Safety\Exceptions\AiUnavailableException;
 use Saad\AiKit\Safety\KillSwitch;
 use Saad\AiKit\Safety\TurnGuard;
 use Saad\AiKit\Streaming\SseStream;
-use Saad\AiKit\Streaming\StreamEventMapper;
+use Saad\AiKit\Streaming\TurnBuffer;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Throwable;
 
 /**
  * The /manage admin assistant chat API — the operator copilot whose writes
  * pause the turn on ai-kit's classified approval seam. The transport mirrors
  * the public {@see \App\Http\Controllers\Ai\ChatController} SSE contract
- * (reasoning/delta/tool/done/error) plus an `approval` or `question` event
- * per card whenever the turn paused, so the client renders تأكيد/رفض cards
- * inline. Decisions resume the SAME turn through {@see decide()} and the
- * continuation streams back over the identical SSE contract. Conversations
- * belong to the authenticated admin (AdminOwner, "admin:{id}").
+ * (turn/reasoning/delta/tool/done/error) plus an `approval` or `question`
+ * event per card whenever the turn paused, so the client renders تأكيد/رفض
+ * cards inline. Conversations belong to the authenticated admin (AdminOwner,
+ * "admin:{id}").
+ *
+ * ── Resumable turns ── Neither {@see send()} nor {@see decide()} generates
+ * inside the request any more: each opens a durable {@see TurnBuffer} turn,
+ * queues {@see GenerateAdminAssistantReply} to fold the model stream into it,
+ * and then TAILS that buffer. Both still answer as SSE over the same event
+ * contract, so the panel's transport is unchanged — but every frame now
+ * carries an `id:` line, a leading `turn {id}` frame hands the client the
+ * handle, and an operator whose connection drops mid-write reconnects to
+ * {@see stream()} with `?cursor=<last seq>` instead of losing the turn.
+ *
+ * A resume mints a NEW turn (the paused one finished when it paused), which
+ * is invisible to the client: it reads the same stream off the same POST.
+ * {@see decide()} stays keyed by CONVERSATION rather than by turn — the
+ * server's pause markers live on the conversation, so nothing about resuming
+ * has to look up a turn record, and the endpoint's URL, payload and status
+ * codes are exactly what the panel already speaks.
  *
  * `reasoning` and `tool` are ai-kit v0.5.0 defaults and are deliberately
  * left on: the panel shows thinking as a collapsible block and tool progress
@@ -50,12 +64,14 @@ use Throwable;
  * Layered gates on every endpoint: panel auth (route middleware) → ai-kit's
  * kill switch, which folds master ai_enabled AND admin_assistant_enabled
  * (503 with the reason) with the kit's cache switch → daily spend budget on
- * turn entry (503, via TurnGuard) → the route's per-admin burst limiter (429).
+ * turn entry (503, via TurnGuard) → the route's per-admin burst limiter
+ * (429). The queued job re-checks the kill switch on its way out of the
+ * queue, which is where the money — and the writes — actually land.
  */
 class AdminAssistantController extends Controller
 {
     /** Usage feature label for admin assistant turns (ai-kit usage module). */
-    private const FEATURE = 'admin_assistant';
+    private const FEATURE = GenerateAdminAssistantReply::FEATURE;
 
     /**
      * GET /manage/assistant (name: manage.assistant.index) — the chat page.
@@ -81,6 +97,7 @@ class AdminAssistantController extends Controller
         AiSettings $settings,
         TurnGuard $guard,
         ConversationOwnership $ownership,
+        TurnBuffer $buffer,
     ): JsonResponse|StreamedResponse {
         try {
             $guard->check(self::FEATURE);
@@ -95,13 +112,46 @@ class AdminAssistantController extends Controller
 
         $owner = new AdminOwner($admin);
         $conversationId = $this->ownedConversationId($request->input('conversation_id'), $owner, $ownership);
-        $prompt = $request->validated('message');
 
-        return response()->stream(
-            fn () => $this->streamTurn($prompt, $owner, $conversationId),
-            200,
-            SseStream::headers(),
-        );
+        return $this->startTurn($buffer, $admin, $conversationId, prompt: (string) $request->validated('message'));
+    }
+
+    /**
+     * GET /manage/assistant/turns/{turn}/stream (name: manage.assistant.stream)
+     * — resume a turn from `?cursor=<last seq>` (or `Last-Event-ID`). Replaying
+     * a buffer spends nothing, so only ownership gates it; an unknown or
+     * expired turn is a 404 so the client stops retrying.
+     */
+    public function stream(Request $request, TurnBuffer $buffer, string $turn): StreamedResponse
+    {
+        /** @var User $admin */
+        $admin = $request->user();
+
+        $this->ownedTurn($buffer, $turn, (int) $admin->id);
+
+        $after = max(0, (int) $request->query('cursor', $request->header('Last-Event-ID', '0')));
+
+        return $this->tail($buffer, $turn, $after);
+    }
+
+    /**
+     * POST /manage/assistant/turns/{turn}/cancel (name:
+     * manage.assistant.cancel) — the admin pressed stop. Generation runs in a
+     * queued job now, so hanging up the SSE connection no longer ends it: flag
+     * the turn and the job finishes early with whatever it had. A stop that
+     * lands after a write already paused leaves that pause standing —
+     * {@see decide()} re-checks the server's pending set regardless.
+     */
+    public function cancel(Request $request, TurnBuffer $buffer, string $turn): JsonResponse
+    {
+        /** @var User $admin */
+        $admin = $request->user();
+
+        $this->ownedTurn($buffer, $turn, (int) $admin->id);
+
+        $buffer->cancel($turn);
+
+        return response()->json(['cancelled' => true]);
     }
 
     /**
@@ -119,6 +169,7 @@ class AdminAssistantController extends Controller
         TurnGuard $guard,
         ConversationOwnership $ownership,
         AssistantCards $cards,
+        TurnBuffer $buffer,
         string $conversation,
     ): JsonResponse|StreamedResponse {
         try {
@@ -158,11 +209,16 @@ class AdminAssistantController extends Controller
         }
 
         try {
-            // The guard is passed here rather than applied afterwards because
-            // this is the only path from client input to Decisions: an edit's
-            // readonly fields are restored from the pause before a
-            // Decision::edit exists at all.
-            $decisions = ResumeDecisions::fromClient($input, $cards->editGuard($pending));
+            // The guard runs HERE, where the server's own copy of the pending
+            // call is in hand: an edit's readonly and hidden fields are
+            // restored from the pause before the decision is serialized into a
+            // job, so what the queue carries is never the raw browser payload.
+            $guarded = $this->guardDecisions($input, $cards->editGuard($pending));
+
+            // Round-trips the guarded payload through the kit's own parser,
+            // which is what rejects an unknown action shape — the same call the
+            // job makes, so nothing reaches the queue the resume cannot read.
+            ResumeDecisions::fromClient($guarded);
         } catch (InvalidArgumentException) {
             // Covers both a malformed decision shape and an edit that invents
             // an argument the card never carried; a tampered readonly field
@@ -170,11 +226,37 @@ class AdminAssistantController extends Controller
             return response()->json(['message' => 'صيغة القرارات غير صالحة أو لا تطابق حقول البطاقة.'], 422);
         }
 
-        return response()->stream(
-            fn () => $this->streamTurn($decisions, $owner, $conversation),
-            200,
-            SseStream::headers(),
-        );
+        // A resume is a NEW turn — the paused one finished when it paused — but
+        // that is invisible to the client, which reads the continuation off
+        // this same response exactly as it always has.
+        return $this->startTurn($buffer, $admin, $conversation, decisions: $guarded);
+    }
+
+    /**
+     * Reconcile every EDIT decision against the server's pending call before it
+     * travels any further. Approvals and rejections pass through untouched —
+     * they carry no arguments to tamper with.
+     *
+     * TODO(kit 0.7.3): replace with `ResumeDecisions::guarded($input, $guard)`.
+     * The kit's `fromClient()` takes the guard but returns a `Decisions`
+     * object, and a queued resume needs the guarded ARRAY (a Decisions cannot
+     * ride a job payload), so the round-trip is spelled out here for now.
+     *
+     * @param  array<string, mixed>  $input
+     * @param  Closure(string, array<string, mixed>): array<string, mixed>  $guard
+     * @return array<string, mixed>
+     */
+    private function guardDecisions(array $input, Closure $guard): array
+    {
+        $guarded = [];
+
+        foreach ($input as $id => $decision) {
+            $guarded[(string) $id] = is_array($decision) && ($decision['action'] ?? null) === 'edit'
+                ? ['action' => 'edit', 'arguments' => $guard((string) $id, (array) ($decision['arguments'] ?? []))]
+                : $decision;
+        }
+
+        return $guarded;
     }
 
     /**
@@ -221,43 +303,79 @@ class AdminAssistantController extends Controller
     }
 
     /**
-     * Run the turn against the model and emit the SSE events, folded through
-     * ai-kit's StreamEventMapper; a pause emits its approval/question cards
-     * through {@see AssistantCards}. Every outcome — including a thrown
-     * provider error — must land as an event.
+     * Open one turn — a fresh prompt or a decided resume — and stream it: a
+     * durable buffer, a queued job to fold the model stream into it, and the
+     * tail of that buffer as the response. The two entry points differ only in
+     * what they hand the job, so the turn id, the meta and the leading `turn`
+     * frame are minted in one place.
+     *
+     * @param  array<string, mixed>|null  $decisions
      */
-    private function streamTurn(
-        Decisions|string $prompt,
-        AdminOwner $owner,
+    private function startTurn(
+        TurnBuffer $buffer,
+        User $admin,
         ?string $conversationId,
-    ): void {
-        $sse = new SseStream;
-        $sse->extendTimeLimit((int) config('ai.chat.timeout', 60) + 30);
+        string $prompt = '',
+        ?array $decisions = null,
+    ): StreamedResponse {
+        $turnId = (string) Str::uuid7();
 
-        // ai-kit's usage module records the turn (exact provider cost,
-        // tokens, timings) automatically; the label is all it needs.
-        Context::add(config('ai-kit.usage.feature_context_key'), self::FEATURE);
+        // `admin_id` is what {@see stream()} and {@see cancel()} read back to
+        // refuse a foreign turn.
+        $buffer->start($turnId, [
+            'admin_id' => (int) $admin->id,
+            'conversation_id' => $conversationId,
+        ]);
 
-        $agent = AdminAssistant::make();
-        $agent = $conversationId !== null
-            ? $agent->continue($conversationId, $owner)
-            : $agent->forUser($owner);
+        // The handle the client stores so it can resume this turn. Appended
+        // BEFORE the job is dispatched, so it is seq 1 and no worker can be
+        // appending concurrently — the buffer's single-writer rule holds.
+        $buffer->append($turnId, 'turn', ['id' => $turnId]);
 
-        try {
-            $response = $agent->stream($prompt);
+        GenerateAdminAssistantReply::dispatch(
+            turnId: $turnId,
+            adminId: (int) $admin->id,
+            prompt: $prompt,
+            conversationId: $conversationId,
+            decisions: $decisions,
+        );
 
-            app(AssistantCards::class)->attachTo(
-                (new StreamEventMapper)
-                    ->onError(fn (): string => $this->genericErrorMessage())
-                    ->doneUsing(fn (): array => [
-                        'conversation_id' => $response->conversationId ?? $conversationId,
-                    ])
-            )->run($response, fn (string $event, array $data) => $sse->emit($event, $data));
-        } catch (Throwable $exception) {
-            report($exception);
+        return $this->tail($buffer, $turnId);
+    }
 
-            $sse->emit('error', ['message' => $this->genericErrorMessage()]);
-        }
+    /**
+     * Tail one turn's durable buffer as SSE — the ONE streaming response this
+     * controller produces, whether the turn was just opened by {@see send()}
+     * or {@see decide()}, or is being resumed by {@see stream()}. The frame
+     * writing, the poll loop, the deadline and the keepalive comments are all
+     * the kit's, configured under `ai-kit.streaming`.
+     */
+    private function tail(TurnBuffer $buffer, string $turnId, int $after = 0): StreamedResponse
+    {
+        return response()->stream(function () use ($buffer, $turnId, $after): void {
+            $sse = app(SseStream::class);
+
+            $sse->extendTimeLimit((int) config('ai-kit.streaming.max_stream_seconds', 180) + 30);
+
+            $buffer->tail($turnId, $after, $sse);
+        }, 200, SseStream::headers());
+    }
+
+    /**
+     * The turn record, or a 404 — for an unknown or expired turn, and equally
+     * for one belonging to another admin. Both are 404 rather than 403: no
+     * admin needs to learn that a colleague's turn id exists.
+     *
+     * @return array<string, mixed>
+     */
+    private function ownedTurn(TurnBuffer $buffer, string $turnId, int $adminId): array
+    {
+        $record = $buffer->get($turnId);
+
+        abort_if($record === null, 404);
+        abort_unless((int) ($record['meta']['admin_id'] ?? 0) === $adminId, 404);
+
+        return $record;
     }
 
     /**
@@ -297,10 +415,5 @@ class AdminAssistantController extends Controller
         }
 
         return null;
-    }
-
-    private function genericErrorMessage(): string
-    {
-        return 'حدث خطأ أثناء توليد الرد. حاول مرة أخرى.';
     }
 }

--- a/app/Http/Controllers/Manage/AdminAssistantController.php
+++ b/app/Http/Controllers/Manage/AdminAssistantController.php
@@ -10,7 +10,6 @@ use App\Http\Requests\Manage\AdminAssistantMessageRequest;
 use App\Jobs\Ai\GenerateAdminAssistantReply;
 use App\Models\User;
 use App\Settings\AiSettings;
-use Closure;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -213,12 +212,10 @@ class AdminAssistantController extends Controller
             // call is in hand: an edit's readonly and hidden fields are
             // restored from the pause before the decision is serialized into a
             // job, so what the queue carries is never the raw browser payload.
-            $guarded = $this->guardDecisions($input, $cards->editGuard($pending));
-
-            // Round-trips the guarded payload through the kit's own parser,
-            // which is what rejects an unknown action shape — the same call the
-            // job makes, so nothing reaches the queue the resume cannot read.
-            ResumeDecisions::fromClient($guarded);
+            // `guarded()` also round-trips the result through the kit's own
+            // parser, so a shape the resume could not read throws in THIS
+            // request rather than inside the job.
+            $guarded = ResumeDecisions::guarded($input, $cards->editGuard($pending));
         } catch (InvalidArgumentException) {
             // Covers both a malformed decision shape and an edit that invents
             // an argument the card never carried; a tampered readonly field
@@ -230,33 +227,6 @@ class AdminAssistantController extends Controller
         // that is invisible to the client, which reads the continuation off
         // this same response exactly as it always has.
         return $this->startTurn($buffer, $admin, $conversation, decisions: $guarded);
-    }
-
-    /**
-     * Reconcile every EDIT decision against the server's pending call before it
-     * travels any further. Approvals and rejections pass through untouched —
-     * they carry no arguments to tamper with.
-     *
-     * TODO(kit 0.7.3): replace with `ResumeDecisions::guarded($input, $guard)`.
-     * The kit's `fromClient()` takes the guard but returns a `Decisions`
-     * object, and a queued resume needs the guarded ARRAY (a Decisions cannot
-     * ride a job payload), so the round-trip is spelled out here for now.
-     *
-     * @param  array<string, mixed>  $input
-     * @param  Closure(string, array<string, mixed>): array<string, mixed>  $guard
-     * @return array<string, mixed>
-     */
-    private function guardDecisions(array $input, Closure $guard): array
-    {
-        $guarded = [];
-
-        foreach ($input as $id => $decision) {
-            $guarded[(string) $id] = is_array($decision) && ($decision['action'] ?? null) === 'edit'
-                ? ['action' => 'edit', 'arguments' => $guard((string) $id, (array) ($decision['arguments'] ?? []))]
-                : $decision;
-        }
-
-        return $guarded;
     }
 
     /**

--- a/app/Jobs/Ai/GenerateAdminAssistantReply.php
+++ b/app/Jobs/Ai/GenerateAdminAssistantReply.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace App\Jobs\Ai;
+
+use App\Ai\Admin\AdminAssistant;
+use App\Ai\Admin\AdminOwner;
+use App\Ai\Admin\AssistantCards;
+use App\Models\User;
+use Generator;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Log;
+use Laravel\Ai\Streaming\Events\StreamEvent;
+use Saad\AiKit\Approvals\Classified\ResumeDecisions;
+use Saad\AiKit\Safety\KillSwitch;
+use Saad\AiKit\Streaming\StreamEventMapper;
+use Saad\AiKit\Streaming\TurnBuffer;
+use Throwable;
+
+/**
+ * Runs one admin-assistant turn in the background, appending its wire events
+ * to the kit's durable {@see TurnBuffer} rather than writing them straight to
+ * a response — the same resumable shape as the student surface's
+ * {@see GenerateChatReply}, so an operator who loses connectivity mid-write
+ * reconnects to the SAME turn instead of losing it.
+ *
+ * The fold is unchanged from the in-request path this replaces: the kit's
+ * {@see StreamEventMapper} with {@see AssistantCards} hooked onto it, so a
+ * gated write still emits its `approval` / `question` card and the turn still
+ * ends there with nothing written. What changed is only WHERE the events go.
+ *
+ * ── Resume turns ── A decided batch does not continue the paused job (it
+ * finished when the turn paused); it mints a NEW turn that prompts the same
+ * conversation with the decisions. The vendor loop replays the paused calls,
+ * executes the approved ones and carries on. That continuation may itself
+ * pause again, so one logical exchange can span several turns.
+ *
+ * ── Acting user ── Every write the turn performs runs as the admin who asked
+ * for it, so the guard is swapped for the turn's duration and restored after
+ * (Octane-safe): the tools' own authorization, the activity-log causer and
+ * every policy read the right user.
+ */
+class GenerateAdminAssistantReply implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * The usage label every model call in an admin turn is recorded under,
+     * and the kill-switch scope that darkens the surface (it folds the master
+     * ai_enabled AND admin_assistant_enabled toggles).
+     */
+    public const FEATURE = 'admin_assistant';
+
+    /** One attempt: a half-streamed turn must never silently replay its writes. */
+    public int $tries = 1;
+
+    /**
+     * @param  array<string, mixed>|null  $decisions  a RESUME turn's card decisions, already
+     *                                                reconciled against the server's pending
+     *                                                calls by the decide endpoint
+     */
+    public function __construct(
+        public string $turnId,
+        public int $adminId,
+        public string $prompt = '',
+        public ?string $conversationId = null,
+        public ?array $decisions = null,
+    ) {
+        $this->onQueue((string) config('ai.chat.queue', 'default'));
+    }
+
+    public function handle(TurnBuffer $buffer, KillSwitch $killSwitch): void
+    {
+        // The request guarded this turn before it was queued; a kill switch
+        // engaged mid-incident exists precisely to stop a queued backlog
+        // spending — and, here, writing — its way through. The daily budget is
+        // deliberately NOT re-checked: an admin already told their turn would
+        // run should not lose it to someone else's spend.
+        if ($killSwitch->engaged(self::FEATURE)) {
+            $buffer->fail($this->turnId, 'المساعد الإداري غير متاح حالياً.');
+
+            return;
+        }
+
+        $admin = User::query()->find($this->adminId);
+
+        if ($admin === null) {
+            $buffer->fail($this->turnId, $this->genericErrorMessage());
+
+            return;
+        }
+
+        // ai-kit's usage module records the turn (exact provider cost, tokens,
+        // timings) automatically; the label is all it needs.
+        Context::add((string) config('ai-kit.usage.feature_context_key'), self::FEATURE);
+
+        // Authenticate the acting admin for the WHOLE turn so every policy,
+        // scope and audit causer that reads auth()->user() is correct, then
+        // restore the prior guard — the worker is long-lived and must not leak
+        // one turn's user into the next.
+        $auth = Auth::guard();
+        $previousUser = $auth->hasUser() ? $auth->user() : null;
+        $auth->setUser($admin);
+
+        try {
+            $owner = new AdminOwner($admin);
+
+            $agent = AdminAssistant::make();
+            $agent = $this->conversationId !== null
+                ? $agent->continue($this->conversationId, $owner)
+                : $agent->forUser($owner);
+
+            // A RESUME turn prompts with the admin's decisions instead of new
+            // text. The payload was already reconciled against the server's own
+            // pending calls before it was queued, so what arrives here is never
+            // the raw browser body.
+            $prompt = $this->decisions !== null
+                ? ResumeDecisions::fromClient($this->decisions)
+                : $this->prompt;
+
+            $response = $agent->stream($prompt);
+
+            app(AssistantCards::class)
+                ->attachTo(
+                    (new StreamEventMapper)
+                        ->onError(fn (): string => $this->genericErrorMessage())
+                        ->doneUsing(fn (): array => [
+                            'conversation_id' => $response->conversationId ?? $this->conversationId,
+                        ])
+                )
+                // No `$meta`: the only fact the stream and cancel endpoints read
+                // back — the owning admin — was recorded when the controller
+                // opened the turn, and the decide endpoint is keyed by
+                // CONVERSATION rather than by turn, so it never reads turn meta
+                // at all. The conversation id a fresh thread resolves rides the
+                // `done` payload, which IS assembled after the fold.
+                ->runIntoBuffer($this->untilCancelled($response, $buffer), $buffer, $this->turnId);
+        } catch (Throwable $exception) {
+            report($exception);
+
+            $buffer->fail($this->turnId, $this->genericErrorMessage());
+        } finally {
+            $previousUser !== null ? $auth->setUser($previousUser) : Auth::forgetGuards();
+        }
+    }
+
+    /**
+     * The agent's stream, cut short the moment the admin's stop lands.
+     *
+     * The kit's mapper folds any `iterable` and has no stop hook of its own,
+     * so cancellation composes as a generator IN FRONT of it: when the flag
+     * flips this stops yielding, and the fold ends the way a drained stream
+     * ends. A stop that lands after a write already paused leaves that pause
+     * standing — the decide endpoint re-checks the server's pending set before
+     * anything executes, so a half-decided batch cannot slip through.
+     *
+     * @param  iterable<StreamEvent>  $stream
+     * @return Generator<StreamEvent>
+     */
+    private function untilCancelled(iterable $stream, TurnBuffer $buffer): Generator
+    {
+        $lastCheck = 0.0;
+
+        foreach ($stream as $event) {
+            yield $event;
+
+            if (microtime(true) - $lastCheck < 1.0) {
+                continue;
+            }
+
+            $lastCheck = microtime(true);
+
+            if ($buffer->isCancelled($this->turnId)) {
+                return;
+            }
+        }
+    }
+
+    private function genericErrorMessage(): string
+    {
+        return 'حدث خطأ أثناء توليد الرد. حاول مرة أخرى.';
+    }
+
+    /**
+     * A turn whose queue worker died outright (timeout, OOM) still owes its
+     * client a terminal event — without one the buffer stays `running` and the
+     * tail loop holds the connection open until its deadline.
+     */
+    public function failed(?Throwable $exception): void
+    {
+        Log::warning('Admin assistant turn failed', [
+            'turn_id' => $this->turnId,
+            'admin_id' => $this->adminId,
+            'exception' => $exception?->getMessage(),
+        ]);
+
+        app(TurnBuffer::class)->fail($this->turnId, $this->genericErrorMessage());
+    }
+}

--- a/app/Jobs/Ai/GenerateChatReply.php
+++ b/app/Jobs/Ai/GenerateChatReply.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace App\Jobs\Ai;
+
+use App\Ai\Agents\StudentAssistant;
+use App\Ai\Chat\AnswerLinkGuard;
+use App\Ai\Chat\CitationExtractor;
+use App\Ai\Chat\SessionOwner;
+use App\Ai\Chat\StreamingAnswerLinkGuard;
+use App\Models\Ai\ChatAttachment;
+use Generator;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Log;
+use Laravel\Ai\Models\ConversationMessage;
+use Laravel\Ai\Streaming\Events\StreamEvent;
+use Saad\AiKit\Safety\KillSwitch;
+use Saad\AiKit\Streaming\StreamEventMapper;
+use Saad\AiKit\Streaming\StreamResult;
+use Saad\AiKit\Streaming\TurnBuffer;
+use Throwable;
+
+/**
+ * Runs one student-assistant turn in the background, appending its wire
+ * events to the kit's durable {@see TurnBuffer} instead of writing them
+ * straight to a response. The SSE endpoints only ever TAIL that buffer, so a
+ * visitor who loses connectivity, backgrounds the tab or reloads the page
+ * resumes the same turn from `?cursor=<last seq>` rather than losing it —
+ * and the reply keeps generating either way, because nothing about it is tied
+ * to an open socket any more.
+ *
+ * The fold from laravel/ai stream events to wire events is unchanged from the
+ * in-request path this replaces: the kit's {@see StreamEventMapper} with the
+ * link guard on the text pipeline and citations emitted from the turn's tool
+ * results, producing the same `reasoning` / `delta` / `tool` / `citations` /
+ * `done` sequence the client already reads. `runIntoBuffer()` writes the
+ * turn's ONE terminal event through the buffer, so a replayed turn and a live
+ * one are byte-identical.
+ *
+ * Two pieces are app-side because the kit primitive cannot express them:
+ *
+ *  - CANCELLATION: {@see untilCancelled} wraps the stream as a generator IN
+ *    FRONT of the mapper, since the mapper folds a whole iterable with no
+ *    stop hook. The visitor's stop button now flags the turn server-side
+ *    (the buffer's own cancel key) rather than merely hanging up — with
+ *    generation decoupled from the request, hanging up no longer stops it.
+ *  - THE THROWN failure: a provider error the mapper never sees (it was
+ *    raised building or opening the stream) fails the turn here, with the
+ *    same generic line the mapper's `onError` produces.
+ */
+class GenerateChatReply implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * The usage label every model call in a student turn is recorded under,
+     * and the kill-switch scope that darkens the surface. It lives on the job
+     * because the job is what actually spends; ChatController imports it for
+     * its pre-flight guard.
+     */
+    public const FEATURE = 'assistant';
+
+    /** One attempt: a half-streamed reply must never silently replay. */
+    public int $tries = 1;
+
+    /**
+     * @param  list<string>  $attachmentIds  the session's own attachments, bound to the
+     *                                       conversation once the turn resolves one
+     */
+    public function __construct(
+        public string $turnId,
+        public string $sessionId,
+        public string $prompt,
+        public ?string $conversationId = null,
+        public array $attachmentIds = [],
+    ) {
+        $this->onQueue((string) config('ai.chat.queue', 'default'));
+    }
+
+    public function handle(TurnBuffer $buffer, KillSwitch $killSwitch, CitationExtractor $citations): void
+    {
+        // The request already guarded this turn, but that was before it was
+        // queued — possibly long before, and a kill switch engaged mid-incident
+        // exists precisely to stop a queued backlog spending its way through.
+        // Re-check here, where the model call actually happens. The daily
+        // budget is deliberately NOT re-checked: a visitor already told their
+        // turn would run should not lose it to someone else's spend.
+        if ($killSwitch->engaged(self::FEATURE)) {
+            $buffer->fail($this->turnId, 'المساعد الذكي غير متاح حالياً.');
+
+            return;
+        }
+
+        // ai-kit's usage module records the turn (exact provider cost, tokens,
+        // timings) automatically; the label is all it needs.
+        Context::add((string) config('ai-kit.usage.feature_context_key'), self::FEATURE);
+
+        $owner = new SessionOwner($this->sessionId);
+
+        $agent = StudentAssistant::make();
+        $agent = $this->conversationId !== null
+            ? $agent->continue($this->conversationId, $owner)
+            : $agent->forUser($owner);
+
+        try {
+            $response = $agent->stream($this->prompt);
+
+            (new StreamEventMapper)
+                ->transformText(new StreamingAnswerLinkGuard(app(AnswerLinkGuard::class)))
+                ->onError(fn (): string => $this->genericErrorMessage())
+                ->beforeDone(function (StreamResult $result, callable $emit) use ($citations): void {
+                    $items = $citations->extract($result->toolResults);
+
+                    if ($items !== []) {
+                        $emit('citations', ['items' => $items]);
+                    }
+                })
+                ->doneUsing(function () use ($response): array {
+                    $finalConversationId = $response->conversationId ?? $this->conversationId;
+
+                    $this->bindAttachments($finalConversationId);
+
+                    return [
+                        'conversation_id' => $finalConversationId,
+                        'message_id' => $this->latestAssistantMessageId($finalConversationId),
+                    ];
+                })
+                // No `$meta`: `runIntoBuffer` fixes it before the fold, and the
+                // only fact the stream and cancel endpoints read back — the
+                // owning session — was recorded when the controller opened the
+                // turn. The conversation id a fresh thread resolves rides the
+                // `done` payload instead, which IS assembled after the fold.
+                ->runIntoBuffer($this->untilCancelled($response, $buffer), $buffer, $this->turnId);
+        } catch (Throwable $exception) {
+            report($exception);
+
+            $buffer->fail($this->turnId, $this->genericErrorMessage());
+        }
+    }
+
+    /**
+     * The agent's stream, cut short the moment the visitor's stop lands.
+     *
+     * The kit's mapper folds any `iterable` and has no stop hook of its own,
+     * so cancellation composes as a generator IN FRONT of it: when the flag
+     * flips this simply stops yielding, the mapper's fold ends the way a
+     * drained stream ends (flushing held text, running `beforeDone`,
+     * assembling `done`), and whatever streamed so far is what the turn
+     * finishes with.
+     *
+     * The flag lives under its own cache key, so a stop can never race the
+     * appends this job is making. It is polled at most once a second — never a
+     * per-token cache hammer — and the 0.0 seed makes the FIRST event check,
+     * so a stop pressed before anything streamed still lands.
+     *
+     * @param  iterable<StreamEvent>  $stream
+     * @return Generator<StreamEvent>
+     */
+    private function untilCancelled(iterable $stream, TurnBuffer $buffer): Generator
+    {
+        $lastCheck = 0.0;
+
+        foreach ($stream as $event) {
+            yield $event;
+
+            if (microtime(true) - $lastCheck < 1.0) {
+                continue;
+            }
+
+            $lastCheck = microtime(true);
+
+            if ($buffer->isCancelled($this->turnId)) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * Hand the turn's attachments to the conversation it resolved, so a
+     * rehydrated thread can still find the files the visitor sent.
+     */
+    private function bindAttachments(?string $conversationId): void
+    {
+        if ($conversationId === null || $this->attachmentIds === []) {
+            return;
+        }
+
+        ChatAttachment::query()
+            ->whereKey($this->attachmentIds)
+            ->where('session_id', $this->sessionId)
+            ->update(['conversation_id' => $conversationId]);
+    }
+
+    private function latestAssistantMessageId(?string $conversationId): ?string
+    {
+        if ($conversationId === null) {
+            return null;
+        }
+
+        return ConversationMessage::query()
+            ->where('conversation_id', $conversationId)
+            ->where('role', 'assistant')
+            ->orderByDesc('id')
+            ->value('id');
+    }
+
+    private function genericErrorMessage(): string
+    {
+        return 'حدث خطأ أثناء توليد الرد. حاول مرة أخرى.';
+    }
+
+    /**
+     * A turn whose queue worker died outright (timeout, OOM) still owes its
+     * client a terminal event — without one the buffer stays `running` and the
+     * tail loop keeps the connection open until the deadline.
+     */
+    public function failed(?Throwable $exception): void
+    {
+        Log::warning('Assistant turn failed', [
+            'turn_id' => $this->turnId,
+            'exception' => $exception?->getMessage(),
+        ]);
+
+        app(TurnBuffer::class)->fail($this->turnId, $this->genericErrorMessage());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "league/flysystem-aws-s3-v3": "^3.0",
         "pgvector/pgvector": "^0.2.2",
         "predis/predis": "^2.0",
-        "saad/ai-kit": "^0.7.2",
+        "saad/ai-kit": "^0.7.3",
         "smalot/pdfparser": "^2.12",
         "spatie/browsershot": "^5.2",
         "spatie/eloquent-sortable": "^4.5",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "league/flysystem-aws-s3-v3": "^3.0",
         "pgvector/pgvector": "^0.2.2",
         "predis/predis": "^2.0",
-        "saad/ai-kit": "^0.6.0",
+        "saad/ai-kit": "^0.7.2",
         "smalot/pdfparser": "^2.12",
         "spatie/browsershot": "^5.2",
         "spatie/eloquent-sortable": "^4.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e2f7a9a7bed90720bcbc9c46ba6d3c3d",
+    "content-hash": "624903fc81adf0b37a75bef4e1b3c709",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -5283,16 +5283,16 @@
         },
         {
             "name": "saad/ai-kit",
-            "version": "v0.7.2",
+            "version": "v0.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Saad5400/ai-kit.git",
-                "reference": "9c9b325b59335b509473495fbc528a5a5de1b053"
+                "reference": "8851863470aa89734c85afce17cde359c1a8b9c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Saad5400/ai-kit/zipball/9c9b325b59335b509473495fbc528a5a5de1b053",
-                "reference": "9c9b325b59335b509473495fbc528a5a5de1b053",
+                "url": "https://api.github.com/repos/Saad5400/ai-kit/zipball/8851863470aa89734c85afce17cde359c1a8b9c6",
+                "reference": "8851863470aa89734c85afce17cde359c1a8b9c6",
                 "shasum": ""
             },
             "require": {
@@ -5349,10 +5349,10 @@
                 "openrouter"
             ],
             "support": {
-                "source": "https://github.com/Saad5400/ai-kit/tree/v0.7.2",
+                "source": "https://github.com/Saad5400/ai-kit/tree/v0.7.3",
                 "issues": "https://github.com/Saad5400/ai-kit/issues"
             },
-            "time": "2026-08-19T14:04:20+00:00"
+            "time": "2026-08-20T08:35:54+00:00"
         },
         {
             "name": "scrivo/highlight.php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc734bba8e5de243ae80f01150a97288",
+    "content-hash": "e2f7a9a7bed90720bcbc9c46ba6d3c3d",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -5283,16 +5283,16 @@
         },
         {
             "name": "saad/ai-kit",
-            "version": "v0.6.0",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Saad5400/ai-kit.git",
-                "reference": "851081c2f9fd00a7ea6c244b5afb2b5f2a6cbd61"
+                "reference": "9c9b325b59335b509473495fbc528a5a5de1b053"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Saad5400/ai-kit/zipball/851081c2f9fd00a7ea6c244b5afb2b5f2a6cbd61",
-                "reference": "851081c2f9fd00a7ea6c244b5afb2b5f2a6cbd61",
+                "url": "https://api.github.com/repos/Saad5400/ai-kit/zipball/9c9b325b59335b509473495fbc528a5a5de1b053",
+                "reference": "9c9b325b59335b509473495fbc528a5a5de1b053",
                 "shasum": ""
             },
             "require": {
@@ -5349,10 +5349,10 @@
                 "openrouter"
             ],
             "support": {
-                "source": "https://github.com/Saad5400/ai-kit/tree/v0.6.0",
+                "source": "https://github.com/Saad5400/ai-kit/tree/v0.7.2",
                 "issues": "https://github.com/Saad5400/ai-kit/issues"
             },
-            "time": "2026-08-19T10:10:04+00:00"
+            "time": "2026-08-19T14:04:20+00:00"
         },
         {
             "name": "scrivo/highlight.php",

--- a/config/ai.php
+++ b/config/ai.php
@@ -45,12 +45,22 @@ return [
     | surface and the -0731 build's server default is 'high' — every caller
     | must therefore send the effort explicitly to get the faster path.
     |
+    | `queue` is where a resumable assistant turn runs (both the student and
+    | the admin surface). It gets a queue of its OWN rather than sharing one:
+    | `default` is a single worker with no --timeout, so turns would serialize
+    | behind each other, block every other default-queue job, and be killed at
+    | 60s; and `ai` carries multi-minute corpus extraction and ingestion, which
+    | an interactive reply must never wait behind. Static on purpose — like
+    | queue.php's `retry_after` it is a fixed property of our worker topology
+    | (nixpacks.toml's `worker-ai-chat`), not a per-environment knob.
+    |
     */
 
     'chat' => [
         'model' => env('AI_CHAT_MODEL', 'deepseek/deepseek-v4-flash-0731'),
         'reasoning_effort' => env('AI_CHAT_REASONING_EFFORT', 'low'),
         'timeout' => (int) env('AI_CHAT_TIMEOUT', 60),
+        'queue' => 'ai-chat',
     ],
 
     /*

--- a/config/queue.php
+++ b/config/queue.php
@@ -70,8 +70,11 @@ return [
             'queue' => env('REDIS_QUEUE', 'default'),
             // Must exceed the longest a job may run, or a still-running job is
             // reclaimed and processed a second time. Our slowest workers set
-            // --timeout=300 (ai) and jobs declare timeout=120 (telegram), so
-            // this sits safely above 300. Static on purpose: it is a fixed
+            // --timeout=300 (ai, ai-chat) and jobs declare timeout=120
+            // (telegram), so this sits safely above 300 — which makes 300 the
+            // ceiling for any new worker, not a default to raise freely. A
+            // reclaimed assistant turn would re-run a whole reply against a
+            // buffer that already has one. Static on purpose: it is a fixed
             // property of our worker topology, not a per-environment knob.
             'retry_after' => 360,
             'block_for' => null,

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -227,6 +227,37 @@ stdout_logfile=/var/log/worker-ai-queue.log
 stderr_logfile=/var/log/worker-ai-queue.log
 '''
 
+# Interactive assistant turns (config/ai.php `chat.queue`) — the resumable
+# TurnBuffer path, for both the student and the admin surface.
+#
+# Separate from the `ai` queue above on purpose: that one carries multi-minute
+# corpus extraction and ingestion, and a visitor watching an SSE stream must
+# never be queued behind a document ingest. Equally not `default`, which is one
+# worker with no --timeout: turns would serialize behind each other, block every
+# other default-queue job, and die at 60s.
+#
+# --tries=1 because a half-streamed turn must never silently replay — the jobs'
+# own failed() hook writes the terminal error frame instead, so a killed turn
+# ends the client's stream rather than leaving it to spin. --sleep=1 keeps
+# pickup latency out of the visible reply. --timeout=300 matches the AI worker
+# and is the CEILING, not a preference: config/queue.php pins redis retry_after
+# at 360, which must stay above the longest a job may run or a still-streaming
+# turn is reclaimed and run a second time. numprocs=2 so two visitors' turns do
+# not serialize; stopwaitsecs > timeout lets an in-flight turn finish a restart.
+"worker-ai-chat.conf" = '''
+[program:worker-ai-chat]
+process_name=%(program_name)s_%(process_num)02d
+command=bash -c 'exec php /app/artisan queue:work --queue=ai-chat --sleep=1 --tries=1 --timeout=300 --max-time=3600'
+numprocs=2
+autostart=true
+autorestart=true
+stopwaitsecs=310
+stopasgroup=true
+killasgroup=true
+stdout_logfile=/var/log/worker-ai-chat.log
+stderr_logfile=/var/log/worker-ai-chat.log
+'''
+
 "worker-inertia-ssr.conf" = '''
 [program:inertia-ssr]
 command=bash -c 'exec php /app/artisan inertia:start-ssr'

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
             "dependencies": {
                 "@formkit/auto-animate": "^0.9.0",
                 "@inertiajs/vue3": "^2.0.0",
-                "@saad5400/ai-kit": "github:Saad5400/ai-kit#semver:^0.7.2",
+                "@saad5400/ai-kit": "github:Saad5400/ai-kit#semver:^0.7.3",
                 "@tailwindcss/vite": "^4.1.11",
                 "@tanstack/vue-table": "^8.21.3",
                 "@tiptap/core": "^2.8.0",
@@ -1715,8 +1715,8 @@
             ]
         },
         "node_modules/@saad5400/ai-kit": {
-            "version": "0.7.2",
-            "resolved": "git+ssh://git@github.com/Saad5400/ai-kit.git#9c9b325b59335b509473495fbc528a5a5de1b053",
+            "version": "0.7.3",
+            "resolved": "git+ssh://git@github.com/Saad5400/ai-kit.git#8851863470aa89734c85afce17cde359c1a8b9c6",
             "license": "UNLICENSED",
             "dependencies": {
                 "eventsource-parser": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "uqucc-laravel",
+    "name": "uqucc-kitbuffer",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -7,7 +7,7 @@
             "dependencies": {
                 "@formkit/auto-animate": "^0.9.0",
                 "@inertiajs/vue3": "^2.0.0",
-                "@saad5400/ai-kit": "github:Saad5400/ai-kit#semver:^0.6.0",
+                "@saad5400/ai-kit": "github:Saad5400/ai-kit#semver:^0.7.2",
                 "@tailwindcss/vite": "^4.1.11",
                 "@tanstack/vue-table": "^8.21.3",
                 "@tiptap/core": "^2.8.0",
@@ -1715,8 +1715,8 @@
             ]
         },
         "node_modules/@saad5400/ai-kit": {
-            "version": "0.6.0",
-            "resolved": "git+ssh://git@github.com/Saad5400/ai-kit.git#851081c2f9fd00a7ea6c244b5afb2b5f2a6cbd61",
+            "version": "0.7.2",
+            "resolved": "git+ssh://git@github.com/Saad5400/ai-kit.git#9c9b325b59335b509473495fbc528a5a5de1b053",
             "license": "UNLICENSED",
             "dependencies": {
                 "eventsource-parser": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "@formkit/auto-animate": "^0.9.0",
         "@inertiajs/vue3": "^2.0.0",
-        "@saad5400/ai-kit": "github:Saad5400/ai-kit#semver:^0.6.0",
+        "@saad5400/ai-kit": "github:Saad5400/ai-kit#semver:^0.7.2",
         "@tailwindcss/vite": "^4.1.11",
         "@tanstack/vue-table": "^8.21.3",
         "@tiptap/core": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "@formkit/auto-animate": "^0.9.0",
         "@inertiajs/vue3": "^2.0.0",
-        "@saad5400/ai-kit": "github:Saad5400/ai-kit#semver:^0.7.2",
+        "@saad5400/ai-kit": "github:Saad5400/ai-kit#semver:^0.7.3",
         "@tailwindcss/vite": "^4.1.11",
         "@tanstack/vue-table": "^8.21.3",
         "@tiptap/core": "^2.8.0",

--- a/resources/js/pages/AssistantPage.vue
+++ b/resources/js/pages/AssistantPage.vue
@@ -6,7 +6,7 @@ import PageHeader from '@/components/page/PageHeader.vue';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { send as sendChat, show as showConversation } from '@/routes/ai/chat';
+import { cancel as cancelTurn, send as sendChat, show as showConversation, stream as streamTurn } from '@/routes/ai/chat';
 import { store as storeAttachment } from '@/routes/ai/chat/attachments';
 import { show as showPage } from '@/routes/pages';
 import { Link } from '@inertiajs/vue3';
@@ -20,7 +20,7 @@ import { markRaw, nextTick, onBeforeUnmount, onMounted, reactive, ref, useTempla
 /**
  * The student assistant chat. Anonymous, session-owned conversations:
  * POST /ai/chat streams the reply as ai-kit SSE frames
- * (reasoning/delta/tool/citations/done/error), read with the kit's
+ * (turn/reasoning/delta/tool/citations/done/error), read with the kit's
  * `readSseStream`; pre-flight failures (feature disabled 503, budget 503,
  * rate limits 429, validation 422) arrive as plain JSON. Like
  * AiSearchPalette, the disabled state is discovered lazily from the
@@ -34,6 +34,20 @@ import { markRaw, nextTick, onBeforeUnmount, onMounted, reactive, ref, useTempla
  * ones it does not own — while `citations`, `done` and `error` are handled
  * beside it. `groupSegments` then collapses thinking and tool runs into one
  * disclosure, leaving the answer text top-level.
+ *
+ * ── Resumable turns ── The reply is generated into a durable server-side
+ * buffer, so it survives the connection that asked for it. Every frame the
+ * server sends carries an `id:` — the buffer sequence number, handed to the
+ * reader's third argument — and re-issuing the last one as `?cursor=` is what
+ * makes a reconnect resume rather than replay. So a drop (lost signal, a
+ * backgrounded tab, the server's own stream ceiling) climbs a reconnect
+ * ladder against `stream`, and a page reload picks the turn back up from the
+ * id parked in sessionStorage. Seeing any frame forgives the previous drop,
+ * so a long turn never exhausts its retries.
+ *
+ * Because generation no longer rides the request, hanging up does not stop
+ * it: the stop button tells the SERVER to stop, and the turn finishes early
+ * with what it had.
  *
  * Thinking and tool progress are live-only — the server persists neither, so
  * a rehydrated thread shows the answer alone instead of inventing them.
@@ -111,6 +125,10 @@ interface PendingAttachment {
 }
 
 const CONVERSATION_STORAGE_KEY = 'assistant-conversation-id';
+/** The turn still in flight when the page was left, so a reload can resume it. */
+const ACTIVE_TURN_STORAGE_KEY = 'assistant-active-turn-id';
+/** Reconnect attempts before a turn is given up on — the ladder tops out at 8s a try. */
+const MAX_RECONNECTS = 8;
 const MAX_MESSAGE_LENGTH = 2000;
 const MAX_ATTACHMENTS = 5;
 const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
@@ -144,6 +162,29 @@ const examplePrompts = [
 let nextLocalId = 1;
 let nextClientId = 1;
 let abortController: AbortController | undefined;
+
+/**
+ * The turn currently being read, how far into its buffer this client has got,
+ * and whether it has reached a terminal event. `lastSeq` is the cursor every
+ * reconnect re-issues; `reconnects` is reset by any frame that lands, so
+ * progress forgives the drop that preceded it.
+ */
+let currentTurn: string | null = null;
+let lastSeq = 0;
+let reconnects = 0;
+let turnFinished = false;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Whether the visitor has walked away from the turn currently being read. */
+const readAborted = (): boolean => abortController?.signal.aborted === true;
+
+/** The answer as plain text, for matching a replayed turn against a rehydrated one. */
+const answerText = (segments: Segment[]): string =>
+    segments
+        .filter((segment) => segment.type === 'text')
+        .map((segment) => segment.text)
+        .join('');
 
 /**
  * A message whose segment list is reactive and handed to the timeline, so the
@@ -238,9 +279,35 @@ const rehydrateConversation = async (): Promise<void> => {
     }
 };
 
-const handleSseEvent = (event: string, data: Record<string, unknown>, reply: ChatMessage): void => {
-    // Everything goes through the timeline, which ignores what it does not
-    // own — the app's own events below are handled beside it, not instead.
+/**
+ * Fold one frame from the kit's reader.
+ *
+ * `id` is the buffer sequence number the frame was stored under; recording it
+ * is the whole of what makes the next reconnect resume instead of replay.
+ */
+const handleSseEvent = (event: string, data: Record<string, unknown>, reply: ChatMessage, id?: string): void => {
+    if (id !== undefined) {
+        const seq = Number.parseInt(id, 10);
+
+        if (!Number.isNaN(seq)) {
+            lastSeq = seq;
+            reconnects = 0;
+        }
+    }
+
+    // The turn handle, always the first frame. It is not a timeline event —
+    // it is the id a reconnect (or a reload) re-issues to find this turn again.
+    if (event === 'turn') {
+        if (typeof data.id === 'string' && data.id !== '') {
+            currentTurn = data.id;
+            sessionStorage.setItem(ACTIVE_TURN_STORAGE_KEY, data.id);
+        }
+
+        return;
+    }
+
+    // Everything else goes through the timeline, which ignores what it does
+    // not own — the app's own events below are handled beside it, not instead.
     // A tool's name is swapped for its Arabic label on the way in: the chip
     // renders whatever the segment carries, and a student reads none of the
     // identifiers the model and the logs speak.
@@ -249,16 +316,181 @@ const handleSseEvent = (event: string, data: Record<string, unknown>, reply: Cha
     if (event === 'citations' && Array.isArray(data.items)) {
         reply.citations = data.items as Citation[];
     } else if (event === 'done') {
+        // `done` and `error` are each terminal on their own (the kit's buffer
+        // contract): one or the other ends the turn, never both, so reaching
+        // either means there is nothing left to reconnect for.
+        turnFinished = true;
+
         if (typeof data.conversation_id === 'string' && data.conversation_id !== '') {
             conversationId.value = data.conversation_id;
             sessionStorage.setItem(CONVERSATION_STORAGE_KEY, data.conversation_id);
         }
     } else if (event === 'error') {
+        turnFinished = true;
         reply.failed = true;
         errorBanner.value = typeof data.message === 'string' ? data.message : 'حدث خطأ أثناء توليد الرد. حاول مرة أخرى.';
     }
 
     void scrollToBottom();
+};
+
+/** Read one SSE response to its end, folding every frame into the live reply. */
+const readTurn = async (response: Response, reply: ChatMessage): Promise<void> => {
+    await readSseStream(response, (event, data, id) => handleSseEvent(event, (data ?? {}) as Record<string, unknown>, reply, id), {
+        signal: abortController?.signal,
+    });
+};
+
+/**
+ * Keep reading the current turn across drops until it reaches a terminal
+ * event or the ladder runs out.
+ *
+ * A read ends three ways: the turn finished (nothing more to do), the server
+ * hit its own stream ceiling and hung up mid-turn, or the connection broke.
+ * The last two are the same thing to this loop — wait out the backoff and
+ * re-issue `?cursor=lastSeq`, so the server replays only what was missed.
+ * Only an abort — the visitor leaving the page — returns without reconnecting,
+ * and it deliberately leaves the resume handle behind for the next load.
+ *
+ * `immediate` skips the first backoff, for a turn being picked up from
+ * storage rather than recovered from a drop.
+ */
+const followTurn = async (reply: ChatMessage, immediate = false): Promise<void> => {
+    let first = immediate;
+
+    while (!turnFinished && currentTurn !== null && !readAborted()) {
+        if (!first) {
+            if (reconnects >= MAX_RECONNECTS) {
+                turnFinished = true;
+                reply.failed = !hasText(reply);
+                errorBanner.value = 'انقطع الاتصال بالمساعد. حاول مرة أخرى.';
+
+                return;
+            }
+
+            reconnects++;
+            await sleep(Math.min(1000 * 2 ** (reconnects - 1), 8000));
+
+            if (readAborted()) {
+                return;
+            }
+        }
+
+        first = false;
+
+        try {
+            const response = await fetch(`${streamTurn.url(currentTurn)}?cursor=${lastSeq}`, {
+                credentials: 'same-origin',
+                headers: { Accept: 'text/event-stream' },
+                signal: abortController?.signal,
+            });
+
+            if (response.status === 404) {
+                // The buffer expired, or never belonged to this session: there
+                // is no turn to resume, so stop rather than climb the ladder.
+                turnFinished = true;
+                reply.failed = !hasText(reply);
+                errorBanner.value = 'انتهت صلاحية هذا الرد. أعد إرسال سؤالك.';
+
+                return;
+            }
+
+            if (!response.ok || !response.body) {
+                continue;
+            }
+
+            await readTurn(response, reply);
+        } catch (error) {
+            if ((error as Error).name === 'AbortError') {
+                return;
+            }
+        }
+    }
+};
+
+/**
+ * Settle a turn that is no longer being read: clear the live flags and drop
+ * chips nothing will ever resolve.
+ *
+ * The resume handle is forgotten only for a turn that actually ENDED — one
+ * that reached `done` / `error`, expired, or exhausted its retries. A read
+ * that stopped because the visitor navigated away leaves it in place on
+ * purpose: that is precisely the turn the next page load should pick up.
+ */
+const settleTurn = async (reply: ChatMessage): Promise<void> => {
+    reply.streaming = false;
+
+    // Stopping the turn (or losing the connection for good) can leave a chip
+    // mid-flight; a spinner nothing will ever resolve is worse than no chip.
+    // Spliced in place: the timeline owns this array.
+    for (let index = reply.segments.length - 1; index >= 0; index--) {
+        const segment = reply.segments[index];
+
+        if (segment.type === 'tool' && segment.status === 'running') {
+            reply.segments.splice(index, 1);
+        }
+    }
+
+    if (reply.failed && !hasText(reply)) {
+        messages.value = messages.value.filter((item) => item.id !== reply.id);
+    }
+
+    if (turnFinished) {
+        sessionStorage.removeItem(ACTIVE_TURN_STORAGE_KEY);
+        currentTurn = null;
+    }
+
+    isStreaming.value = false;
+    abortController = undefined;
+    await scrollToBottom();
+};
+
+/** Reset the per-turn transport state before a fresh turn is read. */
+const beginTurn = (): void => {
+    currentTurn = null;
+    lastSeq = 0;
+    reconnects = 0;
+    turnFinished = false;
+    isStreaming.value = true;
+    abortController = new AbortController();
+};
+
+/**
+ * Pick a turn left running when the page was closed back up, replaying it
+ * from the start of its buffer. A turn that finished after the tab went away
+ * was persisted in the meantime, so the rehydrated thread already ends with
+ * its answer — the replay would duplicate it, and the settle below drops the
+ * older copy in favour of the richer replayed one.
+ */
+const resumeActiveTurn = async (): Promise<void> => {
+    const storedTurn = sessionStorage.getItem(ACTIVE_TURN_STORAGE_KEY);
+
+    if (!storedTurn || assistantDisabled.value) {
+        return;
+    }
+
+    beginTurn();
+    // Cursor 0 — a restored turn has seen nothing of this buffer yet, so the
+    // replay rebuilds the bubble from its first frame.
+    currentTurn = storedTurn;
+
+    const reply = newMessage('assistant');
+    reply.streaming = true;
+    messages.value.push(reply);
+    const liveReply = messages.value[messages.value.length - 1];
+
+    try {
+        await followTurn(liveReply, true);
+    } finally {
+        const text = answerText(liveReply.segments);
+        const previous = messages.value[messages.value.indexOf(liveReply) - 1];
+
+        if (text !== '' && previous?.role === 'assistant' && answerText(previous.segments) === text) {
+            messages.value = messages.value.filter((item) => item.id !== previous.id);
+        }
+
+        await settleTurn(liveReply);
+    }
 };
 
 const sendMessage = async (): Promise<void> => {
@@ -288,8 +520,7 @@ const sendMessage = async (): Promise<void> => {
 
     draft.value = '';
     attachments.value = [];
-    isStreaming.value = true;
-    abortController = new AbortController();
+    beginTurn();
     await scrollToBottom();
 
     try {
@@ -306,7 +537,7 @@ const sendMessage = async (): Promise<void> => {
                 ...(conversationId.value ? { conversation_id: conversationId.value } : {}),
                 ...(attachmentIds.length > 0 ? { attachment_ids: attachmentIds } : {}),
             }),
-            signal: abortController.signal,
+            signal: abortController?.signal,
         });
 
         const contentType = response.headers.get('Content-Type') ?? '';
@@ -315,6 +546,10 @@ const sendMessage = async (): Promise<void> => {
             const serverMessage = await readJsonMessage(response);
 
             liveReply.failed = true;
+
+            // A pre-flight refusal never opened a turn, so there is nothing to
+            // resume or clean up beyond the bubble itself.
+            turnFinished = true;
 
             if (response.status === 503) {
                 markDisabled(serverMessage ?? undefined);
@@ -331,50 +566,63 @@ const sendMessage = async (): Promise<void> => {
         }
 
         if (!response.body) {
+            turnFinished = true;
             liveReply.failed = true;
             errorBanner.value = 'حدث خطأ أثناء قراءة الرد. حاول مرة أخرى.';
             return;
         }
 
-        await readSseStream(response, (event, data) => handleSseEvent(event, (data ?? {}) as Record<string, unknown>, liveReply), {
-            signal: abortController.signal,
-        });
+        await readTurn(response, liveReply);
     } catch (error) {
-        if ((error as Error).name !== 'AbortError') {
+        if ((error as Error).name === 'AbortError') {
+            return;
+        }
+
+        // The POST itself never got a stream open. If it managed to hand back
+        // a turn id first, the turn is running server-side and `followTurn`
+        // below picks it up; otherwise there is nothing to recover.
+        if (currentTurn === null) {
+            turnFinished = true;
             liveReply.failed = !hasText(liveReply);
             errorBanner.value = 'تعذر الاتصال بالخادم. تأكد من اتصالك ثم أعد المحاولة.';
         }
     } finally {
-        liveReply.streaming = false;
-
-        // Stopping the turn (or losing the connection) can leave a chip
-        // mid-flight; a spinner nothing will ever resolve is worse than no
-        // chip. Spliced in place: the timeline owns this array.
-        for (let index = liveReply.segments.length - 1; index >= 0; index--) {
-            const segment = liveReply.segments[index];
-
-            if (segment.type === 'tool' && segment.status === 'running') {
-                liveReply.segments.splice(index, 1);
-            }
-        }
-
-        if (liveReply.failed && !hasText(liveReply)) {
-            messages.value = messages.value.filter((item) => item.id !== liveReply.id);
-        }
-
-        isStreaming.value = false;
-        abortController = undefined;
-        await scrollToBottom();
+        // The POST's own stream ended. Unless the turn reached a terminal
+        // event, it is still generating server-side — reconnect and follow it
+        // rather than abandoning a reply that is still being written.
+        await followTurn(liveReply);
+        await settleTurn(liveReply);
     }
 };
 
-const stopStreaming = (): void => {
-    abortController?.abort();
+/**
+ * The visitor pressed stop. Generation runs server-side now, so hanging up
+ * would leave it running (and billing): tell the server first, then let the
+ * reader drain the terminal `done` the job writes on its way out. The abort
+ * is the fallback for a cancel request that never lands.
+ */
+const stopStreaming = async (): Promise<void> => {
+    const turn = currentTurn;
+
+    if (turn === null) {
+        abortController?.abort();
+        return;
+    }
+
+    try {
+        await fetch(cancelTurn.url(turn), {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'X-XSRF-TOKEN': xsrfToken(), Accept: 'application/json' },
+        });
+    } catch {
+        abortController?.abort();
+    }
 };
 
 const startNewConversation = (): void => {
     if (isStreaming.value) {
-        stopStreaming();
+        void stopStreaming();
     }
 
     sessionStorage.removeItem(CONVERSATION_STORAGE_KEY);
@@ -495,7 +743,11 @@ const citationUrl = (citation: Citation): string => showPage.url({ slug: citatio
 
 onMounted(() => {
     isCoarsePointer.value = window.matchMedia('(pointer: coarse)').matches;
-    void rehydrateConversation();
+
+    // Restore the thread first, then pick up whatever turn was still running
+    // when the page was left — in that order, so the resumed reply lands after
+    // the history it continues.
+    void rehydrateConversation().then(resumeActiveTurn);
 
     if (!isCoarsePointer.value) {
         focusComposer();

--- a/resources/js/pages/manage/assistant/Index.vue
+++ b/resources/js/pages/manage/assistant/Index.vue
@@ -3,7 +3,13 @@ import ManageLayout from '@/components/manage/ManageLayout.vue';
 import PageHeader from '@/components/manage/PageHeader.vue';
 import { asApprovalCard, isQuestionCard, type AssistantApprovalCard, type CardDecision } from '@/components/manage/assistant/types';
 import { Button } from '@/components/ui/button';
-import { decide as decideChat, send as sendChat, show as showConversation } from '@/routes/manage/assistant';
+import {
+    cancel as cancelTurn,
+    decide as decideChat,
+    send as sendChat,
+    show as showConversation,
+    stream as streamTurn,
+} from '@/routes/manage/assistant';
 import { Head, Link } from '@inertiajs/vue3';
 import type { AiKitCard, ClientDecision, QuestionPayload } from '@saad5400/ai-kit/events';
 import { readSseStream } from '@saad5400/ai-kit/sse';
@@ -34,8 +40,8 @@ import { computed, markRaw, nextTick, onBeforeUnmount, onMounted, reactive, ref,
 /**
  * The admin assistant chat: the operator copilot whose writes pause the turn
  * for approval. POST /manage/assistant/chat streams the reply as ai-kit SSE
- * frames — reasoning/delta/tool/approval/question/done/error, read with the
- * kit's `readSseStream` — the same transport as the public AssistantPage. A
+ * frames — turn/reasoning/delta/tool/approval/question/done/error, read with
+ * the kit's `readSseStream` — the same transport as the public AssistantPage. A
  * pause renders inline cards with تأكيد/رفض (or an answer box); once every
  * pending card is decided, the batch resumes the SAME turn via
  * POST /manage/assistant/chat/{conversation}/decide and the continuation
@@ -48,6 +54,23 @@ import { computed, markRaw, nextTick, onBeforeUnmount, onMounted, reactive, ref,
  * event is pushed through the timeline — it ignores the ones it does not own —
  * and `groupSegments` collapses thinking and tool runs into one disclosure
  * while text and decision cards stay top-level where they occurred.
+ *
+ * ── Resumable turns ── The reply is generated into a durable server-side
+ * buffer, so it survives the connection that asked for it. Every frame the
+ * server sends carries an `id:` — the buffer sequence number, handed to the
+ * reader's third argument — and re-issuing the last one as `?cursor=` is what
+ * makes a reconnect resume rather than replay. So a drop (a flaky link, the
+ * server's own stream ceiling) climbs a reconnect ladder against `stream`,
+ * and a page reload picks the turn back up from the id parked in
+ * sessionStorage. Seeing any frame forgives the previous drop, so a long
+ * turn never exhausts its retries.
+ *
+ * That matters most on this surface: a turn that paused for approval, or one
+ * whose approved writes are running, is exactly the turn an operator cannot
+ * afford to lose to a dropped connection.
+ *
+ * Because generation no longer rides the request, hanging up does not stop
+ * it: the stop button tells the SERVER to stop.
  *
  * Thinking and tool progress are live-only: the server never persists them,
  * so a rehydrated thread replays its stored text and repaints its pending
@@ -76,6 +99,10 @@ interface ChatMessage {
 }
 
 const CONVERSATION_STORAGE_KEY = 'manage-assistant-conversation-id';
+/** The turn still in flight when the page was left, so a reload can resume it. */
+const ACTIVE_TURN_STORAGE_KEY = 'manage-assistant-active-turn-id';
+/** Reconnect attempts before a turn is given up on — the ladder tops out at 8s a try. */
+const MAX_RECONNECTS = 8;
 const MAX_MESSAGE_LENGTH = 2000;
 
 /** First-open teaching prompts: what the assistant is actually for. */
@@ -116,6 +143,29 @@ let nextLocalId = 1;
 let abortController: AbortController | undefined;
 
 /**
+ * The turn currently being read, how far into its buffer this client has got,
+ * and whether it has reached a terminal event. `lastSeq` is the cursor every
+ * reconnect re-issues; `reconnects` is reset by any frame that lands, so
+ * progress forgives the drop that preceded it.
+ */
+let currentTurn: string | null = null;
+let lastSeq = 0;
+let reconnects = 0;
+let turnFinished = false;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Whether the admin has walked away from the turn currently being read. */
+const readAborted = (): boolean => abortController?.signal.aborted === true;
+
+/** The answer as plain text, for matching a replayed turn against a rehydrated one. */
+const answerText = (segments: Segment[]): string =>
+    segments
+        .filter((segment) => segment.type === 'text')
+        .map((segment) => segment.text)
+        .join('');
+
+/**
  * A message whose segment list is reactive and handed to the timeline, so
  * the reducer's in-place mutations re-render the bubble.
  */
@@ -150,6 +200,20 @@ const isBubbleEmpty = (message: ChatMessage): boolean => message.streaming === t
 
 const trackCard = (card: AiKitCard): void => {
     cardDecisions[card.id] ??= { status: 'pending', decision: null, answer: null };
+};
+
+/**
+ * Cards the server reported pending while a resumable turn was outstanding.
+ * They are drawn by that turn's replay, and only fall back to being drawn
+ * here if the replay never arrives.
+ */
+let deferredCards: AiKitCard[] = [];
+
+const paintCards = (target: ChatMessage, cards: AiKitCard[]): void => {
+    for (const card of cards) {
+        target.timeline.push(card.kind === 'question' ? 'question' : 'approval', card);
+        trackCard(card);
+    }
 };
 
 const trackedFor = (card: AiKitCard): CardDecision => cardDecisions[card.id] ?? { status: 'pending', decision: null, answer: null };
@@ -237,18 +301,23 @@ const rehydrateConversation = async (): Promise<void> => {
             });
 
         // A paused turn's undecided cards repaint on the last assistant
-        // bubble (a pause always ends the stored thread on one).
+        // bubble (a pause always ends the stored thread on one) — UNLESS that
+        // turn is still resumable, in which case its own replay paints them in
+        // the bubble they actually happened in. Holding them here rather than
+        // drawing them twice; `resumeActiveTurn` draws them after all if the
+        // replay never lands.
         if (payload.pending_approvals.length > 0) {
-            let target = [...messages.value].reverse().find((message) => message.role === 'assistant');
+            if (sessionStorage.getItem(ACTIVE_TURN_STORAGE_KEY)) {
+                deferredCards = payload.pending_approvals;
+            } else {
+                let target = [...messages.value].reverse().find((message) => message.role === 'assistant');
 
-            if (!target) {
-                target = newMessage('assistant');
-                messages.value.push(target);
-            }
+                if (!target) {
+                    target = newMessage('assistant');
+                    messages.value.push(target);
+                }
 
-            for (const card of payload.pending_approvals) {
-                target.timeline.push(card.kind === 'question' ? 'question' : 'approval', card);
-                trackCard(card);
+                paintCards(target, payload.pending_approvals);
             }
         }
 
@@ -260,9 +329,36 @@ const rehydrateConversation = async (): Promise<void> => {
     }
 };
 
-const handleSseEvent = (event: string, data: Record<string, unknown>, reply: ChatMessage): void => {
-    // Everything goes through the timeline, which ignores what it does not
-    // own — the app-specific events below are handled beside it, not instead.
+/**
+ * Fold one frame from the kit's reader.
+ *
+ * `id` is the buffer sequence number the frame was stored under; recording it
+ * is the whole of what makes the next reconnect resume instead of replay.
+ */
+const handleSseEvent = (event: string, data: Record<string, unknown>, reply: ChatMessage, id?: string): void => {
+    if (id !== undefined) {
+        const seq = Number.parseInt(id, 10);
+
+        if (!Number.isNaN(seq)) {
+            lastSeq = seq;
+            reconnects = 0;
+        }
+    }
+
+    // The turn handle, always the first frame. It is not a timeline event —
+    // it is the id a reconnect (or a reload) re-issues to find this turn again.
+    if (event === 'turn') {
+        if (typeof data.id === 'string' && data.id !== '') {
+            currentTurn = data.id;
+            sessionStorage.setItem(ACTIVE_TURN_STORAGE_KEY, data.id);
+        }
+
+        return;
+    }
+
+    // Everything else goes through the timeline, which ignores what it does
+    // not own — the app-specific events below are handled beside it, not
+    // instead.
     reply.timeline.push(event, data);
 
     if (event === 'approval' || event === 'question') {
@@ -270,16 +366,145 @@ const handleSseEvent = (event: string, data: Record<string, unknown>, reply: Cha
             trackCard(data as unknown as AiKitCard);
         }
     } else if (event === 'done') {
+        // `done` and `error` are each terminal on their own (the kit's buffer
+        // contract): one or the other ends the turn, never both, so reaching
+        // either means there is nothing left to reconnect for.
+        turnFinished = true;
+
         if (typeof data.conversation_id === 'string' && data.conversation_id !== '') {
             conversationId.value = data.conversation_id;
             sessionStorage.setItem(CONVERSATION_STORAGE_KEY, data.conversation_id);
         }
     } else if (event === 'error') {
+        turnFinished = true;
         reply.failed = true;
         errorBanner.value = typeof data.message === 'string' ? data.message : 'حدث خطأ أثناء توليد الرد. حاول مرة أخرى.';
     }
 
     void scrollToBottom();
+};
+
+/** Read one SSE response to its end, folding every frame into the live reply. */
+const readTurn = async (response: Response, reply: ChatMessage): Promise<void> => {
+    await readSseStream(response, (event, data, id) => handleSseEvent(event, (data ?? {}) as Record<string, unknown>, reply, id), {
+        signal: abortController?.signal,
+    });
+};
+
+/**
+ * Keep reading the current turn across drops until it reaches a terminal
+ * event or the ladder runs out.
+ *
+ * A read ends three ways: the turn finished (nothing more to do), the server
+ * hit its own stream ceiling and hung up mid-turn, or the connection broke.
+ * The last two are the same thing to this loop — wait out the backoff and
+ * re-issue `?cursor=lastSeq`, so the server replays only what was missed.
+ * Only an abort — the admin leaving the page — returns without reconnecting,
+ * and it deliberately leaves the resume handle behind for the next load.
+ *
+ * `immediate` skips the first backoff, for a turn being picked up from
+ * storage rather than recovered from a drop.
+ */
+const followTurn = async (reply: ChatMessage, immediate = false): Promise<void> => {
+    let first = immediate;
+
+    while (!turnFinished && currentTurn !== null && !readAborted()) {
+        if (!first) {
+            if (reconnects >= MAX_RECONNECTS) {
+                turnFinished = true;
+                reply.failed = !hasText(reply) && !hasCard(reply);
+                errorBanner.value = 'انقطع الاتصال بالمساعد. حاول مرة أخرى.';
+
+                return;
+            }
+
+            reconnects++;
+            await sleep(Math.min(1000 * 2 ** (reconnects - 1), 8000));
+
+            if (readAborted()) {
+                return;
+            }
+        }
+
+        first = false;
+
+        try {
+            const response = await fetch(`${streamTurn.url(currentTurn)}?cursor=${lastSeq}`, {
+                credentials: 'same-origin',
+                headers: { Accept: 'text/event-stream' },
+                signal: abortController?.signal,
+            });
+
+            if (response.status === 404) {
+                // The buffer expired, or never belonged to this admin: there is
+                // no turn to resume, so stop rather than climb the ladder. Any
+                // cards it left pending survive on the conversation and repaint
+                // on the next rehydrate.
+                turnFinished = true;
+                reply.failed = !hasText(reply) && !hasCard(reply);
+                errorBanner.value = 'انتهت صلاحية هذا الرد. أعد إرسال طلبك.';
+
+                return;
+            }
+
+            if (!response.ok || !response.body) {
+                continue;
+            }
+
+            await readTurn(response, reply);
+        } catch (error) {
+            if ((error as Error).name === 'AbortError') {
+                return;
+            }
+        }
+    }
+};
+
+/**
+ * Settle a turn that is no longer being read: clear the live flags and drop
+ * chips nothing will ever resolve.
+ *
+ * The resume handle is forgotten only for a turn that actually ENDED — one
+ * that reached `done` / `error`, expired, or exhausted its retries. A read
+ * that stopped because the admin navigated away leaves it in place on
+ * purpose: that is precisely the turn the next page load should pick up.
+ */
+const settleTurn = async (reply: ChatMessage): Promise<void> => {
+    reply.streaming = false;
+
+    // Stopping the turn (or losing the connection for good) can leave a chip
+    // mid-flight; a spinner nothing will ever resolve is worse than no chip.
+    // Spliced in place: the timeline owns this array.
+    for (let index = reply.segments.length - 1; index >= 0; index--) {
+        const segment = reply.segments[index];
+
+        if (segment.type === 'tool' && segment.status === 'running') {
+            reply.segments.splice(index, 1);
+        }
+    }
+
+    if (reply.failed && !hasText(reply) && !hasCard(reply)) {
+        messages.value = messages.value.filter((item) => item.id !== reply.id);
+    }
+
+    if (turnFinished) {
+        sessionStorage.removeItem(ACTIVE_TURN_STORAGE_KEY);
+        currentTurn = null;
+    }
+
+    isStreaming.value = false;
+    abortController = undefined;
+    await scrollToBottom();
+};
+
+/** Reset the per-turn transport state before a fresh turn is read. */
+const beginTurn = (): void => {
+    currentTurn = null;
+    lastSeq = 0;
+    reconnects = 0;
+    turnFinished = false;
+    isStreaming.value = true;
+    abortController = new AbortController();
 };
 
 /**
@@ -288,8 +513,7 @@ const handleSseEvent = (event: string, data: Record<string, unknown>, reply: Cha
  * stream contract.
  */
 const streamInto = async (url: string, body: Record<string, unknown>, liveReply: ChatMessage): Promise<void> => {
-    isStreaming.value = true;
-    abortController = new AbortController();
+    beginTurn();
     await scrollToBottom();
 
     try {
@@ -302,7 +526,7 @@ const streamInto = async (url: string, body: Record<string, unknown>, liveReply:
                 Accept: 'text/event-stream',
             },
             body: JSON.stringify(body),
-            signal: abortController.signal,
+            signal: abortController?.signal,
         });
 
         const contentType = response.headers.get('Content-Type') ?? '';
@@ -310,6 +534,9 @@ const streamInto = async (url: string, body: Record<string, unknown>, liveReply:
         if (!contentType.includes('text/event-stream')) {
             const serverMessage = await readJsonMessage(response);
 
+            // A refusal (429 burst, 409 stale cards, 422 bad payload, 503
+            // disabled) never opened a turn, so there is nothing to resume.
+            turnFinished = true;
             liveReply.failed = true;
 
             if (response.status === 429) {
@@ -322,40 +549,32 @@ const streamInto = async (url: string, body: Record<string, unknown>, liveReply:
         }
 
         if (!response.body) {
+            turnFinished = true;
             liveReply.failed = true;
             errorBanner.value = 'حدث خطأ أثناء قراءة الرد. حاول مرة أخرى.';
             return;
         }
 
-        await readSseStream(response, (event, data) => handleSseEvent(event, (data ?? {}) as Record<string, unknown>, liveReply), {
-            signal: abortController.signal,
-        });
+        await readTurn(response, liveReply);
     } catch (error) {
-        if ((error as Error).name !== 'AbortError') {
-            liveReply.failed = !hasText(liveReply);
+        if ((error as Error).name === 'AbortError') {
+            return;
+        }
+
+        // The POST itself never got a stream open. If it managed to hand back
+        // a turn id first, the turn is running server-side and `followTurn`
+        // below picks it up; otherwise there is nothing to recover.
+        if (currentTurn === null) {
+            turnFinished = true;
+            liveReply.failed = !hasText(liveReply) && !hasCard(liveReply);
             errorBanner.value = 'تعذر الاتصال بالخادم. تأكد من اتصالك ثم أعد المحاولة.';
         }
     } finally {
-        liveReply.streaming = false;
-
-        // Stopping the turn (or losing the connection) can leave a chip
-        // mid-flight; a spinner nothing will ever resolve is worse than no
-        // chip. Spliced in place: the timeline owns this array.
-        for (let index = liveReply.segments.length - 1; index >= 0; index--) {
-            const segment = liveReply.segments[index];
-
-            if (segment.type === 'tool' && segment.status === 'running') {
-                liveReply.segments.splice(index, 1);
-            }
-        }
-
-        if (liveReply.failed && !hasText(liveReply) && !hasCard(liveReply)) {
-            messages.value = messages.value.filter((item) => item.id !== liveReply.id);
-        }
-
-        isStreaming.value = false;
-        abortController = undefined;
-        await scrollToBottom();
+        // The POST's own stream ended. Unless the turn reached a terminal
+        // event, it is still generating server-side — reconnect and follow it
+        // rather than abandoning a turn whose writes may still be running.
+        await followTurn(liveReply);
+        await settleTurn(liveReply);
     }
 };
 
@@ -424,13 +643,34 @@ const onQuestionAnswer = (card: QuestionPayload, answer: string): void => {
     void onCardDecision(card, { action: 'edit', arguments: { answer } }, answer);
 };
 
-const stopStreaming = (): void => {
-    abortController?.abort();
+/**
+ * The admin pressed stop. Generation runs server-side now, so hanging up
+ * would leave it running (and writing): tell the server first, then let the
+ * reader drain the terminal `done` the job writes on its way out. The abort
+ * is the fallback for a cancel request that never lands.
+ */
+const stopStreaming = async (): Promise<void> => {
+    const turn = currentTurn;
+
+    if (turn === null) {
+        abortController?.abort();
+        return;
+    }
+
+    try {
+        await fetch(cancelTurn.url(turn), {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'X-XSRF-TOKEN': xsrfToken(), Accept: 'application/json' },
+        });
+    } catch {
+        abortController?.abort();
+    }
 };
 
 const startNewConversation = (): void => {
     if (isStreaming.value) {
-        stopStreaming();
+        void stopStreaming();
     }
 
     sessionStorage.removeItem(CONVERSATION_STORAGE_KEY);
@@ -452,8 +692,56 @@ const onComposerKeydown = (event: KeyboardEvent): void => {
     }
 };
 
+/**
+ * Pick a turn left running when the page was closed back up, replaying it
+ * from the start of its buffer. A turn that finished after the tab went away
+ * was persisted in the meantime, so the rehydrated thread already ends with
+ * its answer — the replay would duplicate it, and the settle below drops the
+ * older copy in favour of the richer replayed one.
+ */
+const resumeActiveTurn = async (): Promise<void> => {
+    const storedTurn = sessionStorage.getItem(ACTIVE_TURN_STORAGE_KEY);
+
+    if (!storedTurn || !props.assistant.enabled) {
+        return;
+    }
+
+    beginTurn();
+    // Cursor 0 — a restored turn has seen nothing of this buffer yet, so the
+    // replay rebuilds the bubble from its first frame.
+    currentTurn = storedTurn;
+
+    messages.value.push(newReply());
+    const liveReply = messages.value[messages.value.length - 1];
+
+    try {
+        await followTurn(liveReply, true);
+    } finally {
+        const text = answerText(liveReply.segments);
+        const previous = messages.value[messages.value.indexOf(liveReply) - 1];
+
+        if (text !== '' && previous?.role === 'assistant' && answerText(previous.segments) === text) {
+            messages.value = messages.value.filter((item) => item.id !== previous.id);
+        }
+
+        // The replay never reached the pause (an expired buffer, an exhausted
+        // ladder): draw the server's pending cards after all, so an operator
+        // is never left with a paused conversation and nothing to decide.
+        if (deferredCards.length > 0 && !hasCard(liveReply)) {
+            paintCards(liveReply, deferredCards);
+        }
+
+        deferredCards = [];
+
+        await settleTurn(liveReply);
+    }
+};
+
 onMounted(() => {
-    void rehydrateConversation();
+    // Restore the thread first, then pick up whatever turn was still running
+    // when the page was left — in that order, so the resumed reply lands after
+    // the history it continues, and after its cards were repainted.
+    void rehydrateConversation().then(resumeActiveTurn);
     draftInput.value?.focus();
 });
 

--- a/routes/manage.php
+++ b/routes/manage.php
@@ -55,6 +55,13 @@ Route::prefix('manage')->name('manage.')->group(function () {
         Route::get('/assistant/chat/{conversation}', [AdminAssistantController::class, 'show'])->name('assistant.show');
         Route::post('/assistant/chat/{conversation}/decide', [AdminAssistantController::class, 'decide'])->middleware('throttle:15,1')->name('assistant.decide');
 
+        // Resuming or stopping a turn already under way: both read the turn
+        // buffer rather than opening one, so neither carries the per-admin
+        // burst limiter — a reconnect ladder must not be throttled into
+        // silence, and neither endpoint can spend anything.
+        Route::get('/assistant/turns/{turn}/stream', [AdminAssistantController::class, 'stream'])->name('assistant.stream');
+        Route::post('/assistant/turns/{turn}/cancel', [AdminAssistantController::class, 'cancel'])->name('assistant.cancel');
+
         Route::get('/corpus', [CorpusDocumentController::class, 'index'])->name('corpus.index');
         Route::post('/corpus', [CorpusDocumentController::class, 'store'])->name('corpus.store');
         Route::post('/corpus/text', [CorpusDocumentController::class, 'storeText'])->name('corpus.store-text');

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,16 +55,28 @@ Route::get('/mstnd/{document}', App\Http\Controllers\CorpusDocumentFileControlle
 Route::middleware('throttle:ai-chat')->group(function () {
     Route::post('/ai/chat', [ChatController::class, 'send'])->name('ai.chat.send');
     Route::post('/ai/chat/attachments', ChatAttachmentController::class)->name('ai.chat.attachments.store');
-
-    // Resuming or stopping a turn the visitor already paid for: both read the
-    // turn buffer rather than opening one, so neither spends a daily quota
-    // slot. They live under /ai/chat/turns/… so the single-segment
-    // {conversation} route below can never swallow them.
-    Route::get('/ai/chat/turns/{turn}/stream', [ChatController::class, 'stream'])->name('ai.chat.stream');
-    Route::post('/ai/chat/turns/{turn}/cancel', [ChatController::class, 'cancel'])->name('ai.chat.cancel');
-
     Route::get('/ai/chat/{conversation}', [ChatController::class, 'show'])->name('ai.chat.show');
 });
+
+// Resuming or stopping a turn the visitor ALREADY paid for, deliberately
+// OUTSIDE the burst limiter above.
+//
+// `ai-chat` is 5 requests per minute per session, and a single long turn can
+// need several of them: the opening POST, then one reconnect every time the
+// kit's tail closes at its `max_stream_seconds` ceiling, plus a stop. Counting
+// those against the same five would 429 the reconnect ladder — which strands a
+// turn that has already been generated and charged for, the exact failure
+// resumability exists to prevent. The manage-side pair is excluded for the
+// same reason.
+//
+// Nothing is given away by excluding them: both read the turn buffer instead of
+// opening a turn, so they spend no model call, no daily quota slot and no
+// budget, and both 404 anything the visitor's own session does not own. The
+// `/ai/chat/turns/…` prefix is what keeps the single-segment {conversation}
+// route from swallowing them — never the group, which has no bearing on
+// matching.
+Route::get('/ai/chat/turns/{turn}/stream', [ChatController::class, 'stream'])->name('ai.chat.stream');
+Route::post('/ai/chat/turns/{turn}/cancel', [ChatController::class, 'cancel'])->name('ai.chat.cancel');
 
 // AI assistant chat page (must come before catch-all route) - with response caching.
 // Always renders; the chat endpoints report the disabled state at runtime.

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,6 +55,14 @@ Route::get('/mstnd/{document}', App\Http\Controllers\CorpusDocumentFileControlle
 Route::middleware('throttle:ai-chat')->group(function () {
     Route::post('/ai/chat', [ChatController::class, 'send'])->name('ai.chat.send');
     Route::post('/ai/chat/attachments', ChatAttachmentController::class)->name('ai.chat.attachments.store');
+
+    // Resuming or stopping a turn the visitor already paid for: both read the
+    // turn buffer rather than opening one, so neither spends a daily quota
+    // slot. They live under /ai/chat/turns/… so the single-segment
+    // {conversation} route below can never swallow them.
+    Route::get('/ai/chat/turns/{turn}/stream', [ChatController::class, 'stream'])->name('ai.chat.stream');
+    Route::post('/ai/chat/turns/{turn}/cancel', [ChatController::class, 'cancel'])->name('ai.chat.cancel');
+
     Route::get('/ai/chat/{conversation}', [ChatController::class, 'show'])->name('ai.chat.show');
 });
 

--- a/tests/Feature/Ai/Chat/ChatEndpointTest.php
+++ b/tests/Feature/Ai/Chat/ChatEndpointTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Ai\Agents\StudentAssistant;
+use App\Ai\Chat\CitationExtractor;
+use App\Jobs\Ai\GenerateChatReply;
 use App\Models\Ai\ChatAttachment;
 use App\Models\Page;
 use App\Settings\AiSettings;
@@ -10,6 +12,7 @@ use Laravel\Ai\Models\ConversationMessage;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Saad\AiKit\Safety\BudgetGuard;
 use Saad\AiKit\Safety\KillSwitch;
+use Saad\AiKit\Streaming\TurnBuffer;
 use Saad\AiKit\Usage\UsageEvent;
 
 beforeEach(function () {
@@ -540,4 +543,166 @@ it('returns the visitor their own message, not the evidence wrapped around it', 
         ->json('messages');
 
     expect($messages[0]['content'])->toBe('وش أفضل تخصص؟');
+});
+
+/*
+|--------------------------------------------------------------------------
+| Resumable turns (ai-kit TurnBuffer)
+|--------------------------------------------------------------------------
+|
+| The reply is folded into a durable buffer by a queued job; the SSE
+| endpoints only tail it. What these pin is the resume contract: the turn
+| handle the client stores, the `id:` lines that are the cursor, replay from
+| a cursor, ownership on both new endpoints, and cancellation.
+|
+*/
+
+/** The reply as the client would assemble it, across however many deltas it took. */
+function sseDeltaText(string $content): string
+{
+    preg_match_all("/^event: delta\ndata: (.+)$/m", $content, $matches);
+
+    return implode('', array_map(
+        fn (string $data): string => (string) (json_decode($data, true)['text'] ?? ''),
+        $matches[1],
+    ));
+}
+
+/** Every SSE frame in the content, as [seq, event] pairs. */
+function sseFrames(string $content): array
+{
+    preg_match_all("/^id: (\d+)\nevent: (\S+)$/m", $content, $matches, PREG_SET_ORDER);
+
+    return array_map(fn (array $match): array => [(int) $match[1], $match[2]], $matches);
+}
+
+it('opens the stream with a turn handle and numbers every frame for resuming', function () {
+    StudentAssistant::fake(['أهلاً بك.']);
+
+    $content = withChatSession(chatSessionId())
+        ->post(route('ai.chat.send'), ['message' => 'مرحبا'])
+        ->assertOk()
+        ->streamedContent();
+
+    $frames = sseFrames($content);
+    $turn = sseEventData($content, 'turn');
+
+    // The handle is the FIRST frame — a client that drops immediately still
+    // knows which turn to reconnect to.
+    expect($frames[0][1])->toBe('turn')
+        ->and($turn['id'])->not->toBeEmpty()
+        ->and(app(TurnBuffer::class)->get($turn['id']))->not->toBeNull();
+
+    // Sequence numbers are dense and ascending: they ARE the cursor.
+    expect(array_column($frames, 0))->toBe(range(1, count($frames)))
+        ->and(collect($frames)->pluck(1))->toContain('delta', 'done');
+});
+
+it('replays only the frames after the cursor a client resumes at', function () {
+    StudentAssistant::fake(['أهلاً بك.']);
+
+    $sessionId = chatSessionId();
+
+    $first = withChatSession($sessionId)
+        ->post(route('ai.chat.send'), ['message' => 'مرحبا'])
+        ->streamedContent();
+
+    $turnId = sseEventData($first, 'turn')['id'];
+    $frames = sseFrames($first);
+    $lastSeq = end($frames)[0];
+
+    // Resuming where the first read stopped yields nothing new...
+    $drained = withChatSession($sessionId)
+        ->get(route('ai.chat.stream', ['turn' => $turnId, 'cursor' => $lastSeq]))
+        ->assertOk()
+        ->streamedContent();
+
+    expect(sseFrames($drained))->toBeEmpty();
+
+    // ...while resuming from the handle replays the reply itself, and only it.
+    $resumed = withChatSession($sessionId)
+        ->get(route('ai.chat.stream', ['turn' => $turnId, 'cursor' => 1]))
+        ->assertOk()
+        ->streamedContent();
+
+    expect($resumed)->not->toContain('event: turn')
+        ->and(sseDeltaText($resumed))->toBe('أهلاً بك.')
+        ->and(sseEventData($resumed, 'done'))->not->toBeNull();
+});
+
+it('resumes from Last-Event-ID when the client sends no cursor', function () {
+    StudentAssistant::fake(['أهلاً بك.']);
+
+    $sessionId = chatSessionId();
+
+    $first = withChatSession($sessionId)
+        ->post(route('ai.chat.send'), ['message' => 'مرحبا'])
+        ->streamedContent();
+
+    $turnId = sseEventData($first, 'turn')['id'];
+    $frames = sseFrames($first);
+    $lastSeq = end($frames)[0];
+
+    $resumed = withChatSession($sessionId)
+        ->withHeader('Last-Event-ID', (string) $lastSeq)
+        ->get(route('ai.chat.stream', ['turn' => $turnId]))
+        ->assertOk()
+        ->streamedContent();
+
+    expect(sseFrames($resumed))->toBeEmpty();
+});
+
+it('answers 404 on a turn belonging to another session, and on an unknown one', function () {
+    StudentAssistant::fake(['أهلاً بك.']);
+
+    $turnId = sseEventData(
+        withChatSession(chatSessionId())->post(route('ai.chat.send'), ['message' => 'مرحبا'])->streamedContent(),
+        'turn',
+    )['id'];
+
+    withChatSession(chatSessionId())->get(route('ai.chat.stream', ['turn' => $turnId]))->assertNotFound();
+    withChatSession(chatSessionId())->post(route('ai.chat.cancel', ['turn' => $turnId]))->assertNotFound();
+    withChatSession(chatSessionId())->get(route('ai.chat.stream', ['turn' => (string) Str::uuid7()]))->assertNotFound();
+});
+
+it('flags a turn cancelled for its own session', function () {
+    StudentAssistant::fake(['أهلاً بك.']);
+
+    $sessionId = chatSessionId();
+
+    $turnId = sseEventData(
+        withChatSession($sessionId)->post(route('ai.chat.send'), ['message' => 'مرحبا'])->streamedContent(),
+        'turn',
+    )['id'];
+
+    expect(app(TurnBuffer::class)->isCancelled($turnId))->toBeFalse();
+
+    withChatSession($sessionId)
+        ->post(route('ai.chat.cancel', ['turn' => $turnId]))
+        ->assertOk()
+        ->assertJson(['cancelled' => true]);
+
+    expect(app(TurnBuffer::class)->isCancelled($turnId))->toBeTrue();
+});
+
+it('fails a queued turn without calling the model when the kill switch engaged after it was queued', function () {
+    StudentAssistant::fake(['لن يصل هذا الرد أبداً.']);
+
+    $buffer = app(TurnBuffer::class);
+    $turnId = (string) Str::uuid7();
+
+    $buffer->start($turnId, ['session_id' => 'session-under-test']);
+
+    // Engaged AFTER the turn entered the queue: the job is where the money
+    // would actually be spent, so that is where the switch has to bite.
+    app(KillSwitch::class)->engage();
+
+    (new GenerateChatReply(turnId: $turnId, sessionId: 'session-under-test', prompt: 'مرحبا'))
+        ->handle($buffer, app(KillSwitch::class), app(CitationExtractor::class));
+
+    $record = $buffer->get($turnId);
+
+    expect($record['status'])->toBe('failed')
+        ->and(collect($record['events'])->pluck('event')->all())->toBe(['error'])
+        ->and(Conversation::query()->count())->toBe(0);
 });

--- a/tests/Feature/Ai/Chat/ChatEndpointTest.php
+++ b/tests/Feature/Ai/Chat/ChatEndpointTest.php
@@ -706,3 +706,41 @@ it('fails a queued turn without calling the model when the kill switch engaged a
         ->and(collect($record['events'])->pluck('event')->all())->toBe(['error'])
         ->and(Conversation::query()->count())->toBe(0);
 });
+
+it('lets a dropped client resume and stop even once the burst limiter is exhausted', function () {
+    StudentAssistant::fake(fn () => 'رد.');
+
+    $sessionId = chatSessionId();
+
+    $turnId = sseEventData(
+        withChatSession($sessionId)->post(route('ai.chat.send'), ['message' => 'مرحبا'])->streamedContent(),
+        'turn',
+    )['id'];
+
+    // Spend the rest of the 5-per-minute burst budget, then prove it really is
+    // spent: a sixth NEW turn is refused.
+    foreach (range(2, 5) as $index) {
+        withChatSession($sessionId)
+            ->post(route('ai.chat.send'), ['message' => "رسالة {$index}"])
+            ->streamedContent();
+    }
+
+    withChatSession($sessionId)
+        ->postJson(route('ai.chat.send'), ['message' => 'السادسة'])
+        ->assertTooManyRequests();
+
+    // The reconnect ladder still gets through. One long turn can need several
+    // reconnects (the kit's tail closes at its ceiling and the client re-issues
+    // its cursor), so counting them against the same five would 429 a client
+    // back into exactly the lost reply resumability exists to prevent — for a
+    // turn already generated and charged.
+    withChatSession($sessionId)
+        ->get(route('ai.chat.stream', ['turn' => $turnId, 'cursor' => 1]))
+        ->assertOk();
+
+    // And so does the stop, which is the only way to end a queued turn early
+    // now that hanging up does not.
+    withChatSession($sessionId)
+        ->post(route('ai.chat.cancel', ['turn' => $turnId]))
+        ->assertOk();
+});

--- a/tests/Feature/Ai/Chat/ChatEndpointTest.php
+++ b/tests/Feature/Ai/Chat/ChatEndpointTest.php
@@ -6,6 +6,7 @@ use App\Jobs\Ai\GenerateChatReply;
 use App\Models\Ai\ChatAttachment;
 use App\Models\Page;
 use App\Settings\AiSettings;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Str;
 use Laravel\Ai\Models\Conversation;
 use Laravel\Ai\Models\ConversationMessage;
@@ -743,4 +744,26 @@ it('lets a dropped client resume and stop even once the burst limiter is exhaust
     withChatSession($sessionId)
         ->post(route('ai.chat.cancel', ['turn' => $turnId]))
         ->assertOk();
+});
+
+/*
+ * A turn must not land on `default` (one worker, no --timeout, so turns
+ * serialize behind each other and are killed at 60s) nor on `ai` (multi-minute
+ * corpus extraction and ingestion, which an interactive reply would wait
+ * behind). nixpacks.toml's `worker-ai-chat` is the other half of this pairing;
+ * the queue NAME is the whole contract between config and worker topology, so
+ * it is worth a test on each surface.
+ *
+ * The streamed body is deliberately NOT rendered: with the queue faked the turn
+ * never completes, so tailing its buffer would block until the kit's stream
+ * deadline. Only the dispatch is under test here.
+ */
+it('dispatches student assistant turns onto the dedicated ai-chat queue', function () {
+    Queue::fake();
+
+    withChatSession(chatSessionId())
+        ->post(route('ai.chat.send'), ['message' => 'مرحبا'])
+        ->assertOk();
+
+    Queue::assertPushedOn('ai-chat', GenerateChatReply::class);
 });

--- a/tests/Feature/Manage/AdminAssistantTest.php
+++ b/tests/Feature/Manage/AdminAssistantTest.php
@@ -14,6 +14,7 @@ use Database\Seeders\RolesAndPermissionsSeeder;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Str;
 use Inertia\Testing\AssertableInertia as Assert;
 use Laravel\Ai\Models\Conversation;
@@ -921,6 +922,25 @@ describe('resumable turns', function () {
         $this->actingAs($other)->get(route('manage.assistant.stream', ['turn' => $turnId]))->assertNotFound();
         $this->actingAs($other)->post(route('manage.assistant.cancel', ['turn' => $turnId]))->assertNotFound();
         $this->actingAs($this->admin)->get(route('manage.assistant.stream', ['turn' => (string) Str::uuid7()]))->assertNotFound();
+    });
+
+    it('dispatches the turn onto the dedicated ai-chat queue', function () {
+        // Not `default` (one worker, no --timeout: turns serialize behind each
+        // other and are killed at 60s) and not `ai` (multi-minute corpus
+        // extraction an interactive reply would wait behind). nixpacks.toml's
+        // `worker-ai-chat` is the other half of this pairing, and the queue NAME
+        // is the whole contract between config and worker topology.
+        //
+        // The streamed body is deliberately NOT rendered: with the queue faked
+        // the turn never completes, so tailing its buffer would block until the
+        // kit's stream deadline. Only the dispatch is under test.
+        Queue::fake();
+
+        $this->actingAs($this->admin)
+            ->post(route('manage.assistant.send'), ['message' => 'مرحبا'])
+            ->assertOk();
+
+        Queue::assertPushedOn('ai-chat', GenerateAdminAssistantReply::class);
     });
 
     it('fails a queued turn without calling the model when the kill switch engaged after it was queued', function () {

--- a/tests/Feature/Manage/AdminAssistantTest.php
+++ b/tests/Feature/Manage/AdminAssistantTest.php
@@ -4,6 +4,7 @@ use App\Ai\Admin\Actions\AssistantActionTool;
 use App\Ai\Admin\Actions\Settings\GetSettingsAction;
 use App\Ai\Admin\AdminAssistant;
 use App\Ai\Admin\SettingsRegistry;
+use App\Jobs\Ai\GenerateAdminAssistantReply;
 use App\Models\Page;
 use App\Models\PrivateTutor\PrivateTutor;
 use App\Models\User;
@@ -22,6 +23,7 @@ use Laravel\Ai\Tools\Request as ToolRequest;
 use Saad\AiKit\Approvals\Classified\StoredApprovals;
 use Saad\AiKit\Safety\BudgetGuard;
 use Saad\AiKit\Safety\KillSwitch;
+use Saad\AiKit\Streaming\TurnBuffer;
 use Saad\AiKit\Usage\UsageEvent;
 use Tests\Support\OpenRouterSse;
 
@@ -812,5 +814,132 @@ describe('settings introspection', function () {
             ->and($registry->isSecretKey('chat_model'))->toBeFalse()
             ->and($registry->mask('1234567890:AAxxYYzz'))->toBe('••••YYzz')
             ->and($registry->mask('abc'))->toBe('••••');
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| Resumable turns (ai-kit TurnBuffer)
+|--------------------------------------------------------------------------
+|
+| Both entry points — a fresh prompt and a decided resume — now open a
+| durable buffer, queue the generation and tail it. What these pin is that
+| the panel's contract survived that move (same POST, same events, same
+| refusals) and that the resume contract holds where it matters most: a turn
+| that paused for approval, and one whose approved write is running.
+|
+*/
+
+describe('resumable turns', function () {
+    /** Every SSE frame in the content, as [seq, event] pairs. */
+    $frames = function (string $content): array {
+        preg_match_all("/^id: (\d+)\nevent: (\S+)$/m", $content, $matches, PREG_SET_ORDER);
+
+        return array_map(fn (array $match): array => [(int) $match[1], $match[2]], $matches);
+    };
+
+    it('opens the stream with a turn handle and numbers every frame', function () use ($frames) {
+        AdminAssistant::fake(['تم.']);
+
+        $content = $this->actingAs($this->admin)
+            ->post(route('manage.assistant.send'), ['message' => 'مرحبا'])
+            ->assertOk()
+            ->streamedContent();
+
+        $seen = $frames($content);
+
+        expect($seen[0][1])->toBe('turn')
+            ->and(adminSseEventData($content, 'turn')['id'])->not->toBeEmpty()
+            ->and(array_column($seen, 0))->toBe(range(1, count($seen)));
+    });
+
+    it('replays a paused turn — cards and all — to a client that reconnects', function () {
+        // A pause is exactly the turn an operator cannot afford to lose to a
+        // dropped connection, so it is the one the replay has to reproduce.
+        $page = Page::factory()->create(['title' => 'قديم']);
+
+        AdminAssistant::fake([
+            new ToolCall('tc_1', 'manage_page_structure', ['action' => 'rename', 'page_id' => $page->id, 'title' => 'جديد']),
+        ]);
+
+        [, $content] = pauseTurnOn($this->admin, new ToolCall('tc_1', 'manage_page_structure', []));
+
+        $turnId = adminSseEventData($content, 'turn')['id'];
+        $card = adminSseEventData($content, 'approval');
+
+        expect($card)->not->toBeNull();
+
+        $resumed = $this->actingAs($this->admin)
+            ->get(route('manage.assistant.stream', ['turn' => $turnId, 'cursor' => 1]))
+            ->assertOk()
+            ->streamedContent();
+
+        // Same card, same id — the client re-renders the decision it was about
+        // to make rather than losing it.
+        expect(adminSseEventData($resumed, 'approval'))->toBe($card)
+            ->and(adminSseEventData($resumed, 'done'))->not->toBeNull();
+    });
+
+    it('keeps the decide endpoint answering as SSE, with the resume on its own turn', function () use ($frames) {
+        $page = Page::factory()->create(['title' => 'قديم']);
+
+        fakeOpenRouter([
+            OpenRouterSse::toolCallBody('tc_1', 'manage_page_structure', ['action' => 'rename', 'page_id' => $page->id, 'title' => 'جديد']),
+            OpenRouterSse::textBody('نفّذت إعادة التسمية.'),
+        ]);
+
+        [$conversationId, $content] = pauseTurnOn($this->admin, new ToolCall('tc_1', 'manage_page_structure', []));
+
+        $pausedTurn = adminSseEventData($content, 'turn')['id'];
+
+        $resumeContent = $this->actingAs($this->admin)
+            ->post(route('manage.assistant.decide', $conversationId), ['decisions' => ['tc_1' => 'approve']])
+            ->assertOk()
+            ->streamedContent();
+
+        $resumeTurn = adminSseEventData($resumeContent, 'turn')['id'];
+
+        // A resume is its own turn — separately resumable, and numbered from 1
+        // like any other, so the client's cursor bookkeeping needs no special
+        // case for it. The write still lands.
+        expect($resumeTurn)->not->toBe($pausedTurn)
+            ->and(array_column($frames($resumeContent), 0))->toBe(range(1, count($frames($resumeContent))))
+            ->and($page->refresh()->title)->toBe('جديد');
+    });
+
+    it('answers 404 on another admin\'s turn, and on an unknown one', function () {
+        AdminAssistant::fake(['تم.']);
+
+        $turnId = adminSseEventData(
+            $this->actingAs($this->admin)->post(route('manage.assistant.send'), ['message' => 'مرحبا'])->streamedContent(),
+            'turn',
+        )['id'];
+
+        $other = User::factory()->create();
+        $other->assignRole('admin');
+
+        $this->actingAs($other)->get(route('manage.assistant.stream', ['turn' => $turnId]))->assertNotFound();
+        $this->actingAs($other)->post(route('manage.assistant.cancel', ['turn' => $turnId]))->assertNotFound();
+        $this->actingAs($this->admin)->get(route('manage.assistant.stream', ['turn' => (string) Str::uuid7()]))->assertNotFound();
+    });
+
+    it('fails a queued turn without calling the model when the kill switch engaged after it was queued', function () {
+        AdminAssistant::fake(['لن يصل هذا الرد أبداً.']);
+
+        $buffer = app(TurnBuffer::class);
+        $turnId = (string) Str::uuid7();
+
+        $buffer->start($turnId, ['admin_id' => (int) $this->admin->id]);
+
+        app(KillSwitch::class)->engage();
+
+        (new GenerateAdminAssistantReply(turnId: $turnId, adminId: (int) $this->admin->id, prompt: 'مرحبا'))
+            ->handle($buffer, app(KillSwitch::class));
+
+        $record = $buffer->get($turnId);
+
+        expect($record['status'])->toBe('failed')
+            ->and(collect($record['events'])->pluck('event')->all())->toBe(['error'])
+            ->and(Conversation::query()->count())->toBe(0);
     });
 });


### PR DESCRIPTION
Two parts: the shared kit moves onto the 0.7 line, and both of uqucc's chat surfaces adopt the kit's `TurnBuffer` so an assistant turn survives the connection that asked for it.

> **This repo auto-deploys on merge to `main`.** Please review and merge yourself — I have not merged.

## Part A — kit `^0.6.0` → `^0.7.3`

Additive across the whole line; nothing here changes behaviour on its own.

| Version | What it adds | Effect on uqucc |
|---|---|---|
| v0.7.0 | gateway maps audio attachments to `input_audio` chat parts | none — uqucc accepts PDFs and images only |
| v0.7.1 | module-gated migration loading | none — the approvals module is on, so its migrations keep loading, and migration identity is basename-only so nothing re-runs |
| v0.7.2 | ToolChip `dir="auto"` + a CSS-driven running ellipsis | the RTL fix uqucc wanted |
| v0.7.3 | closure `$meta`, opt-in trailing `done`, `ResumeDecisions::guarded()` | one helper adopted (below); the other two deliberately not needed |

**The v0.7.2 consumer requirement is already met.** Tool-chip labels must not bake a trailing `…`, or a settled ✓ chip reads as still working. I grepped both label sources: the student surface's `TOOL_LABELS` are all bare verb phrases (`يبحث في صفحات الدليل`), and the admin panel renders the raw tool name. The only baked ellipses in the app are Telegram progress lines (`جاري المعالجة…`) and composer placeholders — neither is a chip, so I left them alone.

Pinned at `^0.7.3` rather than wider: **v0.8.0 is a breaking release** that deletes the transitional proposal module. uqucc has run exclusively on `Approvals\Classified` since #129 so it should be a clean jump, but that is its own change.

## Part B — resumable turns

Previously the model call ran inside the request and wrote each delta straight to the socket, which made the socket load-bearing: a visitor who lost signal, backgrounded the tab or reloaded lost a half-written answer that had already been paid for. Now the turn folds into the kit's `TurnBuffer` from a queued job and the SSE endpoints only tail that buffer, so generation and the connection are independent.

Both surfaces moved — the student chat and the admin assistant. The admin one matters more: the turn an operator cannot afford to lose is precisely the one that paused for approval, or the one whose approved write is running.

### Wire contract: preserved, extended additively

The existing POSTs still answer as SSE over the **same** events (`reasoning` / `delta` / `tool` / `citations` / `approval` / `question`, one terminal snake-case `done` or `error`), with the same pre-flight JSON refusals and status codes. Nothing was renamed. The evidence is that **all 32 student and 41 admin endpoint tests pass untouched** — I did not edit a single existing assertion.

What is new is additive:

- an `id:` line on every frame — the buffer sequence number, which **is** the resume cursor;
- a leading `turn {id}` frame carrying the handle the client stores;
- four read-only endpoints that read the buffer rather than open one:

```
GET  /ai/chat/turns/{turn}/stream?cursor=<seq>       POST /ai/chat/turns/{turn}/cancel
GET  /manage/assistant/turns/{turn}/stream?cursor=   POST /manage/assistant/turns/{turn}/cancel
```

All four 404 a turn belonging to another session/admin as readily as an unknown one — nobody needs to learn that someone else's turn id exists. None consumes the daily quota, the model, the budget or the per-session burst limiter, because none opens a turn — and a reconnect ladder must not be throttled into silence.

**Review fix (a258149):** the public pair was initially left inside the `throttle:ai-chat` group, which is `Limit::perMinute(5)` per session — the same five the opening POST spends. A long turn needs more than that (the kit's tail closes at its `max_stream_seconds` ceiling and the client re-issues its cursor each time, plus a stop), so the ladder could 429 itself into exactly the lost reply resumability prevents. The manage pair was already excluded for that reason; both surfaces now match. They keep the `web` group so session and CSRF still apply, and the `/ai/chat/turns/…` prefix — not the group — is what keeps the single-segment `{conversation}` route from swallowing them (verified with `route:list`).

### The decide endpoint

`POST /manage/assistant/chat/{conversation}/decide` keeps its URL, payload, `409`-with-the-current-pending-set, `422` and `503`, and still answers as SSE. A resume is now a **new** turn (the paused one finished when it paused), but the client never has to know: it reads the continuation off the same POST.

It stays keyed by **conversation**, not turn — the server's pause markers live on the conversation — so nothing about resuming looks up a turn record.

### Cancellation had to become a server concern

The stop button used to abort the fetch. That was enough while the model call lived in the request; with generation queued, hanging up would leave the turn running and billing. It now flags the turn, and the job (polling at most once a second, seeded so the first event checks) finishes early with what it has. `untilCancelled` is the generator-in-front-of-the-mapper pattern the kit documents as of v0.7.3.

### Client behaviour

A read now ends three ways instead of one: the turn reached a terminal event, the server hung up mid-turn, or the connection broke. The last two are the same thing — wait out the backoff, re-issue `?cursor=lastSeq`. Any frame that lands forgives the previous drop, so a long turn never exhausts its retries. An abort deliberately **keeps** the handle in sessionStorage: that is the turn the next page load resumes.

`error` is terminal on the client, matching the kit contract — without that the ladder would reconnect after a failure and give up eight retries later. Two de-duplication cases are handled: a replayed finished turn drops the older rehydrated copy when the text matches, and the admin panel holds pending cards back during rehydration while a resumable turn is outstanding (drawing them after all only if the replay never lands), so a pause is never rendered twice.

## Worker topology (review fix, `5a1d695`)

Both jobs read `config('ai.chat.queue', 'default')`, but `config/ai.php` had no `queue` key under `chat` — so the fallback won and turns landed on the **default** queue, served by a single `worker-queue` with `--sleep=3` and no `--timeout`. Three problems for an interactive turn: replies serialize behind each other, every other default-queue job waits behind a multi-minute turn, and anything past 60s is killed. The `ai` queue was no better a home — it carries corpus extraction and ingestion.

Fixed with a dedicated queue and worker:

- `config/ai.php`: `'queue' => 'ai-chat'`, static like `queue.php`'s `retry_after` — a fixed property of worker topology, not an env knob.
- `nixpacks.toml`: a `worker-ai-chat.conf` asset cloned from `worker-ai-queue` (the build already copies `/assets/worker-*.conf`). `numprocs=2` so turns don't serialize, `--sleep=1` to keep pickup latency out of the visible reply, `--tries=1` because a half-streamed turn must never replay, `--timeout=300`, `stopwaitsecs=310`.
- `config/queue.php`: the comment enumerating the slowest workers now names `ai-chat` too, and says out loud that **300 is the ceiling** — redis `retry_after` is 360 and must stay above the longest a job may run, or a still-streaming turn is reclaimed and generated a second time against a buffer that already holds one.

Two tests assert the queue **name** on each surface, since that name is the whole contract between config and worker topology. Both fail when the config key is removed. They deliberately don't render the streamed body: with the queue faked the turn never completes, so tailing its buffer blocks until the kit's stream deadline — which is how the first draft of the test timed out.

## v0.7.3 helpers: one adopted, two deliberately declined

**Adopted — `ResumeDecisions::guarded($input, $guard)`.** This is exactly the pair `AdminAssistantController` had spelled out by hand: reconcile every edit against the server's own pending call, then round-trip through `fromClient()` so an unreadable shape throws in the request rather than inside the job. The local helper and its `TODO(kit 0.7.3)` marker are gone. The swap is provably behaviour-identical, not merely shorter: the two tests that exercise the guard specifically — *restores a tampered readonly id from the pause* and *422 when an edit invents an argument* — pass unchanged.

**Not needed — closure `$meta` on `runIntoBuffer()`.** That solves post-fold facts landing in the *record*. Both jobs here assemble their completion in `doneUsing`, which already runs after the fold, and the only fact any endpoint reads back off a record is the owner id, written at `start()` before the turn was queued. Since decide() is conversation-keyed it reads no turn meta at all. Both jobs pass no `$meta`, and no sink was ever hand-rolled.

**Not needed — `fail(trailingDone: true)`.** That exists for clients that cannot be fixed. Ours can, and was: `error` is terminal on both clients, which is the kit's own contract.

There are now **no `TODO(kit …)` markers left in this PR.**

## Test evidence

| Gate | Result |
|---|---|
| `php artisan test` | **1217 passed**, 2 failed |
| `tests/Feature/Ai/Chat/ChatEndpointTest.php` | 40 passed (32 pre-existing untouched + 8 new) |
| `tests/Feature/Manage/AdminAssistantTest.php` | 47 passed (41 pre-existing untouched + 6 new) |
| `npm run build` | clean |
| `vue-tsc --noEmit` | clean |
| `npm test` (vitest) | 129 passed |
| `npx prettier --check` on the two changed `.vue` files | clean |
| `./vendor/bin/pint` on every file this PR touches | clean |

**The 2 failures are pre-existing on `main` and unrelated**: `ExampleTest` and `PublicRoutesTest` both assert `GET /` renders a `Welcome` Inertia component, but `resources/js/pages/Welcome.vue` was deleted in #117 and the tests were never updated. `git ls-tree origin/main` confirms the file is absent there too.

New tests pin the resume contract rather than restating the old one: the turn handle arriving first and frames being densely numbered; a cursor replaying only what came after it; `Last-Event-ID` as an equivalent cursor; 404 on a foreign or unknown turn on both new endpoints; cancellation flagging the turn; the kill switch failing a turn that was queued before it engaged, without calling the model; and a dropped client still resuming and stopping once the burst limiter is exhausted (that one fails with 429 against the pre-fix routes, so it pins the behaviour rather than restating it). On the admin side, a **paused** turn replaying its approval card identically to a reconnecting client, and a decided resume arriving on its own separately-resumable turn while the write still lands.

The approval-resume tests use the `Http::fake` OpenRouter SSE technique rather than the agent-level fake, which deliberately disables `Approvable` resume.

## Notes for review

- **Deviation from catodemy #554, deliberate:** catodemy's POST returns `202 {turnId}` and the client opens a separate GET. uqucc's POSTs keep returning the SSE stream directly (they start the buffer, queue the job, then tail it), which is what let every existing test and both clients' request flow survive unchanged. The GET stream endpoint exists purely for resuming. Same resumability, far less churn — but flagging it since it diverges from the reference.
- **Vite config verified intact**: `@saad5400/ai-kit` is still in `optimizeDeps.exclude` and `ssr.noExternal`.
- **Per-delta buffer appends: no action needed.** `runIntoBuffer` writes one entry per `delta`, each a read-modify-write of the growing event list, which would be costly on `.env.example`'s `CACHE_STORE=database`. Confirmed in review that prod already runs redis, so this is moot; noting it only so the next reader knows the pattern was considered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjaTH1ywjkEBfoDkHRBHw9


