### PR TITLE
Kit 0.9.0: shared default chat model, v0.9.0 cards, Arabic field labels

### DIFF
--- a/app/Ai/Admin/Actions/AdminAction.php
+++ b/app/Ai/Admin/Actions/AdminAction.php
@@ -15,11 +15,10 @@ use Illuminate\JsonSchema\Types\Type;
  *   - The MCP server ({@see \App\Mcp\Tools\AdminActionTool}) wraps it as an
  *     immediate-write tool, gated by {@see requiredAbility()} over OAuth.
  *   - The in-app assistant ({@see \App\Ai\Admin\Actions\AssistantActionTool})
- *     wraps a WRITE as a confirm-gated proposal (ai-kit's ProposalExecutor
- *     persists a pending {@see \Saad\AiKit\Approvals\Proposal} a human
- *     confirms, then re-validates and calls {@see execute()} through the
- *     {@see \App\Ai\Admin\ProposableAdminAction} adapter), and a READ as an
- *     immediate call.
+ *     wraps a WRITE as a confirm-gated pause on ai-kit's classified seam:
+ *     the tool pauses the turn, the admin decides on a card, and their
+ *     decision resumes the SAME call, re-validating before {@see run()}. A
+ *     READ is an immediate call.
  *
  * Contract for writes: {@see validate()} normalizes raw model input against
  * live state (throwing {@see AdminActionException} with an Arabic reason on

--- a/app/Ai/Admin/Actions/Corpus/AuthorPageFromDocumentAction.php
+++ b/app/Ai/Admin/Actions/Corpus/AuthorPageFromDocumentAction.php
@@ -10,6 +10,7 @@ use App\Jobs\Ai\AuthorPageFromDocumentJob;
 use App\Models\Corpus\CorpusDocument;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
 use Saad\AiKit\Safety\BudgetGuard;
 
 /**
@@ -123,6 +124,22 @@ class AuthorPageFromDocumentAction extends AdminAction
             'document_id' => $schema->integer()
                 ->description('The id of the extracted corpus document to author a page from, from list_corpus_documents.')
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'document_id' => Field::readonly('document_id', label: 'المستند'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Corpus/ReextractCorpusDocumentAction.php
+++ b/app/Ai/Admin/Actions/Corpus/ReextractCorpusDocumentAction.php
@@ -9,6 +9,7 @@ use App\Jobs\Ai\ExtractCorpusDocumentJob;
 use App\Models\Corpus\CorpusDocument;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
 
 /**
  * Queue a re-extraction of a corpus document — re-run the PDF text layer or the
@@ -89,6 +90,22 @@ class ReextractCorpusDocumentAction extends AdminAction
             'document_id' => $schema->integer()
                 ->description('The id of the corpus document to re-extract, from list_corpus_documents.')
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'document_id' => Field::readonly('document_id', label: 'المستند'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Corpus/ReingestCorpusDocumentAction.php
+++ b/app/Ai/Admin/Actions/Corpus/ReingestCorpusDocumentAction.php
@@ -9,6 +9,7 @@ use App\Jobs\Ai\IngestDocumentJob;
 use App\Models\Corpus\CorpusDocument;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
 
 /**
  * Queue a re-chunk and re-embed of a corpus document's current extracted
@@ -97,6 +98,22 @@ class ReingestCorpusDocumentAction extends AdminAction
             'document_id' => $schema->integer()
                 ->description('The id of the corpus document to re-ingest, from list_corpus_documents.')
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'document_id' => Field::readonly('document_id', label: 'المستند'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Pages/ManagePageStructureAction.php
+++ b/app/Ai/Admin/Actions/Pages/ManagePageStructureAction.php
@@ -11,6 +11,7 @@ use App\Ai\Admin\PageChangeRules;
 use App\Models\Page;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
 use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
@@ -200,15 +201,22 @@ class ManagePageStructureAction extends AdminAction
     }
 
     /**
-     * `action` names the structural operation, not its payload: switching a
-     * confirmed `rename` to `delete` would make the card a preview of a
-     * different write entirely, and the Arabic summary the admin read would
-     * describe neither. It is the operation's identity, so it is readonly.
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
      *
      * @return array<string, mixed>
      */
     public function fieldWidgets(): array
     {
-        return ['action' => FieldWidget::Readonly];
+        return [
+            'action' => Field::readonly('action', label: 'نوع التغيير'),
+            'page_id' => Field::readonly('page_id', label: 'الصفحة'),
+            'title' => Field::make('title', FieldWidget::Text, label: 'العنوان'),
+            'parent_id' => Field::readonly('parent_id', label: 'الصفحة الأم'),
+            'ids' => Field::readonly('ids', label: 'الترتيب الجديد'),
+        ];
     }
 }

