### PR TITLE
سؤال اليوم: stop one upstream timeout from costing the day its question

### DIFF
--- a/app/Ai/Quiz/QuizAuthor.php
+++ b/app/Ai/Quiz/QuizAuthor.php
@@ -9,11 +9,14 @@ use App\Settings\AiSettings;
 use App\Support\QuizContentHtml;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Str;
+use Laravel\Ai\Exceptions\AiException;
 use RuntimeException;
 use Saad\AiKit\Safety\BudgetGuard;
+use Saad\AiKit\Safety\Exceptions\AiUnavailableException;
 
 /**
  * Generates the daily multiple-choice question: one authoring-tier agent call
@@ -280,9 +283,18 @@ class QuizAuthor
     }
 
     /**
-     * Author one question, retrying the whole agent run only if the model
+     * Author one question, retrying the whole agent run when the model
      * finishes without ever submitting a valid question through the tool
-     * (in-conversation correction handles ordinary validation failures).
+     * (in-conversation correction handles ordinary validation failures), or
+     * when the call never reached a verdict at all.
+     *
+     * That second family is why the catch is wider than RuntimeException: the
+     * authoring tier reasons for a minute or two per question and regularly
+     * grazes its 180s HTTP timeout, and an upstream timeout arrives as a
+     * ConnectionException — an ordinary Exception. Letting it escape the loop
+     * meant one flaky night call burned the whole day's generation, and the
+     * day was rescued only by the poster's inline fallback at posting time, so
+     * the group got its question late.
      *
      * @return array{question: string, options: array<int, string>, correct_option: int, explanation: string|null, hint: string|null, obvious_hint: string|null}
      */
@@ -294,7 +306,11 @@ class QuizAuthor
         for ($attempt = 1; $attempt <= self::MAX_ATTEMPTS; $attempt++) {
             try {
                 return $this->generate($prompt);
-            } catch (RuntimeException $exception) {
+            } catch (AiUnavailableException $exception) {
+                // The turn was refused before it cost anything — the budget is
+                // spent or the kit is off. Another attempt refuses identically.
+                throw $exception;
+            } catch (AiException|ConnectionException|RuntimeException $exception) {
                 $lastError = $exception;
             }
         }

--- a/app/Console/Commands/PostDailyQuiz.php
+++ b/app/Console/Commands/PostDailyQuiz.php
@@ -33,8 +33,15 @@ class PostDailyQuiz extends Command
      * How long to wait before retrying the inline fallback generation. The
      * command runs every minute; a failing authoring model must not be asked
      * that often.
+     *
+     * Kept short because this window opens at posting time and every minute
+     * of it is a minute the group is waiting: an attempt already occupies
+     * several of these minutes on its own (the authoring tier reasons for one
+     * to two minutes, twice), so this is the pause *after* a failure, not the
+     * spacing between calls. It closes for the day the moment a question
+     * exists.
      */
