### PR TITLE
Show a sent message's attachments, openable only by the session that sent them

### DIFF
--- a/app/Http/Controllers/Ai/ChatAttachmentFileController.php
+++ b/app/Http/Controllers/Ai/ChatAttachmentFileController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Http\Controllers\Ai;
+
+use App\Ai\Chat\SessionOwner;
+use App\Http\Controllers\Controller;
+use App\Models\Ai\ChatAttachment;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Saad\AiKit\Conversations\ConversationOwnership;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * GET /ai/chat/attachments/{attachment} (name: ai.chat.attachments.show) —
+ * the one door onto a chat attachment's bytes: the file the visitor themselves
+ * attached to a sent message, opened from the chip on that message's bubble.
+ *
+ * SESSION-OWNED, because that is the only identity this surface has: the public
+ * site has no accounts, so the uploader is the session that stored the row (the
+ * same identity {@see ChatController::stream()} and `cancel()` gate a turn on,
+ * and the same one {@see SessionOwner} hands laravel/ai as the conversation
+ * participant). A visitor whose session ends loses access to their own
+ * uploads — that is the honest consequence of an anonymous surface, and it
+ * matches what already happens to their threads.
+ *
+ * THE REFUSAL IS 404, NEVER 403, and that is a deliberate posture rather than
+ * laziness about status codes. A 403 confirms the id exists, which turns the
+ * ULID space into a census oracle: walk it, and every 403 is somebody else's
+ * real file. Collapsing "no such attachment" and "not yours" into one answer
+ * makes a stranger's id indistinguishable from a made-up one, so a prober
+ * learns nothing either way. The ownership filter is therefore part of the
+ * LOOKUP — not a check after a successful find — so no branch exists between
+ * the two cases that could later grow a distinguishable response.
+ *
+ * There is no signed URL and no public URL: the bytes are streamed through this
+ * authorized route so the gate sits on every fetch, and one code path serves
+ * the local dev disk and S3 alike.
+ */
+class ChatAttachmentFileController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        ConversationOwnership $ownership,
+        string $attachment,
+    ): StreamedResponse {
+        $sessionId = $request->session()->getId();
+
+        $row = ChatAttachment::query()
+            ->ownedBySession($sessionId)
+            ->whereKey($attachment)
+            ->first();
+
+        abort_if($row === null, 404);
+
+        // Second gate, and not a redundant one. `session_id` says who uploaded
+        // the bytes; this says the THREAD they are filed under is also this
+        // session's, so an attachment can never be read through a conversation
+        // its owner no longer holds. The two can only disagree through a bug,
+        // which is what defence in depth is for, and it costs one indexed
+        // lookup taken only when the row is anchored at all.
+        //
+        // An UNANCHORED row is not refused. Those are uploads whose turn never
+        // stored a message (it failed, or the visitor stopped it) plus any row
+        // written before the anchor column existed; they are still this
+        // session's own files and `session_id` already proved it. Refusing them
+        // would hide a visitor's own upload to enforce an anchor that was never
+        // written.
+        if ($row->conversation_id !== null
+            && ! $ownership->owns($row->conversation_id, $sessionId, SessionOwner::class)) {
+            abort(404);
+        }
+
+        $disk = Storage::disk($row->disk);
+
+        // 404, not 500, when the row outlived its file: the retention sweep in
+        // PruneChatAttachments makes that a routine edge, never a server fault.
+        abort_unless($disk->exists($row->path), 404);
+
+        $mime = (string) $row->mime !== '' ? (string) $row->mime : 'application/octet-stream';
+
+        return $disk->response(
+            $row->path,
+            $row->original_filename,
+            [
+                'Content-Type' => $mime,
+                // Holds the declared type whether the file renders inline or
+                // downloads, so an innocent extension can never be sniffed
+                // into an active document on our own origin.
+                'X-Content-Type-Options' => 'nosniff',
+                // A visitor's private upload: never store it in a shared cache.
+                'Cache-Control' => 'private, max-age=0, no-store',
+            ],
+            $row->isInlineSafe() ? 'inline' : 'attachment',
+        );
+    }
+}

--- a/app/Http/Controllers/Ai/ChatController.php
+++ b/app/Http/Controllers/Ai/ChatController.php
@@ -189,22 +189,59 @@ class ChatController extends Controller
             404,
         );
 
+        // One query for the whole thread's attachments, grouped by the message
+        // they were sent with — never one query per bubble. Only the columns the
+        // chip needs: `extracted_markdown` is a longText that can run to 20k
+        // characters per file, and pulling it for every attachment in a thread
+        // to render a filename would be pure waste.
+        $attachments = ChatAttachment::query()
+            ->anchoredToConversation($conversation)
+            ->select(['id', 'message_id', 'original_filename', 'mime', 'size'])
+            ->get()
+            ->groupBy('message_id');
+
         $messages = ConversationMessage::query()
             ->where('conversation_id', $conversation)
             ->orderBy('id')
             ->get()