--- a/app/Ai/Admin/Actions/Pages/RestorePageAction.php
+++ b/app/Ai/Admin/Actions/Pages/RestorePageAction.php
@@ -8,6 +8,7 @@ use App\Ai\Admin\Actions\AdminActionException;
 use App\Models\Page;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
 
 /**
  * Restore a soft-deleted (trashed) page. Mirrors
@@ -99,6 +100,22 @@ class RestorePageAction extends AdminAction
             'page_id' => $schema->integer()
                 ->description('The id of the trashed page to restore, from list_pages.')
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'page_id' => Field::readonly('page_id', label: 'الصفحة'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Pages/UpdatePageAction.php
+++ b/app/Ai/Admin/Actions/Pages/UpdatePageAction.php
@@ -12,6 +12,8 @@ use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
+use Saad\AiKit\Approvals\Classified\Field;
+use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
  * Update a page's settings — title, slug, icon and visibility flags — mirroring
@@ -153,5 +155,39 @@ class UpdatePageAction extends AdminAction
             'smart_search' => $schema->boolean()->description('Whether the page is included in smart search.'),
             'requires_prefix' => $schema->boolean()->description('Whether the Telegram bot only surfaces this page when the message carries the guide keyword prefix.'),
         ];
+    }
+
+    /**
+     * Arabic labels for the approval card, drawn from the SAME
+     * {@see FIELD_LABELS} vocabulary {@see summarize()} writes its sentence
+     * from, so the card's labels and its summary cannot drift apart.
+     *
+     * Each field's widget is restated alongside its label because declaring
+     * a spec REPLACES the kit's value-based inference for that argument: an
+     * id declared without `Field::readonly` would come back as an editable
+     * text box, and a boolean as a text input.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        $widgets = [
+            'title' => FieldWidget::Text,
+            'slug' => FieldWidget::Text,
+            'icon' => FieldWidget::Text,
+            'hidden' => FieldWidget::Boolean,
+            'hidden_from_bot' => FieldWidget::Boolean,
+            'hidden_from_ai' => FieldWidget::Boolean,
+            'smart_search' => FieldWidget::Boolean,
+            'requires_prefix' => FieldWidget::Boolean,
+        ];
+
+        $fields = ['page_id' => Field::readonly('page_id', label: 'الصفحة')];
+
+        foreach ($widgets as $name => $widget) {
+            $fields[$name] = Field::make($name, $widget, label: self::FIELD_LABELS[$name]);
+        }
+
+        return $fields;
     }
 }

--- a/app/Ai/Admin/Actions/Pages/UpdatePageContentAction.php
+++ b/app/Ai/Admin/Actions/Pages/UpdatePageContentAction.php
@@ -10,6 +10,7 @@ use App\Ai\Copilot\TipTapContent;
 use App\Models\Page;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
 use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
@@ -124,15 +125,20 @@ class UpdatePageContentAction extends AdminAction
     }
 
     /**
-     * A whole page body is the one argument on this card worth reading
-     * before confirming, so it gets the markdown editor rather than the
-     * single-line input a short first draft would otherwise infer.
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
      *
      * @return array<string, mixed>
      */
     public function fieldWidgets(): array
     {
-        return ['content' => FieldWidget::Markdown];
+        return [
+            'page_id' => Field::readonly('page_id', label: 'الصفحة'),
+            'content' => Field::make('content', FieldWidget::Markdown, label: 'المحتوى'),
+        ];
     }
 
     /**

--- a/app/Ai/Admin/Actions/Quiz/CreateQuizTopicAction.php
+++ b/app/Ai/Admin/Actions/Quiz/CreateQuizTopicAction.php
@@ -8,6 +8,8 @@ use App\Ai\Admin\Actions\AdminActionException;
 use App\Models\QuizTopic;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
+use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
  * Add a daily-quiz topic, mirroring
@@ -47,6 +49,24 @@ class CreateQuizTopicAction extends AdminAction
                 ->description('Optional guidance for the author model about this topic.'),
             'is_spotlight' => $schema->boolean()
                 ->description('True for a major-specific theme shown only on the weekly spotlight day. Defaults to false.'),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'name' => Field::make('name', FieldWidget::Text, label: 'اسم الموضوع'),
+            'prompt_hint' => Field::make('prompt_hint', FieldWidget::Textarea, label: 'تلميح التوليد'),
+            'is_spotlight' => Field::make('is_spotlight', FieldWidget::Boolean, label: 'موضوع الأسبوع'),
         ];
     }
 

--- a/app/Ai/Admin/Actions/Quiz/DeleteQuizTopicAction.php
+++ b/app/Ai/Admin/Actions/Quiz/DeleteQuizTopicAction.php
@@ -8,6 +8,7 @@ use App\Ai\Admin\Actions\AdminActionException;
 use App\Models\QuizTopic;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
 
 /**
  * Delete a daily-quiz topic, mirroring
@@ -49,6 +50,22 @@ class DeleteQuizTopicAction extends AdminAction
             'topic_id' => $schema->integer()
                 ->description('The id of the topic to delete, from list_quiz_topics.')
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'topic_id' => Field::readonly('topic_id', label: 'الموضوع'),
         ];
     }
 

--- a/app/Ai/Admin/Actions/Quiz/RegenerateDailyQuizAction.php
+++ b/app/Ai/Admin/Actions/Quiz/RegenerateDailyQuizAction.php
@@ -10,6 +10,8 @@ use App\Models\DailyQuiz;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Carbon;
+use Saad\AiKit\Approvals\Classified\Field;
+use Saad\AiKit\Approvals\Classified\FieldWidget;
 use Throwable;
 
 /**
@@ -49,6 +51,22 @@ class RegenerateDailyQuizAction extends AdminAction
         return [
             'date' => $schema->string()
                 ->description('The day to regenerate, as YYYY-MM-DD. Defaults to today.'),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'date' => Field::make('date', FieldWidget::Text, label: 'التاريخ'),
         ];
     }
 

--- a/app/Ai/Admin/Actions/Quiz/UpdateDailyQuizAction.php
+++ b/app/Ai/Admin/Actions/Quiz/UpdateDailyQuizAction.php
@@ -11,6 +11,7 @@ use App\Models\User;
 use App\Support\QuizContentHtml;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Str;
+use Saad\AiKit\Approvals\Classified\Field;
 use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
@@ -201,17 +202,24 @@ class UpdateDailyQuizAction extends AdminAction
     }
 
     /**
-     * The question is an HTML fragment and the explanation runs to a
-     * paragraph — both need an editor with room, whatever length the model
-     * happened to send.
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
      *
      * @return array<string, mixed>
      */
     public function fieldWidgets(): array
     {
         return [
-            'question' => FieldWidget::Code,
-            'explanation' => FieldWidget::Textarea,
+            'quiz_id' => Field::readonly('quiz_id', label: 'السؤال اليومي'),
+            'question' => Field::make('question', FieldWidget::Code, label: 'نص السؤال'),
+            'options' => Field::readonly('options', label: 'الخيارات'),
+            'correct_option' => Field::make('correct_option', FieldWidget::Number, label: 'رقم الخيار الصحيح'),
+            'explanation' => Field::make('explanation', FieldWidget::Textarea, label: 'الشرح'),
+            'hint' => Field::make('hint', FieldWidget::Textarea, label: 'تلميح'),
+            'obvious_hint' => Field::make('obvious_hint', FieldWidget::Textarea, label: 'تلميح صريح'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Quiz/UpdateQuizTopicAction.php
+++ b/app/Ai/Admin/Actions/Quiz/UpdateQuizTopicAction.php
@@ -8,6 +8,8 @@ use App\Ai\Admin\Actions\AdminActionException;
 use App\Models\QuizTopic;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
+use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
  * Edit a daily-quiz topic, mirroring
@@ -48,6 +50,26 @@ class UpdateQuizTopicAction extends AdminAction
             'prompt_hint' => $schema->string()->description('New generation hint. Pass an empty string to clear it.'),
             'is_spotlight' => $schema->boolean()->description('Whether this is a weekly spotlight (major-specific) topic.'),
             'is_active' => $schema->boolean()->description('Whether the topic is active (eligible to be picked).'),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'topic_id' => Field::readonly('topic_id', label: 'الموضوع'),
+            'name' => Field::make('name', FieldWidget::Text, label: 'اسم الموضوع'),
+            'prompt_hint' => Field::make('prompt_hint', FieldWidget::Textarea, label: 'تلميح التوليد'),
+            'is_spotlight' => Field::make('is_spotlight', FieldWidget::Boolean, label: 'موضوع الأسبوع'),
+            'is_active' => Field::make('is_active', FieldWidget::Boolean, label: 'مُفعَّل'),
         ];
     }
 

--- a/app/Ai/Admin/Actions/Reviews/ApprovePageChangeAction.php
+++ b/app/Ai/Admin/Actions/Reviews/ApprovePageChangeAction.php
@@ -9,6 +9,7 @@ use App\Models\PageChangeRequest;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\DB;
+use Saad\AiKit\Approvals\Classified\Field;
 use Throwable;
 
 /**
@@ -125,6 +126,22 @@ class ApprovePageChangeAction extends AdminAction
             'change_request_id' => $schema->integer()
                 ->description('The id of the pending change request to approve, from list_pending_changes.')
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'change_request_id' => Field::readonly('change_request_id', label: 'طلب التعديل'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Reviews/RejectPageChangeAction.php
+++ b/app/Ai/Admin/Actions/Reviews/RejectPageChangeAction.php
@@ -8,6 +8,7 @@ use App\Ai\Admin\Actions\AdminActionException;
 use App\Models\PageChangeRequest;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
 use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
@@ -114,13 +115,19 @@ class RejectPageChangeAction extends AdminAction
     }
 
     /**
-     * The rejection note is prose the reviewer usually rewrites, so it gets
-     * an editor rather than a single line.
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
      *
      * @return array<string, mixed>
      */
     public function fieldWidgets(): array
     {
-        return ['note' => FieldWidget::Textarea];
+        return [
+            'change_request_id' => Field::readonly('change_request_id', label: 'طلب التعديل'),
+            'note' => Field::make('note', FieldWidget::Textarea, label: 'سبب الرفض'),
+        ];
     }
 }

--- a/app/Ai/Admin/Actions/Settings/UpdateSettingAction.php
+++ b/app/Ai/Admin/Actions/Settings/UpdateSettingAction.php
@@ -8,6 +8,7 @@ use App\Ai\Admin\Actions\AdminActionException;
 use App\Ai\Admin\SettingsRegistry;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
 use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
