### PR TITLE
سؤال اليوم: twelve reminder phases، ولا واحد منها يسكت

### DIFF
--- a/app/Console/Commands/SendQuizReminders.php
+++ b/app/Console/Commands/SendQuizReminders.php
@@ -12,7 +12,7 @@ use Illuminate\Console\Command;
  */
 class SendQuizReminders extends Command
 {
-    protected $signature = 'quiz:remind {phase : The reminder phase — one of opener, refloat, night, morning, hint, lastcall}';
+    protected $signature = 'quiz:remind {phase : The reminder phase — one of kickoff, opener, topic, refloat, momentum, night, latenight, morning, trap, hint, lastcall, closing}';
 
     protected $description = 'Send a reminder to answer the live daily quiz';
 

--- a/app/Services/Quiz/QuizReminder.php
+++ b/app/Services/Quiz/QuizReminder.php
@@ -15,42 +15,66 @@ use Telegram\Bot\Api;
  * the poll) rather than posting a fresh block — the least-annoying way to fight
  * the message getting buried in an active group.
  *
- * Six phases spread across the quiz's 24-hour window (see the schedule in
+ * Twelve phases spread across the quiz's 24-hour window (see the schedule in
  * routes/console.php), each with its own voice so the day does not read as the
- * same nudge six times:
- *   - {@see self::OPENER}: the question just went up.
+ * same nudge twelve times:
+ *   - {@see self::KICKOFF}: the poll just went up, before anyone has voted.
+ *   - {@see self::OPENER}: quotes how many have answered so far.
+ *   - {@see self::TOPIC}: teases the subject the question came from.
  *   - {@see self::REFLOAT}: taunts with the share of answers that were wrong.
+ *   - {@see self::MOMENTUM}: quotes the answers that landed in the last hour.
  *   - {@see self::NIGHT}: a last pass before the group goes to sleep.
+ *   - {@see self::LATENIGHT}: the small-hours pass, for whoever is still up.
  *   - {@see self::MORNING}: the morning re-float, carrying accuracy so far.
+ *   - {@see self::TRAP}: warns off the wrong option the crowd is falling for.
  *   - {@see self::HINT}: the question's stored non-spoiler hint.
  *   - {@see self::LASTCALL}: "closes soon", carrying the blunter second hint.
+ *   - {@see self::CLOSING}: the buzzer, minutes before the poll stops.
  *
  * A phase whose line has nothing to say is skipped rather than softened: the