-    private const FALLBACK_RETRY_MINUTES = 15;
+    private const FALLBACK_RETRY_MINUTES = 5;
 
     public function handle(QuizSettings $settings, QuizSchedule $schedule, QuizAuthor $author, QuizPoster $poster): int
     {

--- a/routes/console.php
+++ b/routes/console.php
@@ -32,9 +32,25 @@ Schedule::command('ai:ingest-pages')
     ->withoutOverlapping()
     ->runInBackground();
 
+// Both entries carry an explicit one-hour mutex expiry rather than the 24-hour
+// default: they share one mutex (it is keyed by the command, not the time), a
+// generation runs for minutes at most, and a run killed mid-flight must not
+// leave a lock that silently swallows the 11:00 safety net below — or
+// tomorrow's 05:00 run.
 Schedule::command('quiz:generate')
     ->dailyAt('05:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(60)
+    ->runInBackground();
+
+// Safety net for the 05:00 run, which is one command invocation and can still
+// exhaust its attempts on a bad night — the authoring tier grazes its 180s
+// timeout. Without this, a question-less day is discovered only by `quiz:post`
+// at posting time, and the group gets its question late. A no-op on every
+// normal day: `quiz:generate` skips a date that already has a question, and
+// this still lands hours before posting so admins keep their review window.
+Schedule::command('quiz:generate')
+    ->dailyAt('11:00')
+    ->withoutOverlapping(60)
     ->runInBackground();
 
 // Runs every minute and posts only when the configured moment arrives — the

--- a/tests/Feature/Quiz/QuizGenerationTest.php
+++ b/tests/Feature/Quiz/QuizGenerationTest.php
@@ -8,7 +8,10 @@ use App\Models\QuizTopic;
 use App\Settings\AiSettings;
 use App\Settings\QuizSettings;
 use Carbon\CarbonInterface;
+use Illuminate\Http\Client\ConnectionException;
+use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Responses\Data\ToolCall;
+use Saad\AiKit\Safety\Exceptions\BudgetExceededException;
 
 beforeEach(function () {
     config()->set('ai.providers.openrouter.key', 'test-key');
@@ -259,6 +262,67 @@ it('retries when the model finishes without submitting, then succeeds', function
     $this->artisan('quiz:generate')->assertExitCode(0);
 
     expect(DailyQuiz::query()->count())->toBe(1);
+});
+
+/**
+ * A faked run whose first turn dies with the given transport/provider failure
+ * and whose retry submits a question normally.
+ */
+function quizFailingFirstTurn(Throwable $failure): Closure
+{
+    $turn = 0;
+
+    return function () use (&$turn, $failure): ToolCall|string {
+        return match (++$turn) {
+            1 => throw $failure,
+            2 => quizToolCall(),
+            default => 'تم، اعتمدت السؤال.',
+        };
+    };
+}
+
+it('retries when the authoring call times out upstream, then succeeds', function () {
+    QuizTopic::factory()->create();
+    QuizAuthoringAgent::fake(quizFailingFirstTurn(
+        new ConnectionException('cURL error 28: Operation timed out after 180000 milliseconds')
+    ));
+
+    $this->artisan('quiz:generate')->assertExitCode(0);
+
+    expect(DailyQuiz::query()->count())->toBe(1);
+});
+
+it('retries when the provider errors, then succeeds', function () {
+    QuizTopic::factory()->create();
+    QuizAuthoringAgent::fake(quizFailingFirstTurn(new AiException('The provider is overloaded.')));
+
+    $this->artisan('quiz:generate')->assertExitCode(0);
+
+    expect(DailyQuiz::query()->count())->toBe(1);
+});
+
+it('gives up when every authoring call times out upstream', function () {
+    QuizTopic::factory()->create();
+    QuizAuthoringAgent::fake(fn () => throw new ConnectionException('cURL error 28'));
+
+    $this->artisan('quiz:generate')->assertExitCode(1);
+
+    expect(DailyQuiz::query()->count())->toBe(0);
+});
+
+it('does not retry once the daily AI budget is spent', function () {
+    QuizTopic::factory()->create();
+    $turns = 0;
+    QuizAuthoringAgent::fake(function () use (&$turns) {
+        $turns++;
+
+        throw new BudgetExceededException(9.0, 5.0, 3600);
+    });
+
+    $this->artisan('quiz:generate')->assertExitCode(1);
+
+    expect($turns)->toBe(1)
+        ->and(DailyQuiz::query()->count())->toBe(0);
 });
 
 it('gives up when the model never submits a question', function () {


### PR DESCRIPTION
## What happened

Today's question (2026-08-26) *was* posted — at **16:34 instead of 16:00**, 34 minutes late. On 23 Aug the same thing happened, rescued a minute late.

The nightly `quiz:generate` at 05:00 timed out and left no question at all:

```
[2026-08-26 05:03:03] production.WARNING: cURL error 28: Operation timed out after 180000ms
  … QuizAuthor->generateQuestion() … GenerateDailyQuiz
```

`quiz:post` then discovered the empty day at posting time and generated inline, needing three attempts (16:00, 16:16, 16:31 — spaced by its 15-minute throttle) before the model answered inside the timeout.

## Why the 05:00 run gave up after one attempt

`QuizAuthor::generateQuestion()` already loops `MAX_ATTEMPTS` times, but caught only `RuntimeException` — which covers "the model finished without submitting through the tool" and nothing else. The failure that actually happens in production is an upstream timeout, which arrives as `Illuminate\Http\Client\ConnectionException` — a plain `Exception`, as is every `Laravel\Ai\Exceptions\AiException`. It escaped the loop on attempt 1.

The authoring tier (`deepseek-v4-pro-0813`, reasoning effort `high`) runs one to two minutes per question against a 180s timeout, so grazing it is routine — the successful call today took **125s**.

## The fix — three layers

- **`QuizAuthor`** retries transient upstream failures (`ConnectionException`, `AiException`), not just "never submitted". A budget/kit refusal (`AiUnavailableException`) still fails fast — a second attempt would refuse identically and cost nothing to discover.
- **A second `quiz:generate` at 11:00.** A no-op on every normal day (the command skips a date that already has a question), and early enough that admins keep their review window. Both entries now carry an explicit 60-minute mutex expiry: they share one mutex (keyed by command, not time), so the 24-hour default would let a run killed mid-flight silently swallow the next one.
- **The poster's fallback throttle: 15 → 5 minutes.** That window only opens at posting time, and every minute of it is a minute the group is waiting. An attempt already occupies several minutes on its own.

## Tests

Four new cases in `tests/Feature/Quiz/QuizGenerationTest.php` — retry-then-succeed for a timeout and for a provider error, give-up when every call times out, and no-retry once the budget is spent. 33 pass in that file; `tests/Feature/Quiz/` and `QuizManagementTest` are otherwise unchanged against baseline.

⚠️ Unrelated: `QuizLeaderboardHandlerTest` / `QuizMyScoreHandlerTest` have 7 pre-existing `UniqueConstraintViolationException` failures on `main` (same count before and after this branch), from the rolling-30-day board in #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)