@@ -125,16 +126,20 @@ class UpdateSettingAction extends AdminAction
     }
 
     /**
-     * `group` and `key` address WHICH setting the write lands on, exactly as
-     * an id does, so only `value` is the admin's to change here.
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
      *
      * @return array<string, mixed>
      */
     public function fieldWidgets(): array
     {
         return [
-            'group' => FieldWidget::Readonly,
-            'key' => FieldWidget::Readonly,
+            'group' => Field::readonly('group', label: 'مجموعة الإعداد'),
+            'key' => Field::readonly('key', label: 'مفتاح الإعداد'),
+            'value' => Field::make('value', FieldWidget::Text, label: 'القيمة الجديدة'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Telegram/DeleteTelegramChatAction.php
+++ b/app/Ai/Admin/Actions/Telegram/DeleteTelegramChatAction.php
@@ -8,6 +8,7 @@ use App\Ai\Admin\Actions\AdminActionException;
 use App\Models\TelegramChatSetting;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
 
 /**
  * Delete a Telegram chat's settings row, mirroring
@@ -48,6 +49,22 @@ class DeleteTelegramChatAction extends AdminAction
             'chat_id' => $schema->string()
                 ->description('The Telegram chat_id of the chat whose settings to delete, from list_telegram_chats.')
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'chat_id' => Field::readonly('chat_id', label: 'معرّف المحادثة'),
         ];
     }
 

--- a/app/Ai/Admin/Actions/Telegram/ResetTelegramChatAction.php
+++ b/app/Ai/Admin/Actions/Telegram/ResetTelegramChatAction.php
@@ -8,6 +8,7 @@ use App\Ai\Admin\Actions\AdminActionException;
 use App\Models\TelegramChatSetting;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
 
 /**
  * Forget the assistant's current conversation for a Telegram chat so it starts
@@ -41,6 +42,22 @@ class ResetTelegramChatAction extends AdminAction
             'chat_id' => $schema->string()
                 ->description('The Telegram chat_id of the chat to reset, from list_telegram_chats.')
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'chat_id' => Field::readonly('chat_id', label: 'معرّف المحادثة'),
         ];
     }
 

--- a/app/Ai/Admin/Actions/Telegram/SetTelegramChatAiAction.php
+++ b/app/Ai/Admin/Actions/Telegram/SetTelegramChatAiAction.php
@@ -8,6 +8,8 @@ use App\Ai\Admin\Actions\AdminActionException;
 use App\Models\TelegramChatSetting;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
+use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
  * Enable or disable the bot's AI assistant for a single Telegram chat, mirroring
@@ -44,6 +46,23 @@ class SetTelegramChatAiAction extends AdminAction
             'enabled' => $schema->boolean()
                 ->description('True to enable the assistant for this chat, false to disable it.')
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'chat_id' => Field::readonly('chat_id', label: 'معرّف المحادثة'),
+            'enabled' => Field::make('enabled', FieldWidget::Boolean, label: 'الذكاء الاصطناعي مُفعَّل'),
         ];
     }
 

--- a/app/Ai/Admin/Actions/Tutors/CreateCourseAction.php
+++ b/app/Ai/Admin/Actions/Tutors/CreateCourseAction.php
@@ -10,6 +10,8 @@ use App\Models\PrivateTutor\PrivateTutorCourse;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\Validator;
+use Saad\AiKit\Approvals\Classified\Field;
+use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
  * Create a private-tutor course (the taxonomy tutors are tagged with). Mirrors
@@ -86,6 +88,22 @@ class CreateCourseAction extends AdminAction
             'name' => $schema->string()
                 ->description('The course name.')
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'name' => Field::make('name', FieldWidget::Text, label: 'اسم المادة'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Tutors/CreateTutorAction.php
+++ b/app/Ai/Admin/Actions/Tutors/CreateTutorAction.php
@@ -10,6 +10,8 @@ use App\Models\PrivateTutor\PrivateTutor;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\Validator;
+use Saad\AiKit\Approvals\Classified\Field;
+use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
  * Create a private tutor and attach its courses. Mirrors
@@ -112,6 +114,24 @@ class CreateTutorAction extends AdminAction
             'course_ids' => $schema->array()
                 ->description('Optional ids of the courses this tutor teaches, from list_tutors.')
                 ->items($schema->integer()),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'name' => Field::make('name', FieldWidget::Text, label: 'اسم المدرّس'),
+            'url' => Field::make('url', FieldWidget::Text, label: 'الرابط'),
+            'course_ids' => Field::readonly('course_ids', label: 'المواد'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Tutors/DeleteCourseAction.php
+++ b/app/Ai/Admin/Actions/Tutors/DeleteCourseAction.php
@@ -8,6 +8,7 @@ use App\Ai\Admin\Actions\AdminActionException;
 use App\Models\PrivateTutor\PrivateTutorCourse;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
 
 /**
  * Delete a private-tutor course. It is detached from any tutors via the pivot
@@ -96,6 +97,22 @@ class DeleteCourseAction extends AdminAction
             'course_id' => $schema->integer()
                 ->description('The id of the course to delete, from list_tutors.')
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'course_id' => Field::readonly('course_id', label: 'المادة'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Tutors/DeleteTutorAction.php
+++ b/app/Ai/Admin/Actions/Tutors/DeleteTutorAction.php
@@ -8,6 +8,7 @@ use App\Ai\Admin\Actions\AdminActionException;
 use App\Models\PrivateTutor\PrivateTutor;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
 
 /**
  * Delete a private tutor. Attached courses are detached, not deleted. Mirrors
@@ -95,6 +96,22 @@ class DeleteTutorAction extends AdminAction
             'tutor_id' => $schema->integer()
                 ->description('The id of the tutor to delete, from list_tutors.')
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'tutor_id' => Field::readonly('tutor_id', label: 'المدرّس'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Tutors/ReorderCoursesAction.php
+++ b/app/Ai/Admin/Actions/Tutors/ReorderCoursesAction.php
@@ -10,6 +10,7 @@ use App\Models\PrivateTutor\PrivateTutorCourse;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\Validator;
+use Saad\AiKit\Approvals\Classified\Field;
 
 /**
  * Reorder the private-tutor courses from an ordered array of ids. Mirrors
@@ -96,6 +97,22 @@ class ReorderCoursesAction extends AdminAction
                 ->description('The course ids (from list_tutors) in the desired display order.')
                 ->items($schema->integer())
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'ids' => Field::readonly('ids', label: 'الترتيب الجديد'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Tutors/ReorderTutorsAction.php
+++ b/app/Ai/Admin/Actions/Tutors/ReorderTutorsAction.php
@@ -10,6 +10,7 @@ use App\Models\PrivateTutor\PrivateTutor;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\Validator;
+use Saad\AiKit\Approvals\Classified\Field;
 
 /**
  * Reorder the private tutors from an ordered array of ids. Mirrors
@@ -94,6 +95,22 @@ class ReorderTutorsAction extends AdminAction
                 ->description('The tutor ids (from list_tutors) in the desired display order.')
                 ->items($schema->integer())
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'ids' => Field::readonly('ids', label: 'الترتيب الجديد'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Tutors/UpdateCourseAction.php
+++ b/app/Ai/Admin/Actions/Tutors/UpdateCourseAction.php
@@ -10,6 +10,8 @@ use App\Models\PrivateTutor\PrivateTutorCourse;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\Validator;
+use Saad\AiKit\Approvals\Classified\Field;
+use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
  * Rename a private-tutor course. Mirrors
@@ -103,6 +105,23 @@ class UpdateCourseAction extends AdminAction
             'name' => $schema->string()
                 ->description('The new course name.')
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'course_id' => Field::readonly('course_id', label: 'المادة'),
+            'name' => Field::make('name', FieldWidget::Text, label: 'اسم المادة'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Tutors/UpdateTutorAction.php
+++ b/app/Ai/Admin/Actions/Tutors/UpdateTutorAction.php
@@ -10,6 +10,8 @@ use App\Models\PrivateTutor\PrivateTutor;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\Validator;
+use Saad\AiKit\Approvals\Classified\Field;
+use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
  * Update a private tutor and sync its attached courses. Mirrors
@@ -131,6 +133,25 @@ class UpdateTutorAction extends AdminAction
             'course_ids' => $schema->array()
                 ->description('Optional ids of the courses this tutor teaches (replaces the current set), from list_tutors.')
                 ->items($schema->integer()),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'tutor_id' => Field::readonly('tutor_id', label: 'المدرّس'),
+            'name' => Field::make('name', FieldWidget::Text, label: 'اسم المدرّس'),
+            'url' => Field::make('url', FieldWidget::Text, label: 'الرابط'),
+            'course_ids' => Field::readonly('course_ids', label: 'المواد'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Users/CreateUserAction.php
+++ b/app/Ai/Admin/Actions/Users/CreateUserAction.php
@@ -9,6 +9,8 @@ use App\Http\Requests\Manage\StoreUserRequest;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\Validator;
+use Saad\AiKit\Approvals\Classified\Field;
+use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
  * Create a panel user. Mirrors
@@ -133,6 +135,26 @@ class CreateUserAction extends AdminAction
                 ->items($schema->string()),
             'requires_review' => $schema->boolean()
                 ->description('Whether this user\'s content edits must be reviewed before going live. Applied only if you hold assign-roles.'),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'name' => Field::make('name', FieldWidget::Text, label: 'الاسم'),
+            'email' => Field::make('email', FieldWidget::Text, label: 'البريد الإلكتروني'),
+            'password' => Field::make('password', FieldWidget::Text, label: 'كلمة المرور'),
+            'roles' => Field::readonly('roles', label: 'الأدوار'),
+            'requires_review' => Field::make('requires_review', FieldWidget::Boolean, label: 'تخضع تعديلاته للمراجعة'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Users/DeleteUserAction.php
+++ b/app/Ai/Admin/Actions/Users/DeleteUserAction.php
@@ -7,6 +7,7 @@ use App\Ai\Admin\Actions\AdminAction;
 use App\Ai\Admin\Actions\AdminActionException;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Saad\AiKit\Approvals\Classified\Field;
 
 /**
  * Delete a panel user. Mirrors
@@ -101,6 +102,22 @@ class DeleteUserAction extends AdminAction
             'user_id' => $schema->integer()
                 ->description('The id of the user to delete, from list_users.')
                 ->required(),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'user_id' => Field::readonly('user_id', label: 'المستخدم'),
         ];
     }
 }

--- a/app/Ai/Admin/Actions/Users/UpdateUserAction.php
+++ b/app/Ai/Admin/Actions/Users/UpdateUserAction.php
@@ -11,6 +11,8 @@ use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator as ValidatorInstance;
+use Saad\AiKit\Approvals\Classified\Field;
+use Saad\AiKit\Approvals\Classified\FieldWidget;
 
 /**
  * Update a panel user. Mirrors
@@ -220,6 +222,31 @@ class UpdateUserAction extends AdminAction
                 ->items($schema->string()),
             'requires_review' => $schema->boolean()
                 ->description('Whether this user\'s content edits must be reviewed. Applied only if you hold assign-roles.'),
+        ];
+    }
+
+    /**
+     * Arabic labels for the approval card, with each field's widget restated
+     * alongside its label. Declaring a spec REPLACES the kit's value-based
+     * inference for that argument, so the widget an unlabelled field would
+     * have been given has to be named here — an id declared without
+     * `Field::readonly` would come back as an editable text box.
+     *
+     * @return array<string, mixed>
+     */
+    public function fieldWidgets(): array
+    {
+        return [
+            'user_id' => Field::readonly('user_id', label: 'المستخدم'),
+            'name' => Field::make('name', FieldWidget::Text, label: 'الاسم'),
+            'email' => Field::make('email', FieldWidget::Text, label: 'البريد الإلكتروني'),
+            'password' => Field::make('password', FieldWidget::Text, label: 'كلمة المرور'),
+            'verified' => Field::make('verified', FieldWidget::Boolean, label: 'البريد موثَّق'),
+            'username' => Field::make('username', FieldWidget::Text, label: 'اسم المستخدم'),
+            'url' => Field::make('url', FieldWidget::Text, label: 'الرابط'),
+            'avatar' => Field::make('avatar', FieldWidget::Text, label: 'رابط الصورة'),
+            'roles' => Field::readonly('roles', label: 'الأدوار'),
+            'requires_review' => Field::make('requires_review', FieldWidget::Boolean, label: 'تخضع تعديلاته للمراجعة'),
         ];
     }
 

--- a/app/Ai/Admin/AdminAssistant.php
+++ b/app/Ai/Admin/AdminAssistant.php
@@ -36,8 +36,8 @@ use Stringable;
  *     // or ->continue($conversationId, new AdminOwner($admin))
  *     $response = $agent->stream($prompt);
  *
- * Model/provider wiring is identical to the public assistant: the
- * operator-editable AiSettings->chat_model on the configured default
+ * Model/provider wiring is identical to the public assistant:
+ * {@see \App\Settings\AiSettings::chatModel()} on the configured default
  * provider.
  */
 #[MaxSteps(12)]
@@ -79,7 +79,7 @@ class AdminAssistant implements Agent, Conversational, HasProviderOptions, HasTo
      */
     public function provider(): array
     {
-        return [(string) config('ai.default', 'openrouter') => $this->model()];
+        return [(string) config('ai.default', 'openrouter') => $this->settings->chatModel()];
     }
 
     public function timeout(): int
@@ -143,15 +143,5 @@ class AdminAssistant implements Agent, Conversational, HasProviderOptions, HasTo
         - الإجراءات الحساسة (حذف صفحة، إيقاف مفتاح تشغيل): نبّه المشرف إلى أثر التغيير في ملخصك.
         - ارفض بلطف أي طلب خارج إدارة الموقع (أسئلة عامة، محتوى غير لائق) واذكر أن تخصصك إدارة صفحات الموقع وإعداداته.
         PROMPT;
-    }
-
-    /**
-     * The operator-configured chat model, falling back to config.
-     */
-    private function model(): string
-    {
-        $model = trim($this->settings->chat_model);
-
-        return $model !== '' ? $model : (string) config('ai.chat.model', 'deepseek/deepseek-v4-flash');
     }
 }

--- a/app/Ai/Agents/StudentAssistant.php
+++ b/app/Ai/Agents/StudentAssistant.php
@@ -32,9 +32,10 @@ use Stringable;
  * {@see \App\Ai\Chat\SessionOwner} value object whose id is the visitor's
  * session id (web) or a transport-prefixed key such as "telegram:12345".
  *
- * The model comes from the operator-editable AiSettings->chat_model, falling
- * back to config('ai.chat.model'); the provider stays behind the config
- * seam (config('ai.default')), so this class never names OpenRouter.
+ * The model comes from {@see \App\Settings\AiSettings::chatModel()} — the
+ * operator's setting over this app's config over the kit's shared fleet
+ * default; the provider stays behind the config seam (config('ai.default')),
+ * so this class never names OpenRouter.
  */
 #[MaxSteps(12)]
 class StudentAssistant implements Agent, Conversational, HasProviderOptions, HasTools
@@ -67,7 +68,7 @@ class StudentAssistant implements Agent, Conversational, HasProviderOptions, Has
      */
     public function provider(): array
     {
-        return [(string) config('ai.default', 'openrouter') => $this->model()];
+        return [(string) config('ai.default', 'openrouter') => $this->settings->chatModel()];
     }
 
     public function timeout(): int
@@ -142,15 +143,5 @@ class StudentAssistant implements Agent, Conversational, HasProviderOptions, Has
         - لا تختلق روابط أو أرقاماً أو مواد لوائح؛ وإن لم تكن متأكداً فقل إنك غير متأكد.
         - انتبه لتاريخ «آخر تحديث» في نتائج البحث والصفحات: إذا مضى على تحديث الصفحة التي استندت إليها سنة أو أكثر فنبّه الطالب إلى أن المعلومة قد تكون قديمة ويُستحسن التأكد منها.
         PROMPT;
-    }
-
-    /**
-     * The operator-configured chat model, falling back to config.
-     */
-    private function model(): string
-    {
-        $model = trim($this->settings->chat_model);
-
-        return $model !== '' ? $model : (string) config('ai.chat.model', 'deepseek/deepseek-v4-flash');
     }
 }