- * three turnout phases need at least one answer to quote, and the two hint
- * phases need a stored hint.
+ * turnout phases need at least one answer to quote, the hint phase needs a
+ * stored hint, and the topic phase needs the quiz to carry a topic.
  */
 class QuizReminder
 {
+    public const KICKOFF = 'kickoff';
+
     public const OPENER = 'opener';
+
+    public const TOPIC = 'topic';
 
     public const REFLOAT = 'refloat';
 
+    public const MOMENTUM = 'momentum';
+
     public const NIGHT = 'night';
 
+    public const LATENIGHT = 'latenight';
+
     public const MORNING = 'morning';
+
+    public const TRAP = 'trap';
 
     public const HINT = 'hint';
 
     public const LASTCALL = 'lastcall';
 
+    public const CLOSING = 'closing';
+
     /** Every phase `quiz:remind` accepts, in the order they fire. */
     public const PHASES = [
+        self::KICKOFF,
         self::OPENER,
+        self::TOPIC,
         self::REFLOAT,
+        self::MOMENTUM,
         self::NIGHT,
+        self::LATENIGHT,
         self::MORNING,
+        self::TRAP,
         self::HINT,
         self::LASTCALL,
+        self::CLOSING,
     ];
 
     private ?Api $telegram;
@@ -74,7 +98,7 @@ class QuizReminder
 
         $openPosts = QuizPost::query()
             ->open()
-            ->with('quiz')
+            ->with('quiz.topic')
             ->get()
             ->filter(fn (QuizPost $post): bool => $post->quiz !== null);
 
@@ -122,17 +146,23 @@ class QuizReminder
 
     /**
      * This phase's reminder body, or null when the phase has nothing to say
-     * for this quiz yet — no answers to quote, or no hint stored.
+     * for this quiz yet — no answers to quote, no hint, or no topic.
      */
     private function text(string $phase, DailyQuiz $quiz): ?string
     {
         return match ($phase) {
+            self::KICKOFF => 'سؤال اليوم مفتوح 🎯 خذ لك دقيقة وجاوب',
             self::OPENER => $this->withParticipants($quiz, fn (int $participants): string => 'سؤال اليوم نازل، وجاوب عليه '.ArabicPlural::people($participants).' — وأنت؟'),
+            self::TOPIC => $this->topic($quiz),
             self::REFLOAT => $this->withParticipants($quiz, fn (int $participants): string => 'سؤال اليوم غلطوا فيه '.$this->percentOf($quiz, false, $participants).'%، بتقدر عليه؟'),
+            self::MOMENTUM => $this->momentum($quiz),
             self::NIGHT => 'قبل ما تنام 🌙 سؤال اليوم لسه مفتوح',
+            self::LATENIGHT => 'ساهر؟ 🌜 سؤال اليوم لسه ينتظر إجابتك',
             self::MORNING => $this->withParticipants($quiz, fn (int $participants): string => 'صباح الخير ☕ نسبة الإجابات الصحيحة في سؤال اليوم '.$this->percentOf($quiz, true, $participants).'% — تقدر ترفعها؟'),
+            self::TRAP => $this->trap($quiz),
             self::HINT => filled($quiz->hint) ? 'تلميح لسؤال اليوم: '.$this->escape($quiz->hint) : null,
             self::LASTCALL => $this->lastCall($quiz),
+            self::CLOSING => 'آخر فرصة ⏳ سؤال اليوم يقفل بعد شوي',
             default => null,
         };
     }
@@ -161,13 +191,59 @@ class QuizReminder
     }
 
     /**
-     * The final nudge, carrying the blunter second hint. Questions authored
-     * before the second hint existed fall back to the subtle one, and a quiz
-     * with neither gets the bare "last chance" line.
+     * Tease the subject the question was generated from, or null for a quiz
+     * with no topic (hand-written questions, or a deleted topic).
+     */
+    private function topic(DailyQuiz $quiz): ?string
+    {
+        $name = $quiz->topic?->name;
+
+        return filled($name) ? 'سؤال اليوم من «'.$this->escape($name).'» — تحسب نفسك قوي فيه؟' : null;
+    }
+
+    /**
+     * Quote the answers that landed in the last hour, or null on a quiet hour —
+     * "nobody answered recently" is not a nudge worth sending.
+     */
+    private function momentum(DailyQuiz $quiz): ?string
+    {
+        $recent = $quiz->answers()->where('answered_at', '>=', now()->subHour())->count();
+
+        return $recent === 0 ? null : 'وصلتنا '.ArabicPlural::answers($recent).' في آخر ساعة 🔥 لا تتأخر';
+    }
+
+    /**
+     * Warn off the wrong option the crowd is falling for hardest, as a share
+     * of everyone who answered. Null until at least one answer is wrong.
+     */
+    private function trap(DailyQuiz $quiz): ?string
+    {
+        $participants = $quiz->answers()->count();
+
+        $mostPicked = $quiz->answers()
+            ->where('is_correct', false)
+            ->selectRaw('selected_option, count(*) as votes')
+            ->groupBy('selected_option')
+            ->orderByDesc('votes')
+            ->first();
+
+        if ($participants === 0 || $mostPicked === null) {
+            return null;
+        }
+
+        $percent = (int) round($mostPicked->votes / $participants * 100);
+
+        return 'أكثر إجابة غلط في سؤال اليوم اختارها '.$percent.'% — لا تقع فيها';
+    }
+
+    /**
+     * The "closes soon" nudge, carrying the blunter second hint. Questions
+     * authored before the second hint existed fall back to the subtle one, and
+     * a quiz with neither gets the bare line.
      */
     private function lastCall(DailyQuiz $quiz): string
     {
-        $line = 'آخر فرصة في سؤال اليوم';
+        $line = 'قرب يقفل سؤال اليوم';
         $hint = filled($quiz->obvious_hint) ? $quiz->obvious_hint : $quiz->hint;
 
         if (filled($hint)) {

--- a/app/Services/Quiz/QuizReminder.php
+++ b/app/Services/Quiz/QuizReminder.php
@@ -18,7 +18,7 @@ use Telegram\Bot\Api;
  * Twelve phases spread across the quiz's 24-hour window (see the schedule in
  * routes/console.php), each with its own voice so the day does not read as the
  * same nudge twelve times:
- *   - {@see self::KICKOFF}: the poll just went up, before anyone has voted.
+ *   - {@see self::KICKOFF}: the poll just went up.
  *   - {@see self::OPENER}: quotes how many have answered so far.
  *   - {@see self::TOPIC}: teases the subject the question came from.
  *   - {@see self::REFLOAT}: taunts with the share of answers that were wrong.
@@ -31,9 +31,13 @@ use Telegram\Bot\Api;
  *   - {@see self::LASTCALL}: "closes soon", carrying the blunter second hint.
  *   - {@see self::CLOSING}: the buzzer, minutes before the poll stops.
  *
- * A phase whose line has nothing to say is skipped rather than softened: the
- * turnout phases need at least one answer to quote, the hint phase needs a
- * stored hint, and the topic phase needs the quiz to carry a topic.
+ * Every phase always has something to send: a phase whose data is missing —
+ * no answers yet, a quiet hour, no stored hint, no topic — falls back to a
+ * plain line in the same voice rather than staying silent.
+ *
+ * The one thing that does hold a nudge back is the group itself: while members
+ * are muted (a closed group — the bot is an admin and could still post, but
+ * nobody could reply), the reminder is dropped for that chat.
  */
 class QuizReminder
 {
@@ -79,6 +83,13 @@ class QuizReminder
 
     private ?Api $telegram;
 
+    /**
+     * Whether members may post, per chat id — one getChat per chat per run.
+     *
+     * @var array<int, bool>
+     */
+    private array $membersCanPost = [];
+
     public function __construct(
         private readonly QuizSettings $settings,
         ?Api $telegram = null,
@@ -103,17 +114,45 @@ class QuizReminder
             ->filter(fn (QuizPost $post): bool => $post->quiz !== null);
 
         foreach ($openPosts->groupBy('daily_quiz_id') as $posts) {
-            $quiz = $posts->first()->quiz;
-            $text = $this->text($phase, $quiz);
-
-            if ($text === null) {
-                continue;
-            }
+            $text = $this->text($phase, $posts->first()->quiz);
 
             foreach ($posts as $post) {
+                if (! $this->membersCanPost($post->chat_id)) {
+                    continue;
+                }
+
                 $this->replyToPoll($post, $text);
             }
         }
+    }
+
+    /**
+     * Whether the group's members are currently allowed to post. A closed
+     * group gets no nudges: the bot is an admin and its reply would go
+     * through, but nobody there could answer it.
+     *
+     * Fails open — a chat whose permissions cannot be read (a Telegram
+     * hiccup, the bot removed) is treated as open, so one failed lookup does
+     * not silence the day.
+     */
+    private function membersCanPost(int $chatId): bool
+    {
+        if (array_key_exists($chatId, $this->membersCanPost)) {
+            return $this->membersCanPost[$chatId];
+        }
+
+        try {
+            $permission = data_get($this->telegram()->getChat(['chat_id' => $chatId])->toArray(), 'permissions.can_send_messages');
+        } catch (\Throwable $exception) {
+            Log::warning('Failed to read quiz chat permissions', [
+                'chat_id' => $chatId,
+                'message' => $exception->getMessage(),
+            ]);
+
+            $permission = null;
+        }
+
+        return $this->membersCanPost[$chatId] = $permission === null || (bool) $permission;
     }
 
     /**
@@ -144,40 +183,54 @@ class QuizReminder
         }
     }
 
-    /**
-     * This phase's reminder body, or null when the phase has nothing to say
-     * for this quiz yet — no answers to quote, no hint, or no topic.
-     */
-    private function text(string $phase, DailyQuiz $quiz): ?string
+    /** This phase's reminder body. */
+    private function text(string $phase, DailyQuiz $quiz): string
     {
         return match ($phase) {
             self::KICKOFF => 'سؤال اليوم مفتوح 🎯 خذ لك دقيقة وجاوب',
-            self::OPENER => $this->withParticipants($quiz, fn (int $participants): string => 'سؤال اليوم نازل، وجاوب عليه '.ArabicPlural::people($participants).' — وأنت؟'),
+            self::OPENER => $this->opener($quiz),
             self::TOPIC => $this->topic($quiz),
-            self::REFLOAT => $this->withParticipants($quiz, fn (int $participants): string => 'سؤال اليوم غلطوا فيه '.$this->percentOf($quiz, false, $participants).'%، بتقدر عليه؟'),
+            self::REFLOAT => $this->refloat($quiz),
             self::MOMENTUM => $this->momentum($quiz),
             self::NIGHT => 'قبل ما تنام 🌙 سؤال اليوم لسه مفتوح',
             self::LATENIGHT => 'ساهر؟ 🌜 سؤال اليوم لسه ينتظر إجابتك',
-            self::MORNING => $this->withParticipants($quiz, fn (int $participants): string => 'صباح الخير ☕ نسبة الإجابات الصحيحة في سؤال اليوم '.$this->percentOf($quiz, true, $participants).'% — تقدر ترفعها؟'),
+            self::MORNING => $this->morning($quiz),
             self::TRAP => $this->trap($quiz),
-            self::HINT => filled($quiz->hint) ? 'تلميح لسؤال اليوم: '.$this->escape($quiz->hint) : null,
+            self::HINT => $this->hint($quiz),
             self::LASTCALL => $this->lastCall($quiz),
             self::CLOSING => 'آخر فرصة ⏳ سؤال اليوم يقفل بعد شوي',
-            default => null,
+            default => 'سؤال اليوم لسه مفتوح — جاوب قبل ما يقفل',
         };
     }
 
-    /**
-     * Build a turnout-quoting line, or null while nobody has answered — with
-     * no participants there is no share to quote.
-     *
-     * @param  callable(int): string  $line
-     */
-    private function withParticipants(DailyQuiz $quiz, callable $line): ?string
+    /** Open the day on the turnout so far, or on the empty board. */
+    private function opener(DailyQuiz $quiz): string
     {
         $participants = $quiz->answers()->count();
 
-        return $participants === 0 ? null : $line($participants);
+        return $participants === 0
+            ? 'سؤال اليوم نازل ولسه ما جاوب عليه أحد — كن أول واحد'
+            : 'سؤال اليوم نازل، وجاوب عليه '.ArabicPlural::people($participants).' — وأنت؟';
+    }
+
+    /** Taunt with the share that got it wrong, or with the empty board. */
+    private function refloat(DailyQuiz $quiz): string
+    {
+        $participants = $quiz->answers()->count();
+
+        return $participants === 0
+            ? 'سؤال اليوم لسه بلا إجابات، بتقدر عليه؟'
+            : 'سؤال اليوم غلطوا فيه '.$this->percentOf($quiz, false, $participants).'%، بتقدر عليه؟';
+    }
+
+    /** Re-float in the morning on accuracy so far, or on the empty board. */
+    private function morning(DailyQuiz $quiz): string
+    {
+        $participants = $quiz->answers()->count();
+
+        return $participants === 0
+            ? 'صباح الخير ☕ سؤال اليوم لسه ينتظر أول إجابة'
+            : 'صباح الخير ☕ نسبة الإجابات الصحيحة في سؤال اليوم '.$this->percentOf($quiz, true, $participants).'% — تقدر ترفعها؟';
     }
 
     /**
@@ -191,32 +244,34 @@ class QuizReminder
     }
 
     /**
-     * Tease the subject the question was generated from, or null for a quiz
-     * with no topic (hand-written questions, or a deleted topic).
+     * Tease the subject the question was generated from. A quiz with no topic
+     * (hand-written, or a deleted topic) gets the plain nudge.
      */
-    private function topic(DailyQuiz $quiz): ?string
+    private function topic(DailyQuiz $quiz): string
     {
         $name = $quiz->topic?->name;
 
-        return filled($name) ? 'سؤال اليوم من «'.$this->escape($name).'» — تحسب نفسك قوي فيه؟' : null;
+        return filled($name)
+            ? 'سؤال اليوم من «'.$this->escape($name).'» — تحسب نفسك قوي فيه؟'
+            : 'سؤال اليوم فوق ☝️ جرّب حظك فيه';
     }
 
-    /**
-     * Quote the answers that landed in the last hour, or null on a quiet hour —
-     * "nobody answered recently" is not a nudge worth sending.
-     */
-    private function momentum(DailyQuiz $quiz): ?string
+    /** Quote the answers that landed in the last hour, or name the quiet. */
+    private function momentum(DailyQuiz $quiz): string
     {
         $recent = $quiz->answers()->where('answered_at', '>=', now()->subHour())->count();
 
-        return $recent === 0 ? null : 'وصلتنا '.ArabicPlural::answers($recent).' في آخر ساعة 🔥 لا تتأخر';
+        return $recent === 0
+            ? 'الشات هادي 😴 وسؤال اليوم لسه مفتوح'
+            : 'وصلتنا '.ArabicPlural::answers($recent).' في آخر ساعة 🔥 لا تتأخر';
     }
 
     /**
      * Warn off the wrong option the crowd is falling for hardest, as a share
-     * of everyone who answered. Null until at least one answer is wrong.
+     * of everyone who answered — or, with nothing wrong to warn about, praise
+     * the clean board instead.
      */
-    private function trap(DailyQuiz $quiz): ?string
+    private function trap(DailyQuiz $quiz): string
     {
         $participants = $quiz->answers()->count();
 
@@ -227,13 +282,23 @@ class QuizReminder
             ->orderByDesc('votes')
             ->first();
 
-        if ($participants === 0 || $mostPicked === null) {
-            return null;
+        if ($participants === 0) {
+            return 'ما جاوب أحد على سؤال اليوم لين الآن — افتحها أنت';
         }
 
-        $percent = (int) round($mostPicked->votes / $participants * 100);
+        if ($mostPicked === null) {
+            return 'كل الإجابات صح لين الآن ✅ تحافظ على النسبة؟';
+        }
 
-        return 'أكثر إجابة غلط في سؤال اليوم اختارها '.$percent.'% — لا تقع فيها';
+        return 'أكثر إجابة غلط في سؤال اليوم اختارها '.(int) round($mostPicked->votes / $participants * 100).'% — لا تقع فيها';
+    }
+
+    /** The stored non-spoiler hint, or the plain "no hint today" line. */
+    private function hint(DailyQuiz $quiz): string
+    {
+        return filled($quiz->hint)
+            ? 'تلميح لسؤال اليوم: '.$this->escape($quiz->hint)
+            : 'ما فيه تلميح لسؤال اليوم 😄 جاوب باللي تعرفه';
     }
 
     /**

--- a/routes/console.php
+++ b/routes/console.php
@@ -51,12 +51,22 @@ Schedule::command('quiz:announce-weekly')
     ->withoutOverlapping()
     ->runInBackground();
 
-// The six nudges spread across the quiz's 16:00 → 16:00 window, in order.
+// The twelve nudges spread across the quiz's 16:00 → 16:00 window, in order.
 // Each phase has its own voice (see App\Services\Quiz\QuizReminder) and skips
 // itself when it has nothing to say; the whole family is behind the
 // «reminders_enabled» switch.
+Schedule::command('quiz:remind kickoff')
+    ->dailyAt('17:00')
+    ->withoutOverlapping()
+    ->runInBackground();
+
 Schedule::command('quiz:remind opener')
     ->dailyAt('18:30')
+    ->withoutOverlapping()
+    ->runInBackground();
+
+Schedule::command('quiz:remind topic')
+    ->dailyAt('20:00')
     ->withoutOverlapping()
     ->runInBackground();
 
@@ -68,8 +78,18 @@ Schedule::command('quiz:remind refloat')
     ->withoutOverlapping()
     ->runInBackground();
 
+Schedule::command('quiz:remind momentum')
+    ->dailyAt('22:15')
+    ->withoutOverlapping()
+    ->runInBackground();
+
 Schedule::command('quiz:remind night')
     ->dailyAt('23:30')
+    ->withoutOverlapping()
+    ->runInBackground();
+
+Schedule::command('quiz:remind latenight')
+    ->dailyAt('01:30')
     ->withoutOverlapping()
     ->runInBackground();
 
@@ -78,13 +98,23 @@ Schedule::command('quiz:remind morning')
     ->withoutOverlapping()
     ->runInBackground();
 
+Schedule::command('quiz:remind trap')
+    ->dailyAt('11:00')
+    ->withoutOverlapping()
+    ->runInBackground();
+
 Schedule::command('quiz:remind hint')
     ->dailyAt('12:30')
     ->withoutOverlapping()
     ->runInBackground();
 
-// Last call before the live quiz closes at 16:00.
 Schedule::command('quiz:remind lastcall')
     ->dailyAt('14:30')
+    ->withoutOverlapping()
+    ->runInBackground();
+
+// The buzzer, minutes before the live quiz closes at 16:00.
+Schedule::command('quiz:remind closing')
+    ->dailyAt('15:40')
     ->withoutOverlapping()
     ->runInBackground();

--- a/tests/Fakes/FakeTelegramApi.php
+++ b/tests/Fakes/FakeTelegramApi.php
@@ -4,6 +4,7 @@ namespace Tests\Fakes;
 
 use Telegram\Bot\Api;
 use Telegram\Bot\Objects\BaseObject;
+use Telegram\Bot\Objects\Chat;
 use Telegram\Bot\Objects\ChatMember;
 use Telegram\Bot\Objects\File;
 use Telegram\Bot\Objects\Message;
@@ -64,6 +65,14 @@ class FakeTelegramApi extends Api
      * @var array<int, array<int, int>>
      */
     public array $pollResults = [];
+
+    /**
+     * Whether members may post, per chat id — the «can_send_messages» chat
+     * permission getChat() reports. A chat not listed here reads as open.
+     *
+     * @var array<int|string, bool>
+     */
+    public array $membersCanPost = [];
 
     /** Chat-member status per telegram user id (default 'member'). */
     /** @var array<int|string, string> */
@@ -185,6 +194,15 @@ class FakeTelegramApi extends Api
         if (in_array((int) ($params['message_id'] ?? 0), $this->missingMessageIds, true)) {
             throw new \RuntimeException($error);
         }
+    }
+
+    public function getChat(array $params): Chat
+    {
+        return new Chat([
+            'id' => (int) $params['chat_id'],
+            'type' => 'supergroup',
+            'permissions' => ['can_send_messages' => $this->membersCanPost[$params['chat_id']] ?? true],
+        ]);
     }
 
     public function getChatMember(array $params): ChatMember

--- a/tests/Feature/Quiz/QuizReminderTest.php
+++ b/tests/Feature/Quiz/QuizReminderTest.php
@@ -148,12 +148,13 @@ it('teases the topic the question came from', function () {
         ->and($this->fake->sentMessages[0]['text'])->toBe('سؤال اليوم من «أساسيات الشبكات» — تحسب نفسك قوي فيه؟');
 });
 
-it('stays silent on the topic phase when the quiz carries no topic', function () {
+it('falls back to a plain line on the topic phase when the quiz carries no topic', function () {
     liveQuizWith(answers: 3, quizAttributes: ['quiz_topic_id' => null]);
 
     $this->artisan('quiz:remind topic')->assertExitCode(0);
 
-    expect($this->fake->sentMessages)->toBeEmpty();
+    expect($this->fake->sentMessages)->toHaveCount(1)
+        ->and($this->fake->sentMessages[0]['text'])->toBe('سؤال اليوم فوق ☝️ جرّب حظك فيه');
 });
 
 it('quotes the answers that landed in the last hour', function () {
@@ -167,13 +168,14 @@ it('quotes the answers that landed in the last hour', function () {
         ->and($this->fake->sentMessages[0]['text'])->toBe('وصلتنا 4 إجابات في آخر ساعة 🔥 لا تتأخر');
 });
 
-it('stays silent on the momentum phase after a quiet hour', function () {
+it('names the quiet on the momentum phase after an hour with no answers', function () {
     $quiz = liveQuizWith();
     QuizAnswer::factory()->count(6)->create(['daily_quiz_id' => $quiz->id, 'answered_at' => now()->subHours(3)]);
 
     $this->artisan('quiz:remind momentum')->assertExitCode(0);
 
-    expect($this->fake->sentMessages)->toBeEmpty();
+    expect($this->fake->sentMessages)->toHaveCount(1)
+        ->and($this->fake->sentMessages[0]['text'])->toBe('الشات هادي 😴 وسؤال اليوم لسه مفتوح');
 });
 
 it('sends the late-night nudge without needing any turnout', function () {
@@ -197,12 +199,50 @@ it('warns off the wrong option the crowd is falling for', function () {
         ->and($this->fake->sentMessages[0]['text'])->toBe('أكثر إجابة غلط في سؤال اليوم اختارها 50% — لا تقع فيها');
 });
 
-it('stays silent on the trap phase while every answer is correct', function () {
+it('praises the clean board on the trap phase while every answer is correct', function () {
     liveQuizWith(answers: 4);
 
     $this->artisan('quiz:remind trap')->assertExitCode(0);
 
+    expect($this->fake->sentMessages)->toHaveCount(1)
+        ->and($this->fake->sentMessages[0]['text'])->toBe('كل الإجابات صح لين الآن ✅ تحافظ على النسبة؟');
+});
+
+it('opens the trap phase on the empty board when nobody has answered', function () {
+    liveQuizWith(answers: 0);
+
+    $this->artisan('quiz:remind trap')->assertExitCode(0);
+
+    expect($this->fake->sentMessages)->toHaveCount(1)
+        ->and($this->fake->sentMessages[0]['text'])->toBe('ما جاوب أحد على سؤال اليوم لين الآن — افتحها أنت');
+});
+
+it('sends every phase something, on a quiz with nothing to quote', function (string $phase) {
+    liveQuizWith(answers: 0, quizAttributes: ['hint' => null, 'obvious_hint' => null, 'quiz_topic_id' => null]);
+
+    $this->artisan("quiz:remind {$phase}")->assertExitCode(0);
+
+    expect($this->fake->sentMessages)->toHaveCount(1)
+        ->and($this->fake->sentMessages[0]['text'])->not->toBeEmpty();
+})->with(QuizReminder::PHASES);
+
+it('drops the reminder while the group is closed to its members', function () {
+    liveQuizWith(answers: 3);
+    $this->fake->membersCanPost = [-100200300 => false];
+
+    $this->artisan('quiz:remind opener')->assertExitCode(0);
+
     expect($this->fake->sentMessages)->toBeEmpty();
+});
+
+it('reminds the groups that are open and skips the closed ones', function () {
+    $quiz = liveQuizWith(answers: 3);
+    QuizPost::factory()->create(['daily_quiz_id' => $quiz->id, 'chat_id' => -100400500]);
+    $this->fake->membersCanPost = [-100400500 => false];
+
+    $this->artisan('quiz:remind opener')->assertExitCode(0);
+
+    expect(collect($this->fake->sentMessages)->pluck('chat_id')->all())->toBe([-100200300]);
 });
 
 it('always sends the closing buzzer', function () {
@@ -214,20 +254,26 @@ it('always sends the closing buzzer', function () {
         ->and($this->fake->sentMessages[0]['text'])->toBe('آخر فرصة ⏳ سؤال اليوم يقفل بعد شوي');
 });
 
-it('stays silent on a turnout phase while nobody has answered yet', function (string $phase) {
+it('falls back to a plain line on a turnout phase while nobody has answered yet', function (string $phase, string $text) {
     liveQuizWith(answers: 0);
 
     $this->artisan("quiz:remind {$phase}")->assertExitCode(0);
 
-    expect($this->fake->sentMessages)->toBeEmpty();
-})->with(['opener', 'refloat', 'morning']);
+    expect($this->fake->sentMessages)->toHaveCount(1)
+        ->and($this->fake->sentMessages[0]['text'])->toBe($text);
+})->with([
+    ['opener', 'سؤال اليوم نازل ولسه ما جاوب عليه أحد — كن أول واحد'],
+    ['refloat', 'سؤال اليوم لسه بلا إجابات، بتقدر عليه؟'],
+    ['morning', 'صباح الخير ☕ سؤال اليوم لسه ينتظر أول إجابة'],
+]);
 
-it('stays silent on the hint phase when the quiz has no hint', function () {
+it('falls back to a plain line on the hint phase when the quiz has no hint', function () {
     liveQuizWith(answers: 5, quizAttributes: ['hint' => null]);
 
     $this->artisan('quiz:remind hint')->assertExitCode(0);
 
-    expect($this->fake->sentMessages)->toBeEmpty();
+    expect($this->fake->sentMessages)->toHaveCount(1)
+        ->and($this->fake->sentMessages[0]['text'])->toBe('ما فيه تلميح لسؤال اليوم 😄 جاوب باللي تعرفه');
 });
 
 it('reminds every group the quiz is live in', function () {

--- a/tests/Feature/Quiz/QuizReminderTest.php
+++ b/tests/Feature/Quiz/QuizReminderTest.php
@@ -3,6 +3,7 @@
 use App\Models\DailyQuiz;
 use App\Models\QuizAnswer;
 use App\Models\QuizPost;
+use App\Models\QuizTopic;
 use App\Services\Quiz\QuizReminder;
 use App\Settings\QuizSettings;
 use Tests\Fakes\FakeTelegramApi;
@@ -97,7 +98,7 @@ it('sends the subtle hint mid-window', function () {
         ->and($this->fake->sentMessages[0]['text'])->toBe('تلميح لسؤال اليوم: فكّر في وحدات القياس.');
 });
 
-it('always sends the last call and includes the obvious hint', function () {
+it('always sends the closes-soon nudge and includes the obvious hint', function () {
     liveQuizWith(answers: 200, quizAttributes: [
         'hint' => 'فكّر في وحدات القياس.',
         'obvious_hint' => 'العلاقة قسمة على 8.',
@@ -106,10 +107,10 @@ it('always sends the last call and includes the obvious hint', function () {
     $this->artisan('quiz:remind lastcall')->assertExitCode(0);
 
     expect($this->fake->sentMessages)->toHaveCount(1)
-        ->and($this->fake->sentMessages[0]['text'])->toBe('آخر فرصة في سؤال اليوم، تلميح: العلاقة قسمة على 8.');
+        ->and($this->fake->sentMessages[0]['text'])->toBe('قرب يقفل سؤال اليوم، تلميح: العلاقة قسمة على 8.');
 });
 
-it('falls back to the subtle hint in the last call when a quiz predates the obvious one', function () {
+it('falls back to the subtle hint in the closes-soon nudge when a quiz predates the obvious one', function () {
     liveQuizWith(answers: 1, quizAttributes: [
         'hint' => 'فكّر في وحدات القياس.',
         'obvious_hint' => null,
@@ -117,7 +118,7 @@ it('falls back to the subtle hint in the last call when a quiz predates the obvi
 
     $this->artisan('quiz:remind lastcall')->assertExitCode(0);
 
-    expect($this->fake->sentMessages[0]['text'])->toBe('آخر فرصة في سؤال اليوم، تلميح: فكّر في وحدات القياس.');
+    expect($this->fake->sentMessages[0]['text'])->toBe('قرب يقفل سؤال اليوم، تلميح: فكّر في وحدات القياس.');
 });
 
 it('omits the hint line when the quiz has neither hint', function () {
@@ -125,7 +126,92 @@ it('omits the hint line when the quiz has neither hint', function () {
 
     $this->artisan('quiz:remind lastcall')->assertExitCode(0);
 
-    expect($this->fake->sentMessages[0]['text'])->toBe('آخر فرصة في سؤال اليوم');
+    expect($this->fake->sentMessages[0]['text'])->toBe('قرب يقفل سؤال اليوم');
+});
+
+it('kicks the day off without needing any turnout', function () {
+    liveQuizWith(answers: 0);
+
+    $this->artisan('quiz:remind kickoff')->assertExitCode(0);
+
+    expect($this->fake->sentMessages)->toHaveCount(1)
+        ->and($this->fake->sentMessages[0]['text'])->toBe('سؤال اليوم مفتوح 🎯 خذ لك دقيقة وجاوب');
+});
+
+it('teases the topic the question came from', function () {
+    $topic = QuizTopic::factory()->create(['name' => 'أساسيات الشبكات']);
+    liveQuizWith(answers: 0, quizAttributes: ['quiz_topic_id' => $topic->id]);
+
+    $this->artisan('quiz:remind topic')->assertExitCode(0);
+
+    expect($this->fake->sentMessages)->toHaveCount(1)
+        ->and($this->fake->sentMessages[0]['text'])->toBe('سؤال اليوم من «أساسيات الشبكات» — تحسب نفسك قوي فيه؟');
+});
+
+it('stays silent on the topic phase when the quiz carries no topic', function () {
+    liveQuizWith(answers: 3, quizAttributes: ['quiz_topic_id' => null]);
+
+    $this->artisan('quiz:remind topic')->assertExitCode(0);
+
+    expect($this->fake->sentMessages)->toBeEmpty();
+});
+
+it('quotes the answers that landed in the last hour', function () {
+    $quiz = liveQuizWith();
+    QuizAnswer::factory()->count(4)->create(['daily_quiz_id' => $quiz->id, 'answered_at' => now()->subMinutes(20)]);
+    QuizAnswer::factory()->count(9)->create(['daily_quiz_id' => $quiz->id, 'answered_at' => now()->subHours(5)]);
+
+    $this->artisan('quiz:remind momentum')->assertExitCode(0);
+
+    expect($this->fake->sentMessages)->toHaveCount(1)
+        ->and($this->fake->sentMessages[0]['text'])->toBe('وصلتنا 4 إجابات في آخر ساعة 🔥 لا تتأخر');
+});
+
+it('stays silent on the momentum phase after a quiet hour', function () {
+    $quiz = liveQuizWith();
+    QuizAnswer::factory()->count(6)->create(['daily_quiz_id' => $quiz->id, 'answered_at' => now()->subHours(3)]);
+
+    $this->artisan('quiz:remind momentum')->assertExitCode(0);
+
+    expect($this->fake->sentMessages)->toBeEmpty();
+});
+
+it('sends the late-night nudge without needing any turnout', function () {
+    liveQuizWith(answers: 0);
+
+    $this->artisan('quiz:remind latenight')->assertExitCode(0);
+
+    expect($this->fake->sentMessages)->toHaveCount(1)
+        ->and($this->fake->sentMessages[0]['text'])->toBe('ساهر؟ 🌜 سؤال اليوم لسه ينتظر إجابتك');
+});
+
+it('warns off the wrong option the crowd is falling for', function () {
+    $quiz = liveQuizWith(answers: 2);
+    QuizAnswer::factory()->count(5)->wrong()->create(['daily_quiz_id' => $quiz->id, 'selected_option' => 3]);
+    QuizAnswer::factory()->count(3)->wrong()->create(['daily_quiz_id' => $quiz->id, 'selected_option' => 0]);
+
+    $this->artisan('quiz:remind trap')->assertExitCode(0);
+
+    // The most-picked wrong option took 5 of 10 answers -> 50%.
+    expect($this->fake->sentMessages)->toHaveCount(1)
+        ->and($this->fake->sentMessages[0]['text'])->toBe('أكثر إجابة غلط في سؤال اليوم اختارها 50% — لا تقع فيها');
+});
+
+it('stays silent on the trap phase while every answer is correct', function () {
+    liveQuizWith(answers: 4);
+
+    $this->artisan('quiz:remind trap')->assertExitCode(0);
+
+    expect($this->fake->sentMessages)->toBeEmpty();
+});
+
+it('always sends the closing buzzer', function () {
+    liveQuizWith(answers: 0, quizAttributes: ['hint' => null, 'obvious_hint' => null]);
+
+    $this->artisan('quiz:remind closing')->assertExitCode(0);
+
+    expect($this->fake->sentMessages)->toHaveCount(1)
+        ->and($this->fake->sentMessages[0]['text'])->toBe('آخر فرصة ⏳ سؤال اليوم يقفل بعد شوي');
 });
 
 it('stays silent on a turnout phase while nobody has answered yet', function (string $phase) {


### PR DESCRIPTION
## الخلاصة

تذكيرات سؤال اليوم كانت ست مرات في نافذة الـ 16:00 → 16:00، وبينها فجوات طويلة: لا شيء بين نزول السؤال و18:30، ولا شيء من 23:30 إلى 09:00، وساعة ونصف صامتة قبل ما يقفل. صارت اثنتي عشرة مرة، وكل مرحلة لها صوتها.

## الجدول الجديد

| الوقت | المرحلة | النص (مع بيانات) | البديل (لا توجد بيانات) |
|---|---|---|---|
| 17:00 | `kickoff` 🆕 | سؤال اليوم مفتوح 🎯 خذ لك دقيقة وجاوب | — |
| 18:30 | `opener` | سؤال اليوم نازل، وجاوب عليه {ن} — وأنت؟ | ولسه ما جاوب عليه أحد — كن أول واحد |
| 20:00 | `topic` 🆕 | سؤال اليوم من «{الموضوع}» — تحسب نفسك قوي فيه؟ | سؤال اليوم فوق ☝️ جرّب حظك فيه |
| 21:00 | `refloat` | غلطوا فيه {٪}، بتقدر عليه؟ | لسه بلا إجابات، بتقدر عليه؟ |
| 22:15 | `momentum` 🆕 | وصلتنا {ن} إجابات في آخر ساعة 🔥 لا تتأخر | الشات هادي 😴 وسؤال اليوم لسه مفتوح |
| 23:30 | `night` | قبل ما تنام 🌙 سؤال اليوم لسه مفتوح | — |
| 01:30 | `latenight` 🆕 | ساهر؟ 🌜 سؤال اليوم لسه ينتظر إجابتك | — |
| 09:00 | `morning` | صباح الخير ☕ نسبة الصحيحة {٪} — تقدر ترفعها؟ | صباح الخير ☕ لسه ينتظر أول إجابة |
| 11:00 | `trap` 🆕 | أكثر إجابة غلط اختارها {٪} — لا تقع فيها | كل الإجابات صح لين الآن ✅ تحافظ على النسبة؟ |
| 12:30 | `hint` | تلميح لسؤال اليوم: … | ما فيه تلميح لسؤال اليوم 😄 جاوب باللي تعرفه |
| 14:30 | `lastcall` | قرب يقفل سؤال اليوم، تلميح: … | السطر وحده بلا تلميح |
| 15:40 | `closing` 🆕 | آخر فرصة ⏳ سؤال اليوم يقفل بعد شوي | — |

`lastcall` تنازل عن «آخر فرصة» للجرس الجديد في 15:40 — ما عاد آخر كلام في اليوم. و`refloat` لا يزال يتخطى الخميس حتى لا يصطدم بإعلان أبطال الأسبوع الساعة 21:00.

## لا مرحلة تسكت

كانت المرحلة التي لا تملك ما تقوله تتخطى نفسها. الآن لكل مرحلة بديل بنفس الصوت — اللوح الفارغ لمراحل المشاركة الثلاث، ونص عادي لسؤال بلا موضوع، و«الشات هادي» لساعة بلا إجابات، و«كل الإجابات صح لين الآن» حين لا توجد إجابة خاطئة بعد، و«ما فيه تلميح» لسؤال بلا تلميح مخزّن. `text()` صارت ترجع `string` بدل `?string`، فأي كويز مفتوح يستلم تذكيره.

## المجموعة المغلقة

قبل كل رد يقرأ البوت صلاحية `can_send_messages` للمحادثة، ويسقط التذكير في أي مجموعة أعضاؤها مكتومون. البوت أدمن ورسالته تعدّي، لكن تذكير ما أحد يقدر يرد عليه هو مجرد إزعاج.

- استدعاء `getChat` واحد لكل محادثة في كل تشغيل، مع تخزين النتيجة.
- القراءة الفاشلة تُعامل كمجموعة مفتوحة، فلا يُسكت عطل مؤقت في تيليجرام اليوم كله.
- ملاحظة: هذه صلاحية المحادثة ككل — مجموعة تغلق موضوعًا (topic) واحدًا فقط يظل التذكير يصلها هناك، فتيليجرام لا يكشف حالة الموضوع في `getChat`.

## الاختبارات

`tests/Feature/Quiz/QuizReminderTest.php` — 41 اختبارًا ناجحًا (116 assertion): نص كل مرحلة ببيانات وبدونها، ومرور كل `QuizReminder::PHASES` على كويز لا يملك ما يُقتبس منه، ومجموعة مغلقة تُسقط التذكير بينما المفتوحة تستلمه. أُضيف `getChat` إلى `Tests\Fakes\FakeTelegramApi` مع `membersCanPost` لضبط الصلاحية في الاختبار.

خارج نطاق هذا التغيير: `QuizMyScoreHandlerTest` و`QuizLeaderboardHandlerTest` يسقطان أصلًا على `main` (7 اختبارات) بسبب `UNIQUE constraint failed: daily_quizzes.quiz_date` — ينشئان كويزين بنفس التاريخ.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LebXFCVue9kKKv4zNYkRxt)_