-            ->map(fn (ConversationMessage $message): array => [
-                'role' => (string) $message->getAttribute('role'),
-                // Wrappers unwind outside-in: the category block wraps the
-                // attachment block wraps what the visitor actually typed.
-                'content' => $message->getAttribute('role') === 'user'
-                    ? $attachmentContext->unwrap($categoryContext->unwrap((string) ConversationContent::reveal($message->getAttribute('content'))))
-                    : $linkGuard->sanitize((string) ConversationContent::reveal($message->getAttribute('content'))),
-                'citations' => $message->getAttribute('role') === 'assistant'
-                    ? $citations->extractFromStored((array) $message->getAttribute('tool_results'))
-                    : [],
-                'created_at' => $message->getAttribute('created_at')?->toIso8601String(),
-            ])
+            ->map(function (ConversationMessage $message) use (
+                $attachmentContext,
+                $categoryContext,
+                $citations,
+                $linkGuard,
+                $attachments,
+            ): array {
+                $isUser = $message->getAttribute('role') === 'user';
+
+                $payload = [
+                    'role' => (string) $message->getAttribute('role'),
+                    // Wrappers unwind outside-in: the category block wraps the
+                    // attachment block wraps what the visitor actually typed.
+                    // The extracted TEXT stays stripped — it is evidence the
+                    // model read, never something the visitor wrote — and the
+                    // files themselves come back as `attachments` below.
+                    'content' => $isUser
+                        ? $attachmentContext->unwrap($categoryContext->unwrap((string) ConversationContent::reveal($message->getAttribute('content'))))
+                        : $linkGuard->sanitize((string) ConversationContent::reveal($message->getAttribute('content'))),
+                    'citations' => $message->getAttribute('role') === 'assistant'
+                        ? $citations->extractFromStored((array) $message->getAttribute('tool_results'))
+                        : [],
+                    'created_at' => $message->getAttribute('created_at')?->toIso8601String(),
+                ];
+
+                $sent = $attachments->get((string) $message->getAttribute('id'));
+
+                // Omitted entirely when a message carried no files, so a
+                // text-only thread is byte-identical to what it sent before.
+                if ($isUser && $sent !== null && $sent->isNotEmpty()) {
+                    $payload['attachments'] = $sent
+                        ->map(fn (ChatAttachment $attachment): array => $this->attachmentPayload($attachment))
+                        ->values()
+                        ->all();
+                }
+
+                return $payload;
+            })
             ->values();
 
         return response()->json(['messages' => $messages]);
@@ -286,6 +323,25 @@ class ChatController extends Controller
         return $ownership->owns($conversationId, $sessionId, SessionOwner::class)
             ? $conversationId
             : null;
+    }
+
+    /**
+     * One attachment as the chat client renders it: enough to draw the chip
+     * (name, type, size) and the authorized URL to open it. The stored PATH and
+     * the extracted TEXT never leave the server — the path is disk-internal and
+     * the extraction is model evidence, not something the visitor wrote.
+     *
+     * @return array<string, mixed>
+     */
+    private function attachmentPayload(ChatAttachment $attachment): array
+    {
+        return [
+            'id' => (string) $attachment->id,
+            'name' => (string) $attachment->original_filename,
+            'mime' => $attachment->mime,
+            'size' => $attachment->size,
+            'url' => route('ai.chat.attachments.show', ['attachment' => $attachment->id]),
+        ];
     }
 
     /**

--- a/app/Jobs/Ai/GenerateChatReply.php
+++ b/app/Jobs/Ai/GenerateChatReply.php
@@ -177,8 +177,17 @@ class GenerateChatReply implements ShouldQueue
     }
 
     /**
-     * Hand the turn's attachments to the conversation it resolved, so a
-     * rehydrated thread can still find the files the visitor sent.
+     * Anchor the turn's attachments to the conversation it resolved AND to the
+     * user message they were sent with, so a rehydrated thread puts the files
+     * back on the right bubble instead of on every bubble.
+     *
+     * The message id is read back rather than handed down because nothing on
+     * the streaming path surfaces it — the store writes the user message while
+     * the turn is running. The read is safe because this job is the
+     * conversation's only writer while it holds the turn, so the newest user
+     * row IS this turn's. A turn that never got that far leaves its rows
+     * unanchored, which renders as no chip: correct, because no stored message
+     * ever carried them.
      */
     private function bindAttachments(?string $conversationId): void
     {
@@ -188,8 +197,20 @@ class GenerateChatReply implements ShouldQueue
 
         ChatAttachment::query()
             ->whereKey($this->attachmentIds)
-            ->where('session_id', $this->sessionId)
-            ->update(['conversation_id' => $conversationId]);
+            ->ownedBySession($this->sessionId)
+            ->update([
+                'conversation_id' => $conversationId,
+                'message_id' => $this->latestUserMessageId($conversationId),
+            ]);
+    }
+
+    private function latestUserMessageId(string $conversationId): ?string
+    {
+        return ConversationMessage::query()
+            ->where('conversation_id', $conversationId)
+            ->where('role', 'user')
+            ->orderByDesc('id')
+            ->value('id');
     }
 
     private function latestAssistantMessageId(?string $conversationId): ?string

--- a/app/Models/Ai/ChatAttachment.php
+++ b/app/Models/Ai/ChatAttachment.php
@@ -5,6 +5,7 @@ namespace App\Models\Ai;
 use App\Support\Disk;
 use App\Support\LocalFile;
 use Database\Factories\Ai\ChatAttachmentFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -24,6 +25,7 @@ use Illuminate\Support\Facades\Storage;
  * @property string $id
  * @property string $session_id
  * @property string|null $conversation_id
+ * @property string|null $message_id
  * @property string $original_filename
  * @property string $disk
  * @property string $path