--- a/app/Ai/Copilot/PageCopilot.php
+++ b/app/Ai/Copilot/PageCopilot.php
@@ -14,7 +14,7 @@ use RuntimeException;
  * Gated on the operator-editable admin_copilot feature flag (which honours
  * the master AI kill switch) — a disabled copilot throws
  * {@see CopilotDisabledException} rather than silently calling out. The
- * model comes from AiSettings->chat_model with a config fallback, mirroring
+ * model comes from {@see \App\Settings\AiSettings::chatModel()}, mirroring
  * {@see \App\Ai\Corpus\DocumentVisionExtractor}.
  */
 class PageCopilot
@@ -129,7 +129,7 @@ class PageCopilot
         $response = (new PageCopilotAgent($instructions))->prompt(
             $prompt,
             provider: (string) config('ai.default', 'openrouter'),
-            model: $this->model(),
+            model: $this->settings->chatModel(),
             timeout: (int) config('ai.chat.timeout', 60),
         );
 
@@ -156,15 +156,5 @@ class PageCopilot
         }
 
         return ['title' => $title, 'description' => $description];
-    }
-
-    /**
-     * The operator-configured chat model, falling back to config.
-     */
-    private function model(): string
-    {
-        $model = trim($this->settings->chat_model);
-
-        return $model !== '' ? $model : (string) config('ai.chat.model', 'deepseek/deepseek-v4-flash');
     }
 }

--- a/app/Settings/AiSettings.php
+++ b/app/Settings/AiSettings.php
@@ -2,6 +2,7 @@
 
 namespace App\Settings;
 
+use Saad\AiKit\Catalog\Catalog;
 use Spatie\LaravelSettings\Settings;
 
 class AiSettings extends Settings
@@ -33,6 +34,29 @@ class AiSettings extends Settings
     public static function group(): string
     {
         return 'ai';
+    }
+
+    /**
+     * The chat model every assistant surface sends to — the ONE place the
+     * resolution chain lives, so the three surfaces cannot drift apart.
+     *
+     * The operator's setting wins, as it always has. An empty row falls
+     * through to config('ai.chat.model') — this app's own AI_CHAT_MODEL
+     * override — and finally to the kit's shared fleet default (ai-kit
+     * docs/DECISIONS.md #21), which is the floor of the chain so the model
+     * decision lives in one place across the three apps instead of three.
+     */
+    public function chatModel(): string
+    {
+        $model = trim($this->chat_model);
+
+        if ($model !== '') {
+            return $model;
+        }
+
+        $configured = trim((string) config('ai.chat.model', ''));
+
+        return $configured !== '' ? $configured : app(Catalog::class)->chatModel();
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "league/flysystem-aws-s3-v3": "^3.0",
         "pgvector/pgvector": "^0.2.2",
         "predis/predis": "^2.0",
-        "saad/ai-kit": "^0.7.3",
+        "saad/ai-kit": "^0.9.0",
         "smalot/pdfparser": "^2.12",
         "spatie/browsershot": "^5.2",
         "spatie/eloquent-sortable": "^4.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "624903fc81adf0b37a75bef4e1b3c709",
+    "content-hash": "c3c9582e91c6ba4ec1f700fec775deaa",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -5283,16 +5283,16 @@
         },
         {
             "name": "saad/ai-kit",
-            "version": "v0.7.3",
+            "version": "v0.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Saad5400/ai-kit.git",
-                "reference": "8851863470aa89734c85afce17cde359c1a8b9c6"
+                "reference": "240110f5bb4d367430641c3e7f26c23a87e7e722"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Saad5400/ai-kit/zipball/8851863470aa89734c85afce17cde359c1a8b9c6",
-                "reference": "8851863470aa89734c85afce17cde359c1a8b9c6",
+                "url": "https://api.github.com/repos/Saad5400/ai-kit/zipball/240110f5bb4d367430641c3e7f26c23a87e7e722",
+                "reference": "240110f5bb4d367430641c3e7f26c23a87e7e722",
                 "shasum": ""
             },
             "require": {
@@ -5349,10 +5349,10 @@
                 "openrouter"
             ],
             "support": {
-                "source": "https://github.com/Saad5400/ai-kit/tree/v0.7.3",
+                "source": "https://github.com/Saad5400/ai-kit/tree/v0.9.0",
                 "issues": "https://github.com/Saad5400/ai-kit/issues"
             },