@@ -57,6 +59,7 @@ class ChatAttachment extends Model
     protected $fillable = [
         'session_id',
         'conversation_id',
+        'message_id',
         'original_filename',
         'disk',
         'path',
@@ -86,6 +89,56 @@ class ChatAttachment extends Model
         static::deleted(function (self $attachment): void {
             Storage::disk($attachment->disk)->delete($attachment->path);
         });
+    }
+
+    /**
+     * The uploads this session owns. The ONE ownership predicate, so the
+     * thread read and the download route ask the identical question — a
+     * foreign id is simply not found rather than found-then-refused.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeOwnedBySession(Builder $query, string $sessionId): Builder
+    {
+        return $query->where('session_id', $sessionId);
+    }
+
+    /**
+     * The attachments anchored to one stored thread, oldest first — the
+     * thread endpoint's single query, grouped by message in PHP.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeAnchoredToConversation(Builder $query, string $conversationId): Builder
+    {
+        return $query->where('conversation_id', $conversationId)
+            ->whereNotNull('message_id')
+            ->orderBy('id');
+    }
+
+    /**
+     * Whether these bytes may be served INLINE rather than forced to
+     * download.
+     *
+     * The recorded mime comes from the upload itself, and the file is served
+     * from our own origin, so a file with an innocent name but HTML or SVG
+     * bytes could otherwise render as an active document there. Only the small
+     * raster + PDF set gets inline; anything else downloads. The upload
+     * validator accepts exactly this set today, so the list is a second lock
+     * on the same door rather than a new policy — and it stays correct if the
+     * validator ever widens.
+     */
+    public function isInlineSafe(): bool
+    {
+        return in_array(strtolower((string) $this->mime), [
+            'application/pdf',
+            'image/jpeg',
+            'image/png',
+            'image/webp',
+            'image/gif',
+        ], true);
     }
 
     /**

--- a/composer.lock
+++ b/composer.lock
@@ -5283,16 +5283,16 @@
         },
         {
             "name": "saad/ai-kit",
-            "version": "v0.9.0",
+            "version": "v0.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Saad5400/ai-kit.git",
-                "reference": "240110f5bb4d367430641c3e7f26c23a87e7e722"
+                "reference": "67fc914352ae3f00ddcc8d4e01c0da46d3aad91f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Saad5400/ai-kit/zipball/240110f5bb4d367430641c3e7f26c23a87e7e722",
-                "reference": "240110f5bb4d367430641c3e7f26c23a87e7e722",
+                "url": "https://api.github.com/repos/Saad5400/ai-kit/zipball/67fc914352ae3f00ddcc8d4e01c0da46d3aad91f",
+                "reference": "67fc914352ae3f00ddcc8d4e01c0da46d3aad91f",
                 "shasum": ""
             },
             "require": {
@@ -5349,10 +5349,10 @@
                 "openrouter"
             ],
             "support": {
-                "source": "https://github.com/Saad5400/ai-kit/tree/v0.9.0",
+                "source": "https://github.com/Saad5400/ai-kit/tree/v0.9.1",
                 "issues": "https://github.com/Saad5400/ai-kit/issues"
             },
-            "time": "2026-08-20T09:43:39+00:00"
+            "time": "2026-08-20T13:56:54+00:00"
         },
         {
             "name": "scrivo/highlight.php",

--- a/database/migrations/2026_08_23_120000_add_message_anchor_to_ai_chat_attachments_table.php
+++ b/database/migrations/2026_08_23_120000_add_message_anchor_to_ai_chat_attachments_table.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Anchor a sent chat attachment to the MESSAGE it was sent with.
+ *
+ * The table already carries `conversation_id`, bound once a turn resolves its
+ * thread — enough for the retention cascade, which only ever asks "which
+ * conversation is this filed under?". It cannot answer the question the chat UI
+ * asks on every reload: "which bubble does this file belong to?". Without a
+ * message anchor a rehydrated thread can only show every file the visitor ever
+ * attached on every one of their messages, which is worse than showing none —
+ * so it showed none, which is the defect this closes.
+ *
+ * `message_id` is NULLABLE and stays null until the conversation store has
+ * actually written the user message; {@see \App\Jobs\Ai\GenerateChatReply}
+ * binds it there, beside the existing `conversation_id` bind:
+ *
+ *  · A turn that never got that far — it failed, or the visitor stopped it
+ *    before anything was stored — leaves its rows unanchored. Unanchored means
+ *    no bubble claims the file, which is correct: it was never attached to a
+ *    stored message. Those rows are still the uploader's own and still
+ *    downloadable by them; the retention sweep in
+ *    {@see \App\Listeners\PruneChatAttachments} collects them.
+ *  · It is the STORE's id (a uuid7 string from laravel/ai), a plain string and
+ *    deliberately NOT a foreign key: the message rows live behind a
+ *    configurable table name and a swappable store, and an attachment must
+ *    never be deleted as a side effect of history pruning it knows nothing
+ *    about. `conversation_id` is already a bare string for the same reason.
+ *
+ * NO NEW INDEX, on purpose. The one read is the thread endpoint's
+ * `where conversation_id = ?`, which fetches a conversation's attachments in a
+ * single query and groups them by message in PHP — never one query per bubble —
+ * and `conversation_id` has carried its own index since the table was created.
+ * A composite `(conversation_id, message_id)` could not cover that read either
+ * (it also selects the filename, mime, size and path), so it would buy nothing
+ * and cost every insert.
+ *
+ * Guarded (`hasTable` / `hasColumn`) so a re-run against an out-of-sync
+ * database is a no-op — the never-edit-a-run-migration rule.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('ai_chat_attachments')
+            || Schema::hasColumn('ai_chat_attachments', 'message_id')) {
+            return;
+        }
+
+        Schema::table('ai_chat_attachments', function (Blueprint $table) {
+            $table->string('message_id', 64)->nullable()->after('conversation_id');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('ai_chat_attachments', 'message_id')) {
+            return;
+        }
+
+        Schema::table('ai_chat_attachments', function (Blueprint $table) {
+            $table->dropColumn('message_id');
+        });
+    }
+};

--- a/resources/js/pages/AssistantPage.vue
+++ b/resources/js/pages/AssistantPage.vue
@@ -6,8 +6,9 @@ import PageHeader from '@/components/page/PageHeader.vue';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { formatFileSize } from '@/lib/formatters';
 import { cancel as cancelTurn, send as sendChat, show as showConversation, stream as streamTurn } from '@/routes/ai/chat';
-import { store as storeAttachment } from '@/routes/ai/chat/attachments';
+import { show as attachmentFile, store as storeAttachment } from '@/routes/ai/chat/attachments';
 import { show as showPage } from '@/routes/pages';
 import { Link } from '@inertiajs/vue3';
 import { readSseStream } from '@saad5400/ai-kit/sse';
@@ -70,12 +71,28 @@ interface Citation {
     heading: string | null;
 }
 
+/**
+ * A file the student actually sent with a message — not a composer entry.
+ * Same shape whether it was just sent (built from the upload's own result) or
+ * restored from the thread endpoint, so one chip renders both.
+ */
+interface SentAttachment {
+    id: string;
+    name: string;
+    mime: string | null;
+    size: number | null;
+    /** The authorized route that streams the bytes back; never a public URL. */
+    url: string;
+}
+
 interface ChatMessage {
     id: number;
     role: 'user' | 'assistant';
     /** The student's own text; an assistant turn renders from `segments` instead. */
     content: string;
     citations: Citation[];
+    /** The files sent with this message; absent on a message that carried none. */
+    attachments?: SentAttachment[];
     /** The turn in arrival order — mutated in place by `timeline`. */
     segments: Segment[];
     timeline: Timeline;
@@ -119,6 +136,8 @@ interface PendingAttachment {
     clientId: number;
     attachmentId: string | null;
     name: string;
+    mime: string;
+    size: number;
     progress: number;
     status: AttachmentStatus;
     error?: string;
@@ -251,7 +270,7 @@ const rehydrateConversation = async (): Promise<void> => {
         }
 
         const payload = (await response.json()) as {
-            messages: { role: string; content: string; citations: Citation[] }[];
+            messages: { role: string; content: string; citations: Citation[]; attachments?: SentAttachment[] }[];
         };
 
         conversationId.value = storedId;
@@ -263,6 +282,10 @@ const rehydrateConversation = async (): Promise<void> => {
             .map((message) => {
                 const restored = newMessage(message.role as 'user' | 'assistant', message.content);
                 restored.citations = message.citations ?? [];
+
+                if (message.attachments !== undefined && message.attachments.length > 0) {
+                    restored.attachments = message.attachments;
+                }
 
                 if (restored.role === 'assistant') {
                     restored.timeline.push('delta', { text: message.content });
@@ -507,11 +530,27 @@ const sendMessage = async (): Promise<void> => {
 
     errorBanner.value = null;
 
-    const attachmentIds = attachments.value
-        .filter((attachment) => attachment.status === 'ready' && attachment.attachmentId)
-        .map((attachment) => attachment.attachmentId as string);
+    const sent = attachments.value.filter((attachment) => attachment.status === 'ready' && attachment.attachmentId);
+    const attachmentIds = sent.map((attachment) => attachment.attachmentId as string);
 
-    messages.value.push(newMessage('user', message));
+    const question = newMessage('user', message);
+
+    // The composer is cleared below, so the bubble takes its own copy of what
+    // was sent — otherwise the files vanish the moment they are sent, which is
+    // the defect this closes. The URL comes from the same named route the
+    // rehydrated payload carries, so a live chip and a restored one open the
+    // identical door.
+    if (sent.length > 0) {
+        question.attachments = sent.map((attachment) => ({
+            id: attachment.attachmentId as string,
+            name: attachment.name,
+            mime: attachment.mime === '' ? null : attachment.mime,
+            size: attachment.size,
+            url: attachmentFile.url(attachment.attachmentId as string),
+        }));
+    }
+
+    messages.value.push(question);
 
     const reply = newMessage('assistant');
     reply.streaming = true;
@@ -707,6 +746,8 @@ const onFilesSelected = (event: Event): void => {
             clientId: nextClientId++,
             attachmentId: null,
             name: file.name,
+            mime: file.type,
+            size: file.size,
             progress: 0,
             status: 'uploading',
         };
@@ -817,10 +858,33 @@ onBeforeUnmount(() => abortController?.abort());
 
                 <template v-for="message in messages" :key="message.id">
                     <!-- User bubble -->
-                    <div v-if="message.role === 'user'" class="flex justify-end">
+                    <div v-if="message.role === 'user'" class="flex flex-col items-end gap-1.5">
                         <div class="max-w-[85%] rounded-2xl rounded-se-sm bg-primary px-4 py-2.5 text-sm whitespace-pre-wrap text-primary-foreground">
                             {{ message.content }}
                         </div>
+
+                        <!-- The files sent with this message, openable only by
+                             the session that sent them. `dir="auto"` per name so
+                             a Latin filename inside an Arabic thread stays
+                             readable, and the size is LTR-isolated so it cannot
+                             reorder against the surrounding RTL text. -->
+                        <ul v-if="message.attachments?.length" class="flex max-w-[85%] flex-wrap justify-end gap-1.5">
+                            <li v-for="attachment in message.attachments" :key="attachment.id">
+                                <a
+                                    :href="attachment.url"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted px-2.5 py-1 text-xs text-muted-foreground transition hover:bg-foreground/10 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                                    :aria-label="`فتح المرفق ${attachment.name}`"
+                                >
+                                    <Paperclip class="size-3 shrink-0" />
+                                    <bdi dir="auto" class="max-w-40 truncate">{{ attachment.name }}</bdi>
+                                    <span v-if="attachment.size" dir="ltr" class="shrink-0 text-[10px] opacity-70">{{
+                                        formatFileSize(attachment.size)
+                                    }}</span>
+                                </a>
+                            </li>
+                        </ul>
                     </div>
 
                     <!-- Assistant bubble -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Ai\ChatAttachmentController;
+use App\Http\Controllers\Ai\ChatAttachmentFileController;
 use App\Http\Controllers\Ai\ChatController;
 use App\Http\Controllers\OgImageController;
 use App\Http\Controllers\PageController;
@@ -85,6 +86,17 @@ Route::middleware('throttle:ai-chat')->group(function () {
 // matching.
 Route::get('/ai/chat/turns/{turn}/stream', [ChatController::class, 'stream'])->name('ai.chat.stream');
 Route::post('/ai/chat/turns/{turn}/cancel', [ChatController::class, 'cancel'])->name('ai.chat.cancel');
+
+// Opening a file the visitor themselves attached to a sent message. OUTSIDE the
+// burst limiter for the same reason as the pair above, and more sharply: one
+// rehydrated thread can offer several chips, so tapping through the files of a
+// single conversation would 429 against a 5-per-minute budget meant for model
+// turns. It spends nothing — no model call, no daily quota slot, no budget —
+// reads back bytes this session itself uploaded, and 404s anything the
+// session does not own. The two-segment `/ai/chat/attachments/…` path is what
+// keeps the single-segment `{conversation}` route above from swallowing it.
+Route::get('/ai/chat/attachments/{attachment}', ChatAttachmentFileController::class)
+    ->name('ai.chat.attachments.show');
 
 // AI assistant chat page (must come before catch-all route) - with response caching.
 // Always renders; the chat endpoints report the disabled state at runtime.

--- a/tests/Feature/Ai/Chat/ChatAttachmentFileTest.php
+++ b/tests/Feature/Ai/Chat/ChatAttachmentFileTest.php
@@ -1,0 +1,183 @@
+<?php
+
+use App\Ai\Chat\SessionOwner;
+use App\Models\Ai\ChatAttachment;
+use App\Settings\AiSettings;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Laravel\Ai\Models\Conversation;
+
+/**
+ * The download door onto a sent chat attachment: the visitor opening a file
+ * they themselves attached, from the chip on their own bubble.
+ *
+ * The whole surface is anonymous, so the only identity is the session that
+ * stored the row — and every refusal is a 404, never a 403, so the ULID space
+ * cannot be walked as a census oracle.
+ */
+beforeEach(function () {
+    Storage::fake(ChatAttachment::DISK);
+
+    $settings = app(AiSettings::class);
+    $settings->ai_enabled = true;
+    $settings->assistant_enabled = true;
+    $settings->save();
+});
+
+/** An attachment whose bytes really exist on the fake disk. */
+function downloadableAttachment(array $attributes = []): ChatAttachment
+{
+    $attachment = ChatAttachment::factory()->ready()->create($attributes);
+
+    Storage::disk($attachment->disk)->put($attachment->path, 'PDF-BYTES');
+
+    return $attachment;
+}
+
+/** A stored thread owned by the given session, as laravel/ai records it. */
+function attachmentConversation(string $sessionId): string
+{
+    $conversationId = (string) Str::uuid7();
+
+    Conversation::query()->create([
+        'id' => $conversationId,
+        'participant_type' => SessionOwner::class,
+        'participant_id' => $sessionId,
+        'title' => 'محادثة',
+    ]);
+
+    return $conversationId;
+}
+
+it('streams a visitor their own attachment with the stored type and nosniff', function () {
+    $sessionId = chatSessionId();
+    $conversationId = attachmentConversation($sessionId);
+
+    $attachment = downloadableAttachment([
+        'session_id' => $sessionId,
+        'conversation_id' => $conversationId,
+        'message_id' => (string) Str::uuid7(),
+        'original_filename' => 'transcript.pdf',
+    ]);
+
+    $response = withChatSession($sessionId)
+        ->get(route('ai.chat.attachments.show', $attachment->id))
+        ->assertOk()
+        ->assertHeader('content-type', 'application/pdf')
+        // The declared type must hold: an innocent extension can never be
+        // sniffed into an active document on our own origin.
+        ->assertHeader('x-content-type-options', 'nosniff');
+
+    expect($response->streamedContent())->toBe('PDF-BYTES')
+        // A PDF is in the inline-safe set, so it opens rather than downloads.
+        ->and($response->headers->get('content-disposition'))->toStartWith('inline');
+
+    // A visitor's private upload is never stored in a shared cache.
+    expect($response->headers->get('cache-control'))->toContain('private')
+        ->and($response->headers->get('cache-control'))->toContain('no-store');
+});
+
+it('forces anything outside the inline-safe set to download instead of render', function () {
+    $sessionId = chatSessionId();
+
+    // A file whose recorded mime is active content. The upload validator does
+    // not accept this today; the route refuses to render it anyway, so the
+    // posture survives the validator ever widening.
+    $attachment = downloadableAttachment([
+        'session_id' => $sessionId,
+        'mime' => 'image/svg+xml',
+        'original_filename' => 'payload.svg',
+    ]);
+
+    $response = withChatSession($sessionId)
+        ->get(route('ai.chat.attachments.show', $attachment->id))
+        ->assertOk()
+        ->assertHeader('x-content-type-options', 'nosniff');
+
+    expect($response->headers->get('content-disposition'))->toStartWith('attachment');
+});
+
+it('answers 404 — never 403 — for another session\'s attachment', function () {
+    $attachment = downloadableAttachment(['session_id' => chatSessionId()]);
+
+    // A 403 here would confirm the id exists, which is what makes the id space
+    // enumerable. A stranger's id must be indistinguishable from a made-up one.
+    withChatSession(chatSessionId())
+        ->get(route('ai.chat.attachments.show', $attachment->id))
+        ->assertNotFound();
+});
+
+it('answers the same 404 for an id that never existed', function () {
+    withChatSession(chatSessionId())
+        ->get(route('ai.chat.attachments.show', (string) Str::ulid()))
+        ->assertNotFound();
+});
+
+it('refuses an attachment filed under a thread the session no longer owns', function () {
+    $sessionId = chatSessionId();
+
+    // The row says this session uploaded it, but the THREAD belongs to someone
+    // else. The two can only disagree through a bug — the second gate is what
+    // stops that bug from becoming a disclosure.
+    $attachment = downloadableAttachment([
+        'session_id' => $sessionId,
+        'conversation_id' => attachmentConversation(chatSessionId()),
+        'message_id' => (string) Str::uuid7(),
+    ]);
+
+    withChatSession($sessionId)
+        ->get(route('ai.chat.attachments.show', $attachment->id))
+        ->assertNotFound();
+});
+
+it('still serves an unanchored upload to its own uploader', function () {
+    $sessionId = chatSessionId();
+
+    // A turn that never stored a message leaves the row unanchored. It is still
+    // this session's own file, and `session_id` already proved it — hiding a
+    // visitor's own upload to enforce an anchor that was never written is not
+    // security.
+    $attachment = downloadableAttachment([
+        'session_id' => $sessionId,
+        'conversation_id' => null,
+        'message_id' => null,
+    ]);
+
+    withChatSession($sessionId)
+        ->get(route('ai.chat.attachments.show', $attachment->id))
+        ->assertOk();
+});
+
+it('answers 404 when the row outlived its file on the disk', function () {
+    $sessionId = chatSessionId();
+
+    // The retention sweep deletes rows and files together, so this is a routine
+    // edge rather than a server fault — a 500 would page someone for nothing.
+    $attachment = ChatAttachment::factory()->ready()->create(['session_id' => $sessionId]);
+
+    withChatSession($sessionId)
+        ->get(route('ai.chat.attachments.show', $attachment->id))
+        ->assertNotFound();
+});
+
+it('keeps opening attachments once the chat burst limiter is spent', function () {
+    $sessionId = chatSessionId();
+
+    $attachment = downloadableAttachment(['session_id' => $sessionId]);
+
+    // `throttle:ai-chat` is 5 turns a minute. One rehydrated thread can offer
+    // more chips than that, and opening a file spends no model call, no quota
+    // slot and no budget — so the route sits outside the limiter, exactly like
+    // the resume/cancel pair.
+    for ($i = 0; $i < 6; $i++) {
+        withChatSession($sessionId)->post(route('ai.chat.send'), ['message' => 'مرحباً']);
+    }
+
+    withChatSession($sessionId)
+        ->post(route('ai.chat.send'), ['message' => 'مرحباً'])
+        ->assertStatus(429);
+
+    withChatSession($sessionId)
+        ->get(route('ai.chat.attachments.show', $attachment->id))
+        ->assertOk();
+});

--- a/tests/Feature/Ai/Chat/ChatEndpointTest.php
+++ b/tests/Feature/Ai/Chat/ChatEndpointTest.php
@@ -30,25 +30,6 @@ beforeEach(function () {
 });
 
 /**
- * Pin the visitor's session id: the framework encrypts default cookies for
- * the request, so StartSession adopts this id exactly — which is what keys
- * conversation ownership and the rate limiters.
- */
-function withChatSession(string $sessionId)
-{
-    // withCredentials(): json helpers (getJson/postJson) only forward default
-    // cookies when credentials are enabled.
-    return test()
-        ->withCredentials()
-        ->withCookie((string) config('session.cookie'), $sessionId);
-}
-
-function chatSessionId(): string
-{
-    return Str::random(40);
-}
-
-/**
  * Parse one named SSE event's data payload out of a streamed chat response.
  *
  * @return array<string, mixed>|null
@@ -311,12 +292,16 @@ it('returns the stored thread to its owning session with the contract shape', fu
         ->assertJsonStructure(['messages' => [['role', 'content', 'citations', 'created_at']]]);
 });
 
-it('hides the original typed message behind attachment wrapping when rehydrating', function () {
+it('rehydrates the typed message without its evidence wrapper, but with the files themselves', function () {
     StudentAssistant::fake(['رد.']);
 
     $sessionId = chatSessionId();
 
-    $attachment = ChatAttachment::factory()->ready()->create(['session_id' => $sessionId]);
+    $attachment = ChatAttachment::factory()->ready()->create([
+        'session_id' => $sessionId,
+        'original_filename' => 'transcript.pdf',
+        'extracted_markdown' => 'المعدل التراكمي: 3.5',
+    ]);
 
     $content = withChatSession($sessionId)
         ->post(route('ai.chat.send'), [
@@ -327,10 +312,94 @@ it('hides the original typed message behind attachment wrapping when rehydrating
 
     $conversationId = sseEventData($content, 'done')['conversation_id'];
 
-    withChatSession($sessionId)
+    $response = withChatSession($sessionId)
         ->getJson(route('ai.chat.show', $conversationId))
         ->assertOk()
-        ->assertJsonPath('messages.0.content', 'كم معدلي؟');
+        // The EXTRACTED TEXT stays stripped: it is evidence the model read, and
+        // 20k characters of PDF is not something the visitor typed.
+        ->assertJsonPath('messages.0.content', 'كم معدلي؟')
+        // The FILE comes back beside it, which is what the bubble draws.
+        ->assertJsonPath('messages.0.attachments.0.id', $attachment->id)
+        ->assertJsonPath('messages.0.attachments.0.name', 'transcript.pdf')
+        ->assertJsonPath('messages.0.attachments.0.mime', 'application/pdf')
+        ->assertJsonPath('messages.0.attachments.0.url', route('ai.chat.attachments.show', $attachment->id));
+
+    // Never the stored path, and never the extraction, on the wire.
+    expect($response->json('messages.0.attachments.0'))->not->toHaveKeys(['path', 'disk', 'extracted_markdown'])
+        ->and($response->json('messages.0'))->not->toHaveKey('attachments.0.path');
+});
+
+it('anchors a sent attachment to the user message it rode in on, not merely to the thread', function () {
+    StudentAssistant::fake(['رد.']);
+
+    $sessionId = chatSessionId();
+    $first = ChatAttachment::factory()->ready()->create(['session_id' => $sessionId]);
+
+    $content = withChatSession($sessionId)
+        ->post(route('ai.chat.send'), ['message' => 'الرسالة الأولى', 'attachment_ids' => [$first->id]])
+        ->streamedContent();
+
+    $conversationId = sseEventData($content, 'done')['conversation_id'];
+
+    // A SECOND turn in the same thread, with its own file. Anchoring by
+    // conversation alone would put both files on both bubbles.
+    $second = ChatAttachment::factory()->ready()->create(['session_id' => $sessionId]);
+
+    withChatSession($sessionId)
+        ->post(route('ai.chat.send'), [
+            'message' => 'الرسالة الثانية',
+            'conversation_id' => $conversationId,
+            'attachment_ids' => [$second->id],
+        ])
+        ->streamedContent();
+
+    $userMessages = ConversationMessage::query()
+        ->where('conversation_id', $conversationId)
+        ->where('role', 'user')
+        ->orderBy('id')
+        ->pluck('id');
+
+    expect($first->refresh()->message_id)->toBe($userMessages[0])
+        ->and($second->refresh()->message_id)->toBe($userMessages[1]);
+
+    $thread = withChatSession($sessionId)->getJson(route('ai.chat.show', $conversationId))->assertOk();
+
+    expect($thread->json('messages.0.attachments'))->toHaveCount(1)
+        ->and($thread->json('messages.0.attachments.0.id'))->toBe($first->id)
+        ->and($thread->json('messages.2.attachments'))->toHaveCount(1)
+        ->and($thread->json('messages.2.attachments.0.id'))->toBe($second->id);
+});
+
+it('omits the attachments key entirely on a message that carried no files', function () {
+    $sessionId = chatSessionId();
+    $conversationId = createStoredConversation($sessionId);
+
+    $response = withChatSession($sessionId)
+        ->getJson(route('ai.chat.show', $conversationId))
+        ->assertOk();
+
+    // A text-only thread stays byte-identical to what it sent before.
+    expect($response->json('messages.0'))->not->toHaveKey('attachments')
+        ->and($response->json('messages.1'))->not->toHaveKey('attachments');
+});
+
+it('leaves an unanchored upload off every bubble', function () {
+    $sessionId = chatSessionId();
+    $conversationId = createStoredConversation($sessionId);
+
+    // A turn that died before the store wrote its message: bound to the thread
+    // but never to a message. No bubble may claim it.
+    ChatAttachment::factory()->ready()->create([
+        'session_id' => $sessionId,
+        'conversation_id' => $conversationId,
+        'message_id' => null,
+    ]);
+
+    $response = withChatSession($sessionId)
+        ->getJson(route('ai.chat.show', $conversationId))
+        ->assertOk();
+
+    expect($response->json('messages.0'))->not->toHaveKey('attachments');
 });
 
 it('answers 404 when another session requests the thread', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -45,3 +45,26 @@ function something()
 {
     // ..
 }
+
+/**
+ * Pin an anonymous visitor's session id for a chat request. The framework
+ * encrypts default cookies, so StartSession adopts this id exactly — which is
+ * what keys conversation ownership, attachment ownership and the rate limiters.
+ *
+ * Shared here rather than in one test file because several chat suites need the
+ * same identity: the endpoint contract, the attachment download door, and
+ * anything else gating on "is this the session that sent it?".
+ */
+function withChatSession(string $sessionId)
+{
+    // withCredentials(): json helpers (getJson/postJson) only forward default
+    // cookies when credentials are enabled.
+    return test()
+        ->withCredentials()
+        ->withCookie((string) config('session.cookie'), $sessionId);
+}
+
+function chatSessionId(): string
+{
+    return Illuminate\Support\Str::random(40);
+}


### PR DESCRIPTION
**DO NOT MERGE** — uqucc auto-deploys on merge and this carries a schema
migration. Needs the owner's explicit go; the manager is obtaining it.

Closes the gap I scoped in #137: sending a chat message with a file showed only
the text — nothing visible on the bubble, nothing clickable, live or after a
reload. Four layers were missing; this builds all four for the student chat.

The admin assistant accepts **no uploads** (no upload route, no client picker),
so "wire both surfaces" resolves to the student chat only.

## 1. Message anchor

`ai_chat_attachments` already carried `conversation_id` — all the retention
cascade needs, and useless for the question the UI asks on every reload: *which
bubble does this file belong to?* Anchoring by conversation alone puts every
file a visitor ever attached on every one of their messages, which is worse than
showing none.

A guarded migration adds a nullable `message_id`, bound by `GenerateChatReply`
beside the existing conversation bind, once the store has actually written the
user message. Following catodemy #578: nullable, ids as plain **strings not
foreign keys** (the message rows live behind a configurable table name and a
swappable store, and an attachment must not be deleted as a side effect of
history pruning it knows nothing about), `hasTable`/`hasColumn` guarded.

**No new index, deliberately.** The one read is `where conversation_id = ?`,
which has been indexed since the table was created; a composite
`(conversation_id, message_id)` could not cover that read either (it also
selects name, mime and size), so it would buy nothing and cost every insert.

**Historic rows** keep their conversation-level binding and stay **chip-less**.
There is no honest way to infer which of a thread's messages an old upload rode
in on, and putting it on the wrong bubble is worse than leaving it off. They
remain downloadable by their uploader.

## 2. Thread payload

`show()` lists each user message's files (`id`, `name`, `mime`, `size`, `url`)
and **omits the key entirely** when a message carried none, so a text-only
thread is byte-identical to before. One query per thread, grouped by message in
PHP, selecting only the chip's columns — `extracted_markdown` is a longText that
can reach 20k characters per file.

**One refinement of the brief, flagged deliberately:** I did *not* stop
`AttachmentContext::unwrap()` from stripping. That strip removes the *extracted
text* from the message content, and it is correct — the extraction is evidence
the model read, not something the visitor wrote, and dumping 20k characters of
PDF into a chat bubble would be a worse bug than the one being fixed. The test
pinning the strip therefore stays valid and was **extended** rather than
rewritten: it now also asserts the FILES come back beside the stripped text,
which is the real contract change. The payload never carries the stored `path`,
`disk` or the extraction.

## 3. Download route

`GET /ai/chat/attachments/{attachment}`, **outside `throttle:ai-chat`** for the
resume/cancel reason and more sharply: one rehydrated thread can offer several
chips, so opening them would 429 against a five-per-minute budget meant for
model turns. It spends no model call, no quota slot, no budget. The two-segment
path keeps the single-segment `{conversation}` route from swallowing it.

Two authorization gates: `session_id` proves who uploaded the bytes (the only
identity an anonymous surface has), and the second proves the **thread** is this
session's too, so a file can never be read through a conversation its owner no
longer holds. Both refuse **404, never 403** — a 403 confirms the id exists,
turning the ULID space into a census oracle — and the ownership filter is part
of the **lookup**, not a check after a successful find, so no branch exists
between "no such attachment" and "not yours". An **unanchored** row is not
refused: `session_id` already proved it is the uploader's own file, and hiding it
to enforce an anchor that was never written is not security.

Streamed through the authorized route (no signed URL, no public URL), inline
only for the raster+PDF set, everything else forced to download,
`X-Content-Type-Options: nosniff` always, `Cache-Control: private, no-store`.
Content-Type from the stored mime. A row that outlived its file answers 404, not
500 — the retention sweep makes that a routine edge.

## 4. Client

The bubble takes its own copy of what was sent *before* the composer is cleared
(the chips used to vanish at the moment of sending), and the rehydrated thread
reads the same shape, so one chip renders both. Filenames are `<bdi dir="auto">`
so a Latin name in an Arabic thread does not scramble; the size is LTR-isolated.
Reuses the app's existing `formatFileSize`.

## Deviation needing a ruling: attachments are NOT passed to `stream()`

Brief item 2 asked me to pass the turn's attachments to the agent so they
persist on the stored user message. **I did not, and I recommend not.**

In laravel/ai the attachments argument is one object used for *both* provider
input and persistence — `AgentPrompt` hands it to the gateway and
`storeUserMessage()` writes `$prompt->attachments->toJson()`. They cannot be
separated. uqucc already extracts each attachment's text up front
(`ExtractChatAttachmentJob`, via the PDF text layer or the vision model) and
folds that text into the prompt, so passing the files as well would:

- send every image/PDF to the model a **second time**, base64-encoded
  (`MapsAttachments` inlines the bytes) — a real per-turn token cost on a live
  anonymous surface, on top of the extraction we already paid for;
- change what the model sees, and so how it answers, as a side effect of a
  display fix.

It also buys the display nothing: the anchor columns already answer "which
bubble", which is what the feature needed. If the owner *wants* the model to
receive raw files instead of extracted text, that is a real design change worth
its own PR (and would let the extraction pipeline go away) — happy to take it,
but not smuggled into this one.

## Gates (no CI in this repo — all local)

- `php artisan test` — **1344 passed**, 2 failed: the known pre-existing
  Welcome-page failures from #117 (`ExampleTest`, `PublicRoutesTest`).
- 12 new tests: 4 on the anchor and thread contract, 8 on the route (owner
  reads bytes; foreign session 404; unknown id 404; foreign-thread 404;
  unanchored still served; missing file 404; non-inline mime forced to
  download; still openable once the burst limiter is spent).
- `npx vue-tsc --noEmit` clean; vitest **141 passed**; `npm run build` and
  `npm run build:ssr` both pass; prettier clean; pint clean on all 9 touched
  PHP files.
- Migration verified on a scratch sqlite DB: applies, rolls back, re-applies,
  and **re-runs as a no-op when the column exists but the migration record does
  not** — the out-of-sync-prod case the guard is for. Both columns nullable, so
  adding it to a populated table rewrites no rows.

Not verified: a real browser pass. No DOM test environment exists here (vitest
runs `environment: 'node'`, no jsdom/test-utils), so the client is covered by
typecheck, build and the payload contract tests rather than a rendering test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