-            "time": "2026-08-20T08:35:54+00:00"
+            "time": "2026-08-20T09:43:39+00:00"
         },
         {
             "name": "scrivo/highlight.php",

--- a/config/ai-kit.php
+++ b/config/ai-kit.php
@@ -91,6 +91,18 @@ return [
     | silence so proxies don't buffer the stream shut, and polls the buffer
     | every `poll_interval_ms`.
     |
+    | The log is stored as a header plus pages of `page_size` events, so an
+    | append costs the same on the ten-thousandth token as on the first.
+    | The producer heartbeats the header on every append (and with
+    | `touch()` while silent inside a long tool call); a tail that finds a
+    | running turn with no heartbeat for `stale_after_seconds` fails it
+    | with the `ai-kit::streaming.stale` message instead of spinning until
+    | the TTL — the liveness signal for a worker killed mid-turn. Keep the
+    | producer's touch interval well under it. `stale_trailing_done`
+    | appends an empty `done` after that stale `error`, for clients that
+    | only tear down on `done` (see TurnBuffer::fail()). 0 disables the
+    | stale check.
+    |
     */
 
     'streaming' => [
@@ -99,6 +111,9 @@ return [
         'max_stream_seconds' => (int) env('AI_KIT_STREAMING_MAX_SECONDS', 180),
         'keepalive_seconds' => (int) env('AI_KIT_STREAMING_KEEPALIVE_SECONDS', 15),
         'poll_interval_ms' => (int) env('AI_KIT_STREAMING_POLL_INTERVAL_MS', 150),
+        'page_size' => 64,
+        'stale_after_seconds' => 300,
+        'stale_trailing_done' => false,
     ],
 
     /*
@@ -227,10 +242,35 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Chat
+    |--------------------------------------------------------------------------
+    |
+    | The shared DEFAULT chat model for the fleet (DECISIONS.md #21). Every
+    | app inherits this slug unless it overrides it — through
+    | AI_KIT_CHAT_MODEL, through its own published config, or through an
+    | app-level setting that wins over config (uqucc's `AiSettings->chat_model`
+    | row does, and has to be migrated at adoption).
+    |
+    | The slug is PINNED by owner ruling, not chosen here: Google Gemini
+    | Flash Lite, the latest lite generation at ruling time (tools +
+    | reasoning + structured outputs + multimodal, 1M context). Cheaper prior
+    | generations (`google/gemini-3.1-flash-lite`,
+    | `google/gemini-2.5-flash-lite`) are the fallback candidates if cost or
+    | behaviour disappoints. Read it through `Catalog::chatModel()`; a model
+    | the catalog also declares picks up that entry's fallbacks and price cap.
+    |
+    */
+
+    'chat' => [
+        'model' => env('AI_KIT_CHAT_MODEL', 'google/gemini-3.5-flash-lite'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Approvals
     |--------------------------------------------------------------------------
     |
-    | Two seams live here. The DECIDED contract (DECISIONS.md #3) is the
+    | One seam lives here — the DECIDED contract (DECISIONS.md #3), the
     | classified pause on laravel/ai's native `Approvable`: tools extend
     | `Classified\ClassifiedTool`, declare a server-derived Capability
     | (read / write+undoable / destructive), reads run free, undoable
@@ -239,25 +279,17 @@ return [
     | `Classified\ApprovalCards` renders the cards and `Classified\AskUser`
     | rides the same pause for mid-turn questions.
     |
-    | TRANSITIONAL: the propose → confirm → execute machinery below
-    | predates that ruling; it stays until the apps running it (uqucc)
-    | migrate onto the classified seam, then it is retired.
+    | Executed writes claim exactly-once rows in `write_executions_table`,
+    | so a resumed or replayed turn never runs the same write twice.
     |
-    | The propose → confirm → execute pattern: proposals persist in
-    | `proposals_table`, executed plan steps claim exactly-once rows in
-    | `write_executions_table`, and proposed plans wait for their confirm
-    | turn in the plan cache store for `plan_ttl_seconds` (an abandoned plan
-    | quietly lapses). `auto_approve` lets a single non-destructive, undoable
-    | step skip the approval card; turn it off to always show the card.
+    | The transitional propose → confirm → execute machinery was RETIRED in
+    | v0.8.0; its `proposals_table`, `plan_cache_store`, `plan_ttl_seconds`
+    | and `auto_approve` keys are gone with it.
     |
     */
 
     'approvals' => [
-        'proposals_table' => 'ai_proposals',
         'write_executions_table' => 'ai_write_executions',
-        'plan_cache_store' => env('AI_KIT_PLAN_CACHE_STORE'),
-        'plan_ttl_seconds' => (int) env('AI_KIT_PLAN_TTL_SECONDS', 3600),
-        'auto_approve' => true,
 
         // Turn undo (opt-in): executed writes ledger their compensations in
         // `undo_table` and UndoTurn replays a whole turn in reverse. Keep

--- a/config/ai.php
+++ b/config/ai.php
@@ -38,12 +38,19 @@ return [
     |--------------------------------------------------------------------------
     |
     | The model used for conversational and content-drafting tasks (page copy,
-    | announcements, summaries). Model ids are OpenRouter slugs, pinned to a
-    | dated build so a silent upstream reroute cannot change chat behavior.
+    | announcements, summaries). Model ids are OpenRouter slugs.
+    |
+    | `model` is deliberately EMPTY by default: the fleet's shared chat model
+    | lives in the kit (ai-kit docs/DECISIONS.md #21, `ai-kit.chat.model`) and
+    | uqucc inherits it rather than pinning a second copy of the slug here.
+    | Set AI_CHAT_MODEL to override the shared default for this app only. The
+    | whole chain — operator setting, this key, the kit default — is resolved
+    | in one place, {@see \App\Settings\AiSettings::chatModel()}.
     |
     | `reasoning_effort` is 'low' because the assistant is an interactive
-    | surface and the -0731 build's server default is 'high' — every caller
-    | must therefore send the effort explicitly to get the faster path.
+    | surface and some builds default to 'high' server-side — every caller
+    | must therefore send the effort explicitly to get the faster path. The
+    | shared Gemini Flash Lite default supports it.
     |
     | `queue` is where a resumable assistant turn runs (both the student and
     | the admin surface). It gets a queue of its OWN rather than sharing one:
@@ -57,7 +64,7 @@ return [
     */
 
     'chat' => [
-        'model' => env('AI_CHAT_MODEL', 'deepseek/deepseek-v4-flash-0731'),
+        'model' => env('AI_CHAT_MODEL'),
         'reasoning_effort' => env('AI_CHAT_REASONING_EFFORT', 'low'),
         'timeout' => (int) env('AI_CHAT_TIMEOUT', 60),
         'queue' => 'ai-chat',

--- a/database/settings/2026_08_20_120000_adopt_shared_default_chat_model.php
+++ b/database/settings/2026_08_20_120000_adopt_shared_default_chat_model.php
@@ -1,0 +1,29 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    /**
+     * Move the pinned chat model onto the fleet's shared default, Google
+     * Gemini Flash Lite (ai-kit docs/DECISIONS.md #21).
+     *
+     * `AiSettings->chat_model` is what the assistants actually send —
+     * config is only the fallback for an empty row — so inheriting the kit's
+     * shared default in config alone would leave every environment on the old
+     * DeepSeek slug. Only rows still on that slug are rewritten; a model an
+     * operator chose deliberately is left alone.
+     *
+     * `reasoning_effort` stays 'low': the shared default supports it, so the
+     * interactive surface keeps the faster path.
+     */
+    public function up(): void
+    {
+        $this->migrator->update(
+            'ai.chat_model',
+            fn (string $model): string => $model === 'deepseek/deepseek-v4-flash-0731'
+                ? 'google/gemini-3.5-flash-lite'
+                : $model,
+        );
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "uqucc-kitbuffer",
+    "name": "uqucc-kit09",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -7,7 +7,7 @@
             "dependencies": {
                 "@formkit/auto-animate": "^0.9.0",
                 "@inertiajs/vue3": "^2.0.0",
-                "@saad5400/ai-kit": "github:Saad5400/ai-kit#semver:^0.7.3",
+                "@saad5400/ai-kit": "github:Saad5400/ai-kit#semver:^0.9.0",
                 "@tailwindcss/vite": "^4.1.11",
                 "@tanstack/vue-table": "^8.21.3",
                 "@tiptap/core": "^2.8.0",
@@ -1715,8 +1715,8 @@
             ]
         },
         "node_modules/@saad5400/ai-kit": {
-            "version": "0.7.3",
-            "resolved": "git+ssh://git@github.com/Saad5400/ai-kit.git#8851863470aa89734c85afce17cde359c1a8b9c6",
+            "version": "0.9.0",
+            "resolved": "git+ssh://git@github.com/Saad5400/ai-kit.git#240110f5bb4d367430641c3e7f26c23a87e7e722",
             "license": "UNLICENSED",
             "dependencies": {
                 "eventsource-parser": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "@formkit/auto-animate": "^0.9.0",
         "@inertiajs/vue3": "^2.0.0",
-        "@saad5400/ai-kit": "github:Saad5400/ai-kit#semver:^0.7.3",
+        "@saad5400/ai-kit": "github:Saad5400/ai-kit#semver:^0.9.0",
         "@tailwindcss/vite": "^4.1.11",
         "@tanstack/vue-table": "^8.21.3",
         "@tiptap/core": "^2.8.0",

--- a/resources/js/pages/manage/assistant/Index.vue
+++ b/resources/js/pages/manage/assistant/Index.vue
@@ -844,6 +844,11 @@ onBeforeUnmount(() => abortController?.abort());
                                     :answer="trackedFor(group.card).answer"
                                     :skipped="trackedFor(group.card).decision?.action === 'reject'"
                                     placeholder="اكتب إجابتك…"
+                                    send-label="إرسال"
+                                    skip-label="تخطٍّ"
+                                    answered-label="إجابتك"
+                                    skipped-label="تم التخطي"
+                                    pending-label="بانتظار ردّك"
                                     @answer="(answer: string) => onQuestionAnswer(group.card as QuestionPayload, answer)"
                                     @skip="onCardDecision(group.card, { action: 'reject' })"
                                 />
@@ -855,6 +860,14 @@ onBeforeUnmount(() => abortController?.abort());
                                         :key="group.card.id"
                                         :card="asApprovalCard(group.card)"
                                         :disabled="!isPending(group.card) || isStreaming"
+                                        :pending="isPending(group.card)"
+                                        confirm-label="تأكيد"
+                                        reject-label="رفض"
+                                        destructive-label="لا يمكن التراجع"
+                                        undoable-label="قابل للتراجع"
+                                        pending-label="بانتظار موافقتك"
+                                        details-label="تفاصيل تقنية"
+                                        empty-label="غير محدَّد"
                                         @decide="(decision: ClientDecision) => onCardDecision(group.card, decision)"
                                     >
                                         <template #icon>

--- a/tests/Feature/Ai/AiGatewayRegistrationTest.php
+++ b/tests/Feature/Ai/AiGatewayRegistrationTest.php
@@ -2,6 +2,7 @@
 
 use Laravel\Ai\AiManager;
 use Laravel\Ai\Exceptions\AiException;
+use Saad\AiKit\Catalog\Catalog;
 use Saad\AiKit\Gateway\ReasoningOpenRouterGateway;
 use Saad\AiKit\Gateway\SpendCollector;
 
@@ -19,11 +20,19 @@ it('defaults the ai provider config to openrouter', function () {
 });
 
 it('exposes per-task model config keys', function () {
-    expect(config('ai.chat.model'))->toBeString()
-        ->and(config('ai.vision.model'))->toBeString()
+    expect(config('ai.vision.model'))->toBeString()
         ->and(config('ai.embeddings.model'))->toBe('openai/text-embedding-3-small')
         ->and(config('ai.embeddings.dimensions'))->toBe(1536)
         ->and(config('ai.embeddings.driver'))->toBeIn(['fake', 'openrouter']);
+});
+
+it('inherits the chat model from the kit instead of pinning its own', function () {
+    // `ai.chat.model` is an override hook (AI_CHAT_MODEL) and nothing more —
+    // the fleet's shared default lives in the kit (ai-kit DECISIONS.md #21),
+    // so uqucc carries no second copy of the slug to drift.
+    expect(config('ai.chat.model'))->toBeNull()
+        ->and(config('ai-kit.chat.model'))->toBe('google/gemini-3.5-flash-lite')
+        ->and(app(Catalog::class)->chatModel())->toBe('google/gemini-3.5-flash-lite');
 });
 
 it('turns an empty or invalid OpenRouter body into a clean AiException, not a TypeError', function () {

--- a/tests/Feature/AiSettingsTest.php
+++ b/tests/Feature/AiSettingsTest.php
@@ -19,7 +19,7 @@ describe('AiSettings defaults', function () {
     it('has the expected default models', function () {
         $settings = app(AiSettings::class);
 
-        expect($settings->chat_model)->toBe('deepseek/deepseek-v4-flash-0731')
+        expect($settings->chat_model)->toBe('google/gemini-3.5-flash-lite')
             ->and($settings->vision_model)->toBe('google/gemini-3.1-flash-lite')
             ->and($settings->embedding_model)->toBe('openai/text-embedding-3-small');
     });
@@ -30,6 +30,34 @@ describe('AiSettings defaults', function () {
         expect($settings->daily_budget_usd)->toBe(5.0)
             ->and($settings->per_session_rate_limit)->toBe(20)
             ->and($settings->per_conversation_rate_limit)->toBe(30);
+    });
+});
+
+describe('AiSettings chat model resolution', function () {
+    it('sends the operator setting when one is stored', function () {
+        $settings = app(AiSettings::class);
+        $settings->chat_model = 'openai/gpt-test';
+        $settings->save();
+
+        expect($settings->chatModel())->toBe('openai/gpt-test');
+    });
+
+    it('falls back to this app\'s config override when the setting is blank', function () {
+        config()->set('ai.chat.model', 'anthropic/claude-test');
+
+        $settings = app(AiSettings::class);
+        $settings->chat_model = '  ';
+
+        expect($settings->chatModel())->toBe('anthropic/claude-test');
+    });
+
+    it('falls through to the kit\'s shared fleet default when neither is set', function () {
+        config()->set('ai.chat.model', null);
+
+        $settings = app(AiSettings::class);
+        $settings->chat_model = '';
+
+        expect($settings->chatModel())->toBe('google/gemini-3.5-flash-lite');
     });
 });
 
@@ -110,7 +138,7 @@ describe('manage settings AI card', function () {
             ->assertInertia(fn (Assert $page) => $page
                 ->component('manage/settings/Index')
                 ->where('ai.ai_enabled', false)
-                ->where('ai.chat_model', 'deepseek/deepseek-v4-flash-0731')
+                ->where('ai.chat_model', 'google/gemini-3.5-flash-lite')
                 ->where('ai.vision_model', 'google/gemini-3.1-flash-lite')
                 ->where('ai.embedding_model', 'openai/text-embedding-3-small')
                 ->where('ai.daily_budget_usd', 5)

--- a/tests/Feature/Manage/AdminAssistantTest.php
+++ b/tests/Feature/Manage/AdminAssistantTest.php
@@ -460,11 +460,45 @@ describe('approval pause via tools', function () {
             'widget' => 'markdown',
             'editable' => true,
             'value' => $body,
+            'label' => 'المحتوى',
         ])
             ->and(adminCardField($card, 'page_id'))->toMatchArray([
                 'widget' => 'readonly',
                 'editable' => false,
                 'value' => $page->id,
+                'label' => 'الصفحة',
+            ]);
+    });
+
+    it('labels every card field in Arabic without losing the widget the label replaces', function () {
+        $page = Page::factory()->create(['title' => 'اللوائح']);
+
+        $arguments = ['page_id' => $page->id, 'title' => 'اللوائح الدراسية', 'hidden' => true];
+
+        AdminAssistant::fake([new ToolCall('tc_1', 'update_page', $arguments)]);
+
+        [, $content] = pauseTurnOn($this->admin, new ToolCall('tc_1', 'update_page', []));
+
+        $card = adminSseEventData($content, 'approval');
+
+        // Declaring a label REPLACES the kit's value-based inference for that
+        // argument, so the widgets are the regression to watch: the id must
+        // stay a readonly definition row and the flag a checkbox, not the
+        // text box a label-only spec would have produced.
+        expect(adminCardField($card, 'page_id'))->toMatchArray([
+            'widget' => 'readonly',
+            'editable' => false,
+            'label' => 'الصفحة',
+        ])
+            ->and(adminCardField($card, 'title'))->toMatchArray([
+                'widget' => 'text',
+                'editable' => true,
+                'label' => 'العنوان',
+            ])
+            ->and(adminCardField($card, 'hidden'))->toMatchArray([
+                'widget' => 'boolean',
+                'editable' => true,
+                'label' => 'الإخفاء من الموقع',
             ]);
     });
 
@@ -479,8 +513,8 @@ describe('approval pause via tools', function () {
 
         $card = adminSseEventData($content, 'approval');
 
-        expect(adminCardField($card, 'action'))->toMatchArray(['widget' => 'readonly', 'editable' => false, 'value' => 'rename'])
-            ->and(adminCardField($card, 'title'))->toMatchArray(['widget' => 'text', 'editable' => true]);
+        expect(adminCardField($card, 'action'))->toMatchArray(['widget' => 'readonly', 'editable' => false, 'value' => 'rename', 'label' => 'نوع التغيير'])
+            ->and(adminCardField($card, 'title'))->toMatchArray(['widget' => 'text', 'editable' => true, 'label' => 'العنوان']);
     });
 
     it('carries the model\'s suggested answers on a question card', function () {


### PR DESCRIPTION
**DO NOT MERGE YET** — uqucc auto-deploys on merge, and this carries a settings
migration that rewrites the live `AiSettings->chat_model` row. The manager owns
the merge.

## 1. Kit bump — `^0.7.3` → `^0.9.0` (composer + npm)

The v0.8.0 removal of the transitional proposal module is a no-op here: uqucc
moved onto the classified seam in #129 and imports none of the deleted classes.
The only trace was a docblock in `AdminAction` still describing the old
`ProposalExecutor` flow and naming the now-deleted
`Saad\AiKit\Approvals\Proposal` — rewritten to describe the pause it actually
runs. (The `Proposal` grep hits elsewhere are uqucc's own `PageContentProposal`
page-authoring model, unrelated to the kit.)

The published `config/ai-kit.php` is re-synced with the v0.9.0 file, keeping
uqucc's one documented override (`conversations.retention_days => 90`,
DECISIONS.md #9). That drops the four retired keys (`proposals_table`,
`plan_cache_store`, `plan_ttl_seconds`, `auto_approve`) and picks up the new
`chat` section plus three streaming/TurnBuffer keys (`page_size`,
`stale_after_seconds`, `stale_trailing_done`) the published copy had been
missing since the resumable-turns work.

The `ai_proposals` **table is deliberately left in place** — the kit ships no
drop migration, and its rows are not ours to delete on a version bump.

## 2. Shared default chat model (DECISIONS.md #21)

`Catalog::chatModel()` becomes the **floor** of uqucc's chain rather than a
second pinned slug: `AiSettings->chat_model` (operator) → `config('ai.chat.model')`
(this app's `AI_CHAT_MODEL` override, now defaulting to empty) → the kit's
shared default. An environment that sets nothing inherits the fleet decision.

The chain had been duplicated verbatim in three private `model()` methods
(`StudentAssistant`, `AdminAssistant`, `PageCopilot`); it now lives once in
`AiSettings::chatModel()`, the one object all three already hold.

A settings migration moves the **seeded** row from
`deepseek/deepseek-v4-flash-0731` to `google/gemini-3.5-flash-lite`, following
the pattern from #130: only a row still holding the old default is rewritten,
so an operator's deliberate choice survives. `reasoning_effort` stays `'low'`
(the Gemini lite supports it). The **authoring** model is outside the ruling
and untouched.

## 3. v0.9.0 card props

The redesigned `ApprovalCard` defaults `pending` to **true** and uqucc never
passed it — so every settled card in a rehydrated thread would have worn the
accent rail and tint meant to mark the one card still awaiting a decision. Now
passed from the same tracked state that drives `disabled`. `QuestionCard`
needs no equivalent (it derives settled state from `answer` / `skipped`, which
uqucc already passed).

Copy props are passed explicitly, matching uqucc's literal-Arabic template
convention, so the card's buttons share the vocabulary of the decision chip
rendered beneath them («تأكيد» → «تم التأكيد») instead of matching it by
coincidence. `pendingLabel` says «بانتظار موافقتك» rather than describing
undoability.

The v0.9.0 theming trap does not apply: uqucc maps every `--ai-kit-*` token to
an `oklch()` color, not to raw HSL channels. Cards already render as top-level
siblings of `ProcessGroup`, which is what the kit requires.

## 4. Arabic `Field` labels on every write action

29 write actions now declare Arabic labels, so a card reads «الصفحة» /
«المحتوى» instead of a humanized `page_id`. Tool schemas stay English for the
model.

**Trap worth recording for the other apps:** declaring a field spec *replaces*
the kit's value-based inference for that argument — `ApprovalCards::fields()`
picks `fromSpec` **or** `infer`, never both — and a spec array without a
`widget` key defaults to a plain **editable text field**. A label added the
obvious way therefore turns a readonly `*_id` into an editable text box that
can repoint the write, and a boolean into a text input. Every label here
restates its widget, and a new test asserts the widgets survived.

`UpdatePageAction` draws its labels from the `FIELD_LABELS` const it already
uses for its Arabic summary sentence, so card and summary cannot drift.

## 5. Resizable sidebar — not applicable to uqucc

Surveyed every AI surface; **uqucc has no sidebar assistant**, so ruling #23
("every app that hosts the assistant in a sidebar") has nothing to attach to
here, and no sidebar was invented:

- `/almosaed` (`pages/AssistantPage.vue`) — a full Inertia page inside
  `DocsLayout`, with a `PageHeader`; the assistant *is* the page.
- `/manage/assistant` (`pages/manage/assistant/Index.vue`) — a full page inside
  `ManageLayout`, a full-width card at `min-height: 65dvh`.
- The `PageCopilot` surfaces are modal dialogs (`CopilotImproveDialog`,
  `CopilotDraftDialog`), not panels.

If the assistant should *become* a dockable sidebar on either surface, that is
a layout redesign and a separate decision, not a bump item.

## 6. Sent-message attachments — gap confirmed, needs server surface

The catodemy defect reproduces in uqucc's student chat, and it is **not**
contained to client rendering, so it is reported rather than fixed here:

- **Client:** `AssistantPage.vue`'s `ChatMessage` type has no attachment field;
  `sendMessage()` pushes `newMessage('user', message)` (text only) and clears
  `attachments.value` immediately, so the composer chips vanish at send.
- **Persistence:** `GenerateChatReply` calls `$agent->stream($prompt)` without
  the `attachments` argument, so `agent_conversation_messages.attachments` is
  always `[]`. Only the *extracted text* reaches the model, folded into the
  prompt.
- **Rehydration:** `ChatController::show()` deliberately strips the folded
  block via `AttachmentContext::unwrap()`, and its JSON contract is
  `role/content/citations/created_at` — no attachment field. A test asserts
  this stripping on purpose.
- **Attribution:** `ai_chat_attachments` carries `conversation_id` but **no
  message-level column**, so even querying it back cannot say which message an
  attachment belonged to.
- **Delivery:** there is **no** route serving a stored attachment back to the
  visitor — `routes/web.php` has only the upload POST.

A coherent fix needs a per-message attribution column (migration), an
`attachments` array on the `show()` contract, and a session-authorized
download/preview route before the client has anything to render or link. Happy
to take that as its own PR.

## Gates (no CI in this repo — all local)

- `php artisan test` — **1222 passed**, 2 failed: the pre-existing
  Welcome-page failures also present on `main` (`ExampleTest`,
  `PublicRoutesTest > renders the welcome page`).
- `npx vue-tsc --noEmit` — clean.
- `npm test` (vitest) — 129 passed.
- `npm run build` **and `npm run build:ssr`** — both pass. The Vite gotcha
  survived: `@saad5400/ai-kit` is still excluded from `optimizeDeps` and listed
  in `ssr.noExternal`. SSR matters because `nixpacks.toml` deploys with
  `build:ssr`.
- `pint` — clean on every touched file.

Not verified: a live visual pass over the redesigned card markup. Exercising a
real pending card needs an authenticated admin plus a live model turn, and the
repo has no DOM test environment (vitest runs `environment: 'node'`, no
jsdom/test-utils), so the card checks here are structural and server-payload
level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
