### PR TITLE
صورة البطاقة: أداة تضبط صورة الطالب على شروط الجامعة داخل المتصفح

### DIFF
--- a/app/Http/Controllers/ToolController.php
+++ b/app/Http/Controllers/ToolController.php
@@ -85,6 +85,25 @@ class ToolController extends Controller
     }
 
     /**
+     * Display the student card photo tool.
+     */
+    public function studentPhoto(): Response
+    {
+        $page = Page::where('slug', '/adwat/sorh-albtaqa')
+            ->where('hidden', false)
+            ->first();
+
+        return Inertia::render('tools/StudentPhotoPage', [
+            'page' => $page ? [
+                'html_content' => $page->html_content,
+                'title' => $page->title,
+            ] : null,
+            'hasContent' => $page && ! empty($page->html_content),
+            'seo' => $this->toolSeo($page, 'صورة البطاقة الجامعية', 'اضبط صورتك على شروط صورة البطاقة الجامعية في جامعة أم القرى: قص ٣ × ٤، صيغة JPG، وحجم أقل من ٣٠٠ كيلوبايت — كل المعالجة داخل متصفحك بدون رفع الصورة.'),
+        ]);
+    }
+
+    /**
      * Display the truth table generator tool.
      */
     public function truthTable(): Response

--- a/resources/js/components/tools/PhotoChecks.vue
+++ b/resources/js/components/tools/PhotoChecks.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import type { PhotoCheck } from '@/lib/studentPhoto/checks';
+import { MANUAL_REQUIREMENTS } from '@/lib/studentPhoto/requirements';
+import { Check, CircleAlert, TriangleAlert } from 'lucide-vue-next';
+
+interface Props {
+    /** Verdicts the tool worked out from the pixels and the file. */
+    checks: PhotoCheck[];
+    /** Which of the human-judgement requirements the student has ticked. */
+    confirmed: Record<string, boolean>;
+}
+
+defineProps<Props>();
+
+const emit = defineEmits<{
+    (event: 'update:confirmed', confirmed: Record<string, boolean>): void;
+}>();
+
+const STATUS_ICONS = { pass: Check, warn: TriangleAlert, fail: CircleAlert };
+
+const STATUS_CLASSES = {
+    pass: 'text-primary',
+    warn: 'text-amber-600 dark:text-amber-500',
+    fail: 'text-destructive',
+};
+
+function toggle(current: Record<string, boolean>, id: string, value: boolean | 'indeterminate'): void {
+    emit('update:confirmed', { ...current, [id]: value === true });
+}
+</script>
+
+<template>
+    <div class="space-y-6">
+        <section class="space-y-3">
+            <h3 class="!my-0 text-base font-semibold">ما تحقّقنا منه تلقائيًا</h3>
+
+            <ul class="!my-0 space-y-2 !ps-0">
+                <li v-for="check in checks" :key="check.id" class="flex items-start gap-2 rounded-lg bg-muted/50 p-3">
+                    <component
+                        :is="STATUS_ICONS[check.status]"
+                        class="mt-0.5 size-4 shrink-0"
+                        :class="STATUS_CLASSES[check.status]"
+                        aria-hidden="true"
+                    />
+                    <div class="space-y-0.5">
+                        <p class="!my-0 text-sm font-medium">{{ check.label }}</p>
+                        <p class="!my-0 text-xs text-muted-foreground">{{ check.detail }}</p>
+                    </div>
+                </li>
+            </ul>
+        </section>
+
+        <section class="space-y-3">
+            <div>
+                <h3 class="!my-0 text-base font-semibold">ما يجب أن تتأكد منه بنفسك</h3>
+                <p class="!my-0 text-xs text-muted-foreground">هذه شروط لا يمكن لأي برنامج الحكم عليها من الصورة، وهي أكثر أسباب رفض صورة البطاقة.</p>
+            </div>
+
+            <ul class="!my-0 space-y-2 !ps-0">
+                <li v-for="requirement in MANUAL_REQUIREMENTS" :key="requirement.id" class="flex items-start gap-2 rounded-lg p-1">
+                    <Checkbox
+                        :id="`requirement-${requirement.id}`"
+                        class="mt-0.5"
+                        :model-value="confirmed[requirement.id] === true"
+                        @update:model-value="toggle(confirmed, requirement.id, $event)"
+                    />
+                    <div class="space-y-0.5">
+                        <Label :for="`requirement-${requirement.id}`" class="text-sm leading-5 font-medium">
+                            {{ requirement.label }}
+                        </Label>
+                        <p class="!my-0 text-xs text-muted-foreground">{{ requirement.detail }}</p>
+                    </div>
+                </li>
+            </ul>
+        </section>
+    </div>
+</template>

--- a/resources/js/components/tools/PhotoCropCanvas.vue
+++ b/resources/js/components/tools/PhotoCropCanvas.vue
@@ -1,0 +1,292 @@
+<script setup lang="ts">
+import { clampView, cropFromView, panView, zoomView, type CropView, type Size } from '@/lib/studentPhoto/geometry';
+import type { WorkingImage } from '@/lib/studentPhoto/render';
+import { ASPECT_RATIO } from '@/lib/studentPhoto/requirements';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+
+interface Props {
+    working: WorkingImage;
+    view: CropView;
+    showGuides?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), { showGuides: true });
+
+const emit = defineEmits<{
+    (event: 'update:view', view: CropView): void;
+    (event: 'reset'): void;
+}>();
+
+/** Breathing room between the crop frame and the edge of the viewport, in CSS pixels. */
+const FRAME_PADDING = 20;
+const KEYBOARD_STEP = 12;
+const KEYBOARD_STEP_FAST = 48;
+const KEYBOARD_ZOOM_FACTOR = 1.12;
+
+const container = ref<HTMLDivElement | null>(null);
+const canvas = ref<HTMLCanvasElement | null>(null);
+const viewport = ref({ width: 0, height: 0 });
+
+/** Active pointers, so one finger pans and two fingers pinch. */
+const pointers = new Map<number, { x: number; y: number }>();
+let pinchStart: { distance: number; zoom: number } | null = null;
+let frameRequest = 0;
+let resizeObserver: ResizeObserver | null = null;
+
+const imageSize = computed<Size>(() => ({ width: props.working.width, height: props.working.height }));
+
+/** The fixed 3:4 window the photo is dragged behind. */
+const frame = computed(() => {
+    const availableWidth = Math.max(0, viewport.value.width - FRAME_PADDING * 2);
+    const availableHeight = Math.max(0, viewport.value.height - FRAME_PADDING * 2);
+    const height = Math.min(availableHeight, availableWidth / ASPECT_RATIO);
+    const width = height * ASPECT_RATIO;
+
+    return {
+        x: (viewport.value.width - width) / 2,
+        y: (viewport.value.height - height) / 2,
+        width,
+        height,
+    };
+});
+
+/** Screen pixels per image pixel at the current zoom. */
+const scale = computed(() => {
+    const crop = cropFromView(props.view, imageSize.value);
+
+    return crop.width > 0 ? frame.value.width / crop.width : 0;
+});
+
+function draw(): void {
+    const element = canvas.value;
+
+    if (!element || frame.value.width <= 0) {
+        return;
+    }
+
+    const ratio = window.devicePixelRatio || 1;
+    const cssWidth = viewport.value.width;
+    const cssHeight = viewport.value.height;
+
+    element.width = Math.max(1, Math.round(cssWidth * ratio));
+    element.height = Math.max(1, Math.round(cssHeight * ratio));
+
+    const context = element.getContext('2d');
+
+    if (!context) {
+        return;
+    }
+
+    context.setTransform(ratio, 0, 0, ratio, 0, 0);
+    context.clearRect(0, 0, cssWidth, cssHeight);
+    context.imageSmoothingEnabled = true;
+    context.imageSmoothingQuality = 'high';
+
+    const crop = cropFromView(props.view, imageSize.value);
+    const pixelScale = scale.value;
+    const originX = frame.value.x - crop.x * pixelScale;
+    const originY = frame.value.y - crop.y * pixelScale;
+
+    context.drawImage(props.working.canvas, originX, originY, props.working.width * pixelScale, props.working.height * pixelScale);
+
+    drawScrim(context, cssWidth, cssHeight);
+    drawFrame(context);
+
+    if (props.showGuides) {
+        drawGuides(context);
+    }
+}
+
+/**
+ * Overlay colours are deliberately plain black/white rather than theme tokens:
+ * they sit on top of an arbitrary photograph, where contrast has to come from
+ * the scrim itself and not from the page's palette.
+ */
+function drawScrim(context: CanvasRenderingContext2D, width: number, height: number): void {
+    const { x, y, width: frameWidth, height: frameHeight } = frame.value;
+
+    context.fillStyle = 'rgba(0, 0, 0, 0.55)';
+    context.fillRect(0, 0, width, y);
+    context.fillRect(0, y + frameHeight, width, height - (y + frameHeight));
+    context.fillRect(0, y, x, frameHeight);
+    context.fillRect(x + frameWidth, y, width - (x + frameWidth), frameHeight);
+}
+
+function drawFrame(context: CanvasRenderingContext2D): void {
+    const { x, y, width, height } = frame.value;
+
+    context.save();
+    context.strokeStyle = 'rgba(255, 255, 255, 0.95)';
+    context.lineWidth = 2;
+    context.strokeRect(x + 1, y + 1, width - 2, height - 2);
+    context.restore();
+}
+
+/** Passport-style aids: where the head should sit and where the eyes should land. */
+function drawGuides(context: CanvasRenderingContext2D): void {
+    const { x, y, width, height } = frame.value;
+
+    context.save();
+    context.strokeStyle = 'rgba(255, 255, 255, 0.65)';
+    context.lineWidth = 1.5;
+    context.setLineDash([6, 6]);
+
+    context.beginPath();
+    context.ellipse(x + width / 2, y + height * 0.44, width * 0.3, height * 0.32, 0, 0, Math.PI * 2);
+    context.stroke();
+
+    context.beginPath();
+    context.moveTo(x + width * 0.12, y + height * 0.42);
+    context.lineTo(x + width * 0.88, y + height * 0.42);
+    context.stroke();
+
+    context.restore();
+}
+
+function scheduleDraw(): void {
+    if (frameRequest) {
+        return;
+    }
+
+    frameRequest = requestAnimationFrame(() => {
+        frameRequest = 0;
+        draw();
+    });
+}
+
+function distanceBetweenPointers(): number {
+    const [first, second] = [...pointers.values()];
+
+    return Math.hypot(first.x - second.x, first.y - second.y);
+}
+
+function handlePointerDown(event: PointerEvent): void {
+    (event.target as HTMLElement).setPointerCapture?.(event.pointerId);
+    pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+    if (pointers.size === 2) {
+        pinchStart = { distance: distanceBetweenPointers(), zoom: props.view.zoom };
+    }
+}
+
+function handlePointerMove(event: PointerEvent): void {
+    const previous = pointers.get(event.pointerId);
+
+    if (!previous) {
+        return;
+    }
+
+    pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+    if (pointers.size >= 2) {
+        if (pinchStart && pinchStart.distance > 0) {
+            const factor = distanceBetweenPointers() / pinchStart.distance;
+
+            emit('update:view', clampView({ ...props.view, zoom: pinchStart.zoom * factor }, imageSize.value));
+        }
+
+        return;
+    }
+
+    emit('update:view', panView(props.view, event.clientX - previous.x, event.clientY - previous.y, scale.value, imageSize.value));
+}
+
+function handlePointerUp(event: PointerEvent): void {
+    pointers.delete(event.pointerId);
+
+    if (pointers.size < 2) {
+        pinchStart = null;
+    }
+}
+
+function handleWheel(event: WheelEvent): void {
+    emit('update:view', zoomView(props.view, Math.exp(-event.deltaY * 0.0015), imageSize.value));
+}
+
+function handleKeydown(event: KeyboardEvent): void {
+    const step = event.shiftKey ? KEYBOARD_STEP_FAST : KEYBOARD_STEP;
+    const pan = (deltaX: number, deltaY: number) => emit('update:view', panView(props.view, deltaX, deltaY, scale.value, imageSize.value));
+
+    switch (event.key) {
+        case 'ArrowRight':
+            pan(step, 0);
+            break;
+        case 'ArrowLeft':
+            pan(-step, 0);
+            break;
+        case 'ArrowUp':
+            pan(0, step);
+            break;
+        case 'ArrowDown':
+            pan(0, -step);
+            break;
+        case '+':
+        case '=':
+            emit('update:view', zoomView(props.view, KEYBOARD_ZOOM_FACTOR, imageSize.value));
+            break;
+        case '-':
+        case '_':
+            emit('update:view', zoomView(props.view, 1 / KEYBOARD_ZOOM_FACTOR, imageSize.value));
+            break;
+        case '0':
+            emit('reset');
+            break;
+        default:
+            return;
+    }
+
+    event.preventDefault();
+}
+
+function measureViewport(): void {
+    const element = container.value;
+
+    if (!element) {
+        return;
+    }
+
+    viewport.value = { width: element.clientWidth, height: element.clientHeight };
+    scheduleDraw();
+}
+
+onMounted(() => {
+    measureViewport();
+
+    if (typeof ResizeObserver !== 'undefined' && container.value) {
+        resizeObserver = new ResizeObserver(measureViewport);
+        resizeObserver.observe(container.value);
+    } else {
+        window.addEventListener('resize', measureViewport);
+    }
+});
+
+onBeforeUnmount(() => {
+    resizeObserver?.disconnect();
+    window.removeEventListener('resize', measureViewport);
+
+    if (frameRequest) {
+        cancelAnimationFrame(frameRequest);
+    }
+});
+
+watch(() => [props.view, props.working, props.showGuides], scheduleDraw, { deep: true });
+</script>
+
+<template>
+    <div ref="container" class="relative h-[26rem] w-full overflow-hidden rounded-xl bg-muted select-none sm:h-[30rem]">
+        <canvas
+            ref="canvas"
+            class="size-full touch-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+            tabindex="0"
+            role="application"
+            aria-label="إطار قص الصورة — اسحب لتحريك الصورة، واستخدم أسهم لوحة المفاتيح للتحريك و + و − للتكبير والتصغير"
+            @pointerdown="handlePointerDown"
+            @pointermove="handlePointerMove"
+            @pointerup="handlePointerUp"
+            @pointercancel="handlePointerUp"
+            @lostpointercapture="handlePointerUp"
+            @wheel.prevent="handleWheel"
+            @keydown="handleKeydown"
+        ></canvas>
+    </div>
+</template>

--- a/resources/js/components/tools/PhotoDropzone.vue
+++ b/resources/js/components/tools/PhotoDropzone.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { Button } from '@/components/ui/button';
+import { formatFileSize } from '@/lib/formatters';
+import { MAX_INPUT_BYTES } from '@/lib/studentPhoto/decode';
+import { ImageUp } from 'lucide-vue-next';
+import { onBeforeUnmount, onMounted, ref } from 'vue';
+
+interface Props {
+    /** Disables picking while a photo is being decoded. */
+    busy?: boolean;
+    /** Listen for a pasted image anywhere on the page (⌘/Ctrl+V). */
+    listenForPaste?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), { busy: false, listenForPaste: true });
+
+const emit = defineEmits<{
+    (event: 'select', file: File): void;
+    (event: 'reject', message: string): void;
+}>();
+
+const fileInput = ref<HTMLInputElement | null>(null);
+const isDragging = ref(false);
+/** Drag events fire per child element, so nesting is counted rather than toggled. */
+const dragDepth = ref(0);
+
+function openPicker(): void {
+    if (!props.busy) {
+        fileInput.value?.click();
+    }
+}
+
+function takeFirstFile(files: FileList | null | undefined, droppedItems?: DataTransferItemList | null): void {
+    const list = files ? [...files] : [];
+
+    if (list.length === 0) {
+        const droppedFolder = droppedItems && [...droppedItems].some((item) => item.webkitGetAsEntry?.()?.isDirectory);
+
+        emit('reject', droppedFolder ? 'أفلِت ملف صورة واحدًا لا مجلدًا.' : 'لم يصل أي ملف. جرّب اختيار الصورة من الزر.');
+
+        return;
+    }
+
+    if (list.length > 1) {
+        emit('reject', 'اخترت أكثر من ملف — سنستخدم الأول فقط.');
+    }
+
+    emit('select', list[0]);
+}
+
+function handleInputChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+
+    takeFirstFile(input.files);
+
+    // Reset so re-picking the same file still fires a change event.
+    input.value = '';
+}
+
+function handleDrop(event: DragEvent): void {
+    dragDepth.value = 0;
+    isDragging.value = false;
+
+    if (props.busy) {
+        return;
+    }
+
+    takeFirstFile(event.dataTransfer?.files, event.dataTransfer?.items);
+}
+
+function handleDragEnter(): void {
+    dragDepth.value += 1;
+    isDragging.value = true;
+}
+
+function handleDragLeave(): void {
+    dragDepth.value = Math.max(0, dragDepth.value - 1);
+
+    if (dragDepth.value === 0) {
+        isDragging.value = false;
+    }
+}
+
+function handlePaste(event: ClipboardEvent): void {
+    if (props.busy || !props.listenForPaste) {
+        return;
+    }
+
+    const pasted = [...(event.clipboardData?.items ?? [])].find((item) => item.kind === 'file');
+    const file = pasted?.getAsFile();
+
+    if (file) {
+        event.preventDefault();
+        emit('select', file);
+    }
+}
+
+onMounted(() => window.addEventListener('paste', handlePaste));
+onBeforeUnmount(() => window.removeEventListener('paste', handlePaste));
+</script>
+
+<template>
+    <div
+        class="flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed p-8 text-center transition-colors"
+        :class="isDragging ? 'border-primary bg-primary/5' : 'border-border bg-muted/40'"
+        @dragenter.prevent="handleDragEnter"
+        @dragover.prevent
+        @dragleave.prevent="handleDragLeave"
+        @drop.prevent="handleDrop"
+    >
+        <ImageUp class="size-10 text-muted-foreground" aria-hidden="true" />
+
+        <div class="space-y-1">
+            <p class="!my-0 font-medium">اسحب صورتك هنا، أو الصقها بلوحة المفاتيح</p>
+            <p class="!my-0 text-sm text-muted-foreground">
+                JPG أو PNG أو WEBP — حتى {{ formatFileSize(MAX_INPUT_BYTES) }}. الصورة لا تُرفع لأي خادم، وكل المعالجة داخل متصفحك.
+            </p>
+        </div>
+
+        <Button type="button" :disabled="busy" @click="openPicker">
+            {{ busy ? 'جارٍ فتح الصورة…' : 'اختر صورة' }}
+        </Button>
+
+        <input ref="fileInput" type="file" accept="image/*" class="hidden" @change="handleInputChange" />
+    </div>
+</template>

--- a/resources/js/lib/formatters.ts
+++ b/resources/js/lib/formatters.ts
@@ -87,3 +87,10 @@ const dateTimeFormatter = new Intl.DateTimeFormat('ar', { dateStyle: 'medium', t
 export function formatDateTime(iso: string): string {
     return dateTimeFormatter.format(new Date(iso));
 }
+
+const fullDateFormatter = new Intl.DateTimeFormat('ar', { year: 'numeric', month: 'long', day: 'numeric' });
+
+/** A Date → a full Arabic date ("١٤ فبراير ٢٠٢٦"), for values that are not ISO strings. */
+export function formatFullDate(date: Date): string {
+    return fullDateFormatter.format(date);
+}

--- a/resources/js/lib/studentPhoto/analysis.test.ts
+++ b/resources/js/lib/studentPhoto/analysis.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { measurePhoto, type PixelSample } from './analysis';
+
+type PixelFactory = (x: number, y: number) => [number, number, number];
+
+function sample(width: number, height: number, pixel: PixelFactory): PixelSample {
+    const data = new Uint8ClampedArray(width * height * 4);
+
+    for (let y = 0; y < height; y += 1) {
+        for (let x = 0; x < width; x += 1) {
+            const offset = (y * width + x) * 4;
+            const [red, green, blue] = pixel(x, y);
+
+            data[offset] = red;
+            data[offset + 1] = green;
+            data[offset + 2] = blue;
+            data[offset + 3] = 255;
+        }
+    }
+
+    return { data, width, height };
+}
+
+const solidGray = sample(40, 40, () => [128, 128, 128]);
+const solidRed = sample(40, 40, () => [220, 40, 40]);
+const checkerboard = sample(40, 40, (x, y) => ((x + y) % 2 === 0 ? [240, 200, 160] : [40, 30, 20]));
+const softGradient = sample(40, 40, (x) => [60 + x * 4, 50 + x * 4, 45 + x * 4]);
+const darkFrame = sample(40, 40, () => [8, 9, 10]);
+const blownFrame = sample(40, 40, () => [253, 253, 252]);
+
+describe('measurePhoto', () => {
+    it('reports a flat grey frame as unsaturated, flat and unsharp', () => {
+        const metrics = measurePhoto(solidGray);
+
+        expect(metrics.meanSaturation).toBe(0);
+        expect(metrics.colorfulRatio).toBe(0);
+        expect(metrics.contrast).toBeCloseTo(0, 5);
+        expect(metrics.sharpness).toBe(0);
+        expect(metrics.meanLuma).toBeCloseTo(128 / 255, 2);
+    });
+
+    it('reports saturated colour for a coloured frame', () => {
+        const metrics = measurePhoto(solidRed);
+
+        expect(metrics.meanSaturation).toBeGreaterThan(0.7);
+        expect(metrics.colorfulRatio).toBe(1);
+    });
+
+    it('scores fine detail far above a smooth gradient', () => {
+        const sharp = measurePhoto(checkerboard);
+        const soft = measurePhoto(softGradient);
+
+        expect(sharp.sharpness).toBeGreaterThan(soft.sharpness * 100);
+        expect(soft.sharpness).toBeLessThan(0.0001);
+    });
+
+    it('flags a dark frame through luma and the dark-pixel share', () => {
+        const metrics = measurePhoto(darkFrame);
+
+        expect(metrics.meanLuma).toBeLessThan(0.1);
+        expect(metrics.darkRatio).toBe(1);
+        expect(metrics.brightRatio).toBe(0);
+    });
+
+    it('flags a blown-out frame through the bright-pixel share', () => {
+        const metrics = measurePhoto(blownFrame);
+
+        expect(metrics.brightRatio).toBe(1);
+        expect(metrics.meanLuma).toBeGreaterThan(0.95);
+    });
+
+    it('ignores saturation noise in near-black pixels', () => {
+        const nearBlackNoise = sample(20, 20, (x) => (x % 2 === 0 ? [4, 0, 0] : [0, 0, 6]));
+
+        expect(measurePhoto(nearBlackNoise).meanSaturation).toBe(0);
+    });
+
+    it('measures contrast as the luma spread', () => {
+        const halfBlackHalfWhite = sample(20, 20, (x) => (x < 10 ? [0, 0, 0] : [255, 255, 255]));
+
+        expect(measurePhoto(halfBlackHalfWhite).contrast).toBeCloseTo(0.5, 1);
+    });
+
+    it('returns zeroed metrics for an empty or short sample', () => {
+        expect(measurePhoto({ data: new Uint8ClampedArray(), width: 0, height: 0 }).sharpness).toBe(0);
+        expect(measurePhoto({ data: new Uint8ClampedArray(4), width: 10, height: 10 }).meanLuma).toBe(0);
+    });
+
+    it('returns zero sharpness for samples too small to convolve', () => {
+        expect(measurePhoto(sample(2, 2, () => [10, 200, 30])).sharpness).toBe(0);
+    });
+
+    it('accepts a plain number array as well as a typed array', () => {
+        const plain = { data: [...solidRed.data], width: solidRed.width, height: solidRed.height };
+
+        expect(measurePhoto(plain).colorfulRatio).toBe(1);
+    });
+});

--- a/resources/js/lib/studentPhoto/analysis.ts
+++ b/resources/js/lib/studentPhoto/analysis.ts
@@ -1,0 +1,153 @@
+/**
+ * Pixel measurements behind the automatic warnings. These are deliberately
+ * simple, explainable statistics rather than a model: the tool only ever warns
+ * on what it can defend ("this looks greyscale", "this looks blurry"), and
+ * leaves judgement calls to the student's own checklist.
+ *
+ * Callers pass a small downscaled sample (see `ANALYSIS_SAMPLE_WIDTH`) so the
+ * numbers mean the same thing whether the source was 8 MP or 0.3 MP.
+ */
+
+/** Analysis is done on a sample this wide, keeping thresholds resolution-independent. */
+export const ANALYSIS_SAMPLE_WIDTH = 200;
+
+export interface PixelSample {
+    data: Uint8ClampedArray | Uint8Array | number[];
+    width: number;
+    height: number;
+}
+
+export interface PhotoMetrics {
+    /** Mean HSV saturation over non-black pixels, 0–1. */
+    meanSaturation: number;
+    /** Share of pixels that are recognisably coloured, 0–1. */
+    colorfulRatio: number;
+    /** Variance of the Laplacian, normalised — higher is sharper. */
+    sharpness: number;
+    /** Mean luma, 0–1. */
+    meanLuma: number;
+    /** Share of near-black and near-white pixels, 0–1. */
+    darkRatio: number;
+    brightRatio: number;
+    /** Standard deviation of luma, 0–1 — near zero means a blank frame. */
+    contrast: number;
+}
+
+const EMPTY_METRICS: PhotoMetrics = {
+    meanSaturation: 0,
+    colorfulRatio: 0,
+    sharpness: 0,
+    meanLuma: 0,
+    darkRatio: 0,
+    brightRatio: 0,
+    contrast: 0,
+};
+
+function luma(red: number, green: number, blue: number): number {
+    return 0.299 * red + 0.587 * green + 0.114 * blue;
+}
+
+/** Measure a decoded RGBA sample. Returns zeroed metrics for an empty sample. */
+export function measurePhoto(sample: PixelSample): PhotoMetrics {
+    const { data, width, height } = sample;
+    const pixelCount = width * height;
+
+    if (pixelCount <= 0 || data.length < pixelCount * 4) {
+        return { ...EMPTY_METRICS };
+    }
+
+    const grayscale = new Float64Array(pixelCount);
+
+    let saturationSum = 0;
+    let saturationSamples = 0;
+    let colorfulCount = 0;
+    let lumaSum = 0;
+    let lumaSquaredSum = 0;
+    let darkCount = 0;
+    let brightCount = 0;
+
+    for (let index = 0; index < pixelCount; index += 1) {
+        const offset = index * 4;
+        const red = data[offset];
+        const green = data[offset + 1];
+        const blue = data[offset + 2];
+
+        const max = Math.max(red, green, blue);
+        const min = Math.min(red, green, blue);
+
+        // Saturation is meaningless in near-black pixels — sensor noise there
+        // would otherwise make a greyscale photo look coloured.
+        if (max >= 16) {
+            const saturation = (max - min) / max;
+
+            saturationSum += saturation;
+            saturationSamples += 1;
+
+            if (saturation >= 0.12) {
+                colorfulCount += 1;
+            }
+        }
+
+        const pixelLuma = luma(red, green, blue);
+
+        grayscale[index] = pixelLuma;
+        lumaSum += pixelLuma;
+        lumaSquaredSum += pixelLuma * pixelLuma;
+
+        if (pixelLuma <= 20) {
+            darkCount += 1;
+        }
+
+        if (pixelLuma >= 247) {
+            brightCount += 1;
+        }
+    }
+
+    const meanLuma = lumaSum / pixelCount;
+    const variance = Math.max(0, lumaSquaredSum / pixelCount - meanLuma * meanLuma);
+
+    return {
+        meanSaturation: saturationSamples === 0 ? 0 : saturationSum / saturationSamples,
+        colorfulRatio: colorfulCount / pixelCount,
+        sharpness: laplacianVariance(grayscale, width, height),
+        meanLuma: meanLuma / 255,
+        darkRatio: darkCount / pixelCount,
+        brightRatio: brightCount / pixelCount,
+        contrast: Math.sqrt(variance) / 255,
+    };
+}
+
+/**
+ * Variance of a 4-neighbour Laplacian over the interior pixels, scaled to a
+ * 0–1-ish range. Flat or out-of-focus photos land near zero; a photo of a
+ * printed photo (a common rejection cause) also scores low.
+ */
+function laplacianVariance(grayscale: Float64Array, width: number, height: number): number {
+    if (width < 3 || height < 3) {
+        return 0;
+    }
+
+    let sum = 0;
+    let squaredSum = 0;
+    let count = 0;
+
+    for (let y = 1; y < height - 1; y += 1) {
+        for (let x = 1; x < width - 1; x += 1) {
+            const index = y * width + x;
+            const value = 4 * grayscale[index] - grayscale[index - 1] - grayscale[index + 1] - grayscale[index - width] - grayscale[index + width];
+
+            sum += value;
+            squaredSum += value * value;
+            count += 1;
+        }
+    }
+
+    if (count === 0) {
+        return 0;
+    }
+
+    const mean = sum / count;
+    const variance = Math.max(0, squaredSum / count - mean * mean);
+
+    return variance / (255 * 255);
+}

--- a/resources/js/lib/studentPhoto/checks.test.ts
+++ b/resources/js/lib/studentPhoto/checks.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import type { PhotoMetrics } from './analysis';
+import { BLANK_CONTRAST_THRESHOLD, buildPhotoChecks, SHARPNESS_WARN_THRESHOLD, worstStatus, type CheckInput, type PhotoCheck } from './checks';
+
+const healthyMetrics: PhotoMetrics = {
+    meanSaturation: 0.3,
+    colorfulRatio: 0.6,
+    sharpness: 0.004,
+    meanLuma: 0.55,
+    darkRatio: 0.02,
+    brightRatio: 0.05,
+    contrast: 0.2,
+};
+
+const now = new Date(2026, 7, 26);
+
+function input(overrides: Partial<CheckInput> = {}): CheckInput {
+    return {
+        outputWidth: 360,
+        outputHeight: 480,
+        outputBytes: 120_000,
+        cropWidth: 1200,
+        metrics: healthyMetrics,
+        takenAt: null,
+        now,
+        ...overrides,
+    };
+}
+
+function find(checks: PhotoCheck[], id: string): PhotoCheck | undefined {
+    return checks.find((check) => check.id === id);
+}
+
+describe('buildPhotoChecks', () => {
+    it('passes everything for a well-framed recent photo', () => {
+        const checks = buildPhotoChecks(input({ takenAt: new Date(2026, 6, 1) }));
+
+        expect(checks.every((check) => check.status === 'pass')).toBe(true);
+        expect(worstStatus(checks)).toBe('pass');
+    });
+
+    it('always reports JPG as the output format', () => {
+        expect(find(buildPhotoChecks(input()), 'format')?.status).toBe('pass');
+    });
+
+    it('fails dimensions outside the accepted envelope', () => {
+        expect(find(buildPhotoChecks(input({ outputWidth: 90, outputHeight: 120 })), 'dimensions')?.status).toBe('fail');
+        expect(find(buildPhotoChecks(input({ outputWidth: 480, outputHeight: 640 })), 'dimensions')?.status).toBe('fail');
+    });
+
+    it('fails a shape that is not 3:4 or is wider than it is tall', () => {
+        expect(find(buildPhotoChecks(input({ outputWidth: 360, outputHeight: 360 })), 'dimensions')?.status).toBe('fail');
+        expect(find(buildPhotoChecks(input({ outputWidth: 360, outputHeight: 240 })), 'dimensions')?.status).toBe('fail');
+    });
+
+    it('accepts every allowed proportional size', () => {
+        for (const [width, height] of [
+            [120, 160],
+            [240, 320],
+            [300, 400],
+            [360, 480],
+        ]) {
+            expect(find(buildPhotoChecks(input({ outputWidth: width, outputHeight: height })), 'dimensions')?.status).toBe('pass');
+        }
+    });
+
+    it('fails a file over the 300 KB ceiling and names the size', () => {
+        const check = find(buildPhotoChecks(input({ outputBytes: 320_000 })), 'file-size');
+
+        expect(check?.status).toBe('fail');
+        expect(check?.detail).toContain('300 KB');
+    });
+
+    it('fails an empty render rather than calling it a small file', () => {
+        expect(find(buildPhotoChecks(input({ outputBytes: 0 })), 'file-size')?.status).toBe('fail');
+    });
+
+    it('warns when the crop has to be upscaled to reach the output size', () => {
+        const check = find(buildPhotoChecks(input({ cropWidth: 180 })), 'clarity');
+
+        expect(check?.status).toBe('warn');
+        expect(check?.detail).toContain('180');
+    });
+
+    it('does not warn about upscaling for a crop that merely rounds down', () => {
+        expect(find(buildPhotoChecks(input({ cropWidth: 359 })), 'clarity')?.status).toBe('pass');
+    });
+
+    it('warns about a blurry photo even when the crop is large enough', () => {
+        const metrics = { ...healthyMetrics, sharpness: SHARPNESS_WARN_THRESHOLD / 2 };
+
+        expect(find(buildPhotoChecks(input({ metrics })), 'clarity')?.status).toBe('warn');
+    });
+
+    it('fails a greyscale photo', () => {
+        const metrics = { ...healthyMetrics, meanSaturation: 0.01, colorfulRatio: 0.005 };
+        const check = find(buildPhotoChecks(input({ metrics })), 'color');
+
+        expect(check?.status).toBe('fail');
+        expect(worstStatus(buildPhotoChecks(input({ metrics })))).toBe('fail');
+    });
+
+    it('does not call a muted but coloured photo greyscale', () => {
+        const metrics = { ...healthyMetrics, meanSaturation: 0.04, colorfulRatio: 0.2 };
+
+        expect(find(buildPhotoChecks(input({ metrics })), 'color')?.status).toBe('pass');
+    });
+
+    it('warns on a dark, a blown-out, and a blank frame', () => {
+        const dark = { ...healthyMetrics, meanLuma: 0.1 };
+        const blown = { ...healthyMetrics, brightRatio: 0.6 };
+        const blank = { ...healthyMetrics, contrast: BLANK_CONTRAST_THRESHOLD / 2 };
+
+        expect(find(buildPhotoChecks(input({ metrics: dark })), 'exposure')?.status).toBe('warn');
+        expect(find(buildPhotoChecks(input({ metrics: blown })), 'exposure')?.status).toBe('warn');
+        expect(find(buildPhotoChecks(input({ metrics: blank })), 'exposure')?.detail).toContain('فارغًا');
+    });
+
+    it('omits the pixel-based checks when no metrics could be measured', () => {
+        const checks = buildPhotoChecks(input({ metrics: null }));
+
+        expect(find(checks, 'exposure')).toBeUndefined();
+        expect(find(checks, 'color')?.status).toBe('pass');
+        expect(find(checks, 'clarity')?.status).toBe('pass');
+    });
+
+    it('passes a photo captured inside the six-month window', () => {
+        const check = find(buildPhotoChecks(input({ takenAt: new Date(2026, 4, 1) })), 'age');
+
+        expect(check?.status).toBe('pass');
+    });
+
+    it('fails a photo captured before the six-month cutoff', () => {
+        const check = find(buildPhotoChecks(input({ takenAt: new Date(2025, 11, 31) })), 'age');
+
+        expect(check?.status).toBe('fail');
+    });
+
+    it('treats the cutoff day itself as still recent', () => {
+        expect(find(buildPhotoChecks(input({ takenAt: new Date(2026, 1, 26) })), 'age')?.status).toBe('pass');
+    });
+
+    it('omits the age check when the file carries no capture date', () => {
+        expect(find(buildPhotoChecks(input()), 'age')).toBeUndefined();
+    });
+
+    it('ignores a capture date in the future instead of failing a good photo', () => {
+        expect(find(buildPhotoChecks(input({ takenAt: new Date(2027, 0, 1) })), 'age')).toBeUndefined();
+    });
+});
+
+describe('worstStatus', () => {
+    it('ranks fail over warn over pass', () => {
+        expect(worstStatus([])).toBe('pass');
+        expect(worstStatus([{ id: 'a', label: '', status: 'pass', detail: '' }])).toBe('pass');
+        expect(
+            worstStatus([
+                { id: 'a', label: '', status: 'pass', detail: '' },
+                { id: 'b', label: '', status: 'warn', detail: '' },
+            ]),
+        ).toBe('warn');
+        expect(
+            worstStatus([
+                { id: 'a', label: '', status: 'warn', detail: '' },
+                { id: 'b', label: '', status: 'fail', detail: '' },
+            ]),
+        ).toBe('fail');
+    });
+});

--- a/resources/js/lib/studentPhoto/checks.ts
+++ b/resources/js/lib/studentPhoto/checks.ts
@@ -1,0 +1,235 @@
+/**
+ * Turns the rendered output plus the pixel metrics into the verdict list the
+ * student reads. One function, one place: the UI renders whatever this returns,
+ * so a rule can never disagree with itself across screens.
+ */
+
+import { formatFileSize, formatFullDate } from '@/lib/formatters';
+import type { PhotoMetrics } from './analysis';
+import { MAX_OUTPUT_BYTES, MAX_OUTPUT_HEIGHT, MAX_OUTPUT_WIDTH, MAX_PHOTO_AGE_MONTHS, MIN_OUTPUT_HEIGHT, MIN_OUTPUT_WIDTH } from './requirements';
+
+export type CheckStatus = 'pass' | 'warn' | 'fail';
+
+export interface PhotoCheck {
+    id: string;
+    label: string;
+    status: CheckStatus;
+    detail: string;
+}
+
+/** A photo that scores below this on Laplacian variance reads as soft or blurry. */
+export const SHARPNESS_WARN_THRESHOLD = 0.0004;
+
+/** Below these two together, the photo is effectively greyscale. */
+export const GRAYSCALE_SATURATION_THRESHOLD = 0.05;
+export const GRAYSCALE_COLORFUL_THRESHOLD = 0.03;
+
+export const DARK_LUMA_THRESHOLD = 0.18;
+export const DARK_PIXEL_RATIO_THRESHOLD = 0.5;
+export const BLOWN_PIXEL_RATIO_THRESHOLD = 0.35;
+export const BLANK_CONTRAST_THRESHOLD = 0.02;
+
+export interface CheckInput {
+    outputWidth: number;
+    outputHeight: number;
+    outputBytes: number;
+    /** Width in source pixels of the region being cropped, for the upscale warning. */
+    cropWidth: number;
+    metrics: PhotoMetrics | null;
+    /** EXIF capture date, when the original carried one. */
+    takenAt: Date | null;
+    now: Date;
+}
+
+/** Latin digits inside an RTL sentence read correctly when isolated. */
+function ltr(value: string | number): string {
+    return `⁦${value}⁩`;
+}
+
+function monthsAgo(date: Date, months: number): Date {
+    const shifted = new Date(date.getTime());
+
+    shifted.setMonth(shifted.getMonth() - months);
+
+    return shifted;
+}
+
+function dimensionsCheck(width: number, height: number): PhotoCheck {
+    const withinEnvelope = width >= MIN_OUTPUT_WIDTH && width <= MAX_OUTPUT_WIDTH && height >= MIN_OUTPUT_HEIGHT && height <= MAX_OUTPUT_HEIGHT;
+    const isTallerThanWide = height > width;
+    const isCardShape = Math.abs(width * 4 - height * 3) <= 1;
+    const passes = withinEnvelope && isTallerThanWide && isCardShape;
+
+    return {
+        id: 'dimensions',
+        label: 'المقاس ٣ × ٤ والطول أكبر من العرض',
+        status: passes ? 'pass' : 'fail',
+        detail: passes
+            ? `${ltr(`${width} × ${height}`)} بكسل — داخل المدى المسموح (العرض ${ltr('120–360')}، الطول ${ltr('160–480')}).`
+            : `${ltr(`${width} × ${height}`)} بكسل خارج المدى المسموح.`,
+    };
+}
+
+function fileSizeCheck(bytes: number): PhotoCheck {
+    const passes = bytes > 0 && bytes <= MAX_OUTPUT_BYTES;
+
+    return {
+        id: 'file-size',
+        label: `حجم الملف لا يزيد عن ${ltr('300 KB')}`,
+        status: passes ? 'pass' : 'fail',
+        detail: passes
+            ? `حجم الملف ${ltr(formatFileSize(bytes))} — بأعلى جودة ممكنة تحت الحد المسموح.`
+            : `حجم الملف ${ltr(formatFileSize(bytes))} ويجب أن ينزل عن ${ltr('300 KB')}. اختر مقاسًا أصغر.`,
+    };
+}
+
+function clarityCheck(cropWidth: number, outputWidth: number, metrics: PhotoMetrics | null): PhotoCheck {
+    const isUpscaled = cropWidth > 0 && cropWidth < outputWidth * 0.98;
+    const isSoft = metrics !== null && metrics.sharpness < SHARPNESS_WARN_THRESHOLD;
+
+    if (isUpscaled) {
+        return {
+            id: 'clarity',
+            label: 'الصورة واضحة وبجودة مناسبة',
+            status: 'warn',
+            detail: `الجزء المقتطع من صورتك عرضه ${ltr(Math.round(cropWidth))} بكسل فقط، وسيُكبَّر إلى ${ltr(outputWidth)} بكسل فيقل وضوحه. قلّل التكبير أو اختر مقاسًا أصغر أو استخدم صورة أعلى دقة.`,
+        };
+    }
+
+    if (isSoft) {
+        return {
+            id: 'clarity',
+            label: 'الصورة واضحة وبجودة مناسبة',
+            status: 'warn',
+            detail: 'الصورة تبدو غير واضحة أو مهتزة — والصور غير الواضحة مرفوضة. جرّب صورة أخرى بإضاءة أفضل وكاميرا ثابتة.',
+        };
+    }
+
+    return {
+        id: 'clarity',
+        label: 'الصورة واضحة وبجودة مناسبة',
+        status: 'pass',
+        detail: 'درجة وضوح الصورة جيدة، ولم يحدث تكبير يفقدها التفاصيل.',
+    };
+}
+
+function colorCheck(metrics: PhotoMetrics | null): PhotoCheck {
+    const looksGrayscale =
+        metrics !== null && metrics.meanSaturation < GRAYSCALE_SATURATION_THRESHOLD && metrics.colorfulRatio < GRAYSCALE_COLORFUL_THRESHOLD;
+
+    return {
+        id: 'color',
+        label: 'الصورة ملوّنة',
+        status: looksGrayscale ? 'fail' : 'pass',
+        detail: looksGrayscale ? 'الصورة تبدو بالأبيض والأسود أو بفلتر يسحب الألوان، والصور غير الملوّنة مرفوضة.' : 'الصورة ملوّنة.',
+    };
+}
+
+function exposureCheck(metrics: PhotoMetrics | null): PhotoCheck | null {
+    if (metrics === null) {
+        return null;
+    }
+
+    if (metrics.contrast < BLANK_CONTRAST_THRESHOLD) {
+        return {
+            id: 'exposure',
+            label: 'الإضاءة مناسبة',
+            status: 'warn',
+            detail: 'الجزء المقتطع يبدو فارغًا أو بلون واحد — تأكد أن الوجه داخل الإطار.',
+        };
+    }
+
+    if (metrics.meanLuma < DARK_LUMA_THRESHOLD || metrics.darkRatio > DARK_PIXEL_RATIO_THRESHOLD) {
+        return {
+            id: 'exposure',
+            label: 'الإضاءة مناسبة',
+            status: 'warn',
+            detail: 'الصورة معتمة وقد تخفي ملامح الوجه. صوّر في مكان أفضل إضاءة.',
+        };
+    }
+
+    if (metrics.brightRatio > BLOWN_PIXEL_RATIO_THRESHOLD) {
+        return {
+            id: 'exposure',
+            label: 'الإضاءة مناسبة',
+            status: 'warn',
+            detail: 'أجزاء واسعة من الصورة شديدة البياض (إضاءة محروقة) وقد تخفي الملامح.',
+        };
+    }
+
+    return {
+        id: 'exposure',
+        label: 'الإضاءة مناسبة',
+        status: 'pass',
+        detail: 'الإضاءة متوازنة.',
+    };
+}
+
+function ageCheck(takenAt: Date | null, now: Date): PhotoCheck | null {
+    if (takenAt === null) {
+        return null;
+    }
+
+    const cutoff = monthsAgo(now, MAX_PHOTO_AGE_MONTHS);
+    const isFuture = takenAt.getTime() > now.getTime() + 24 * 60 * 60 * 1000;
+
+    if (isFuture) {
+        return null;
+    }
+
+    const isRecent = takenAt.getTime() >= cutoff.getTime();
+    const label = `عمر الصورة لا يزيد عن ${ltr(MAX_PHOTO_AGE_MONTHS)} أشهر`;
+    const formatted = formatFullDate(takenAt);
+
+    return {
+        id: 'age',
+        label,
+        status: isRecent ? 'pass' : 'fail',
+        detail: isRecent
+            ? `بيانات الملف تقول إنها صُوّرت في ${formatted}.`
+            : `بيانات الملف تقول إنها صُوّرت في ${formatted}، أي أقدم من ${ltr(MAX_PHOTO_AGE_MONTHS)} أشهر. استخدم صورة حديثة.`,
+    };
+}
+
+/** Build the automatic verdict list, hardest requirements first. */
+export function buildPhotoChecks(input: CheckInput): PhotoCheck[] {
+    const checks: PhotoCheck[] = [
+        {
+            id: 'format',
+            label: 'نوع الملف JPG',
+            status: 'pass',
+            detail: 'الملف الناتج يُحفظ دائمًا بصيغة JPG بامتداد ‎.jpg‎.',
+        },
+        dimensionsCheck(input.outputWidth, input.outputHeight),
+        fileSizeCheck(input.outputBytes),
+        clarityCheck(input.cropWidth, input.outputWidth, input.metrics),
+        colorCheck(input.metrics),
+    ];
+
+    const exposure = exposureCheck(input.metrics);
+
+    if (exposure) {
+        checks.push(exposure);
+    }
+
+    const age = ageCheck(input.takenAt, input.now);
+
+    if (age) {
+        checks.push(age);
+    }
+
+    return checks;
+}
+
+/** The most severe status in a list — drives the summary banner. */
+export function worstStatus(checks: PhotoCheck[]): CheckStatus {
+    if (checks.some((check) => check.status === 'fail')) {
+        return 'fail';
+    }
+
+    if (checks.some((check) => check.status === 'warn')) {
+        return 'warn';
+    }
+
+    return 'pass';
+}

--- a/resources/js/lib/studentPhoto/decode.ts
+++ b/resources/js/lib/studentPhoto/decode.ts
@@ -1,0 +1,275 @@
+/**
+ * Getting an arbitrary file the student picked into something drawable, or
+ * failing with an explanation they can act on.
+ *
+ * The browser is the only decoder available (the tool never uploads anything),
+ * and it refuses plenty of real-world camera files — HEIC from an iPhone being
+ * the big one. Every refusal here carries the reason and the way out.
+ */
+
+import { readExif, withExifOrientation } from './exif';
+import { isRasterType, sniffFileType, type SniffedType } from './sniff';
+
+export type DecodeFailure = 'empty' | 'too-large-file' | 'heif' | 'pdf' | 'svg' | 'tiff' | 'video' | 'unsupported' | 'decode-failed';
+
+/** Refuse absurd inputs before spending memory on them. */
+export const MAX_INPUT_BYTES = 60 * 1024 * 1024;
+
+/** How much of the head to read when looking for EXIF (the segment can be large). */
+const EXIF_SCAN_BYTES = 512 * 1024;
+
+/** Fallback decode width when the full-size decode runs out of memory. */
+const RESCUE_DECODE_WIDTH = 2048;
+
+export class PhotoDecodeError extends Error {
+    constructor(
+        public readonly failure: DecodeFailure,
+        message: string,
+    ) {
+        super(message);
+        this.name = 'PhotoDecodeError';
+    }
+}
+
+export interface DecodedPhoto {
+    /** Anything `drawImage` accepts. */
+    source: ImageBitmap | HTMLImageElement;
+    /** Intrinsic size of `source`, before orientation is applied. */
+    width: number;
+    height: number;
+    /** EXIF orientation still to be applied (1 when the decoder already did it). */
+    orientation: number;
+    takenAt: Date | null;
+    fileType: SniffedType;
+    fileName: string;
+    fileBytes: number;
+    /** Free the bitmap or object URL backing `source`. */
+    release: () => void;
+}
+
+const REFUSAL_MESSAGES: Record<Exclude<DecodeFailure, 'decode-failed'>, string> = {
+    empty: 'الملف فارغ أو تعذّر قراءته. جرّب اختياره مرة أخرى.',
+    'too-large-file': 'حجم الملف أكبر من ٦٠ ميجابايت. اختر صورة أصغر أو صوّرها بجودة أقل من الكاميرا.',
+    heif: 'هذه صورة بصيغة HEIC (الصيغة الافتراضية في الآيفون) ولا يستطيع المتصفح فتحها. من الآيفون: الإعدادات ← الكاميرا ← التنسيقات ← الأعلى توافقًا، ثم أعد التصوير — أو أرسل الصورة لنفسك في واتساب واحفظها ثم ارفعها هنا.',
+    pdf: 'هذا ملف PDF لا صورة. افتحه واحفظ الصورة نفسها كملف صورة، ثم ارفعها هنا.',
+    svg: 'هذا ملف رسم SVG ولا يصلح كصورة شخصية. ارفع صورة من الكاميرا.',
+    tiff: 'صيغة TIFF لا يفتحها المتصفح. احفظ الصورة بصيغة JPG أو PNG ثم ارفعها هنا.',
+    video: 'هذا ملف مقطع مرئي لا صورة. خُذ لقطة ثابتة منه وارفعها.',
+    unsupported: 'تعذّر التعرف على نوع الملف. ارفع صورة بصيغة JPG أو PNG.',
+};
+
+function refuse(failure: Exclude<DecodeFailure, 'decode-failed'>): never {
+    throw new PhotoDecodeError(failure, REFUSAL_MESSAGES[failure]);
+}
+
+async function readHead(file: File, bytes: number): Promise<Uint8Array> {
+    return new Uint8Array(await file.slice(0, Math.min(bytes, file.size)).arrayBuffer());
+}
+
+/** Decode through an `<img>` element — the path for browsers without `createImageBitmap`. */
+async function decodeViaImageElement(file: File): Promise<{ source: HTMLImageElement; release: () => void }> {
+    const url = URL.createObjectURL(file);
+    const image = new Image();
+
+    image.decoding = 'sync';
+
+    try {
+        await new Promise<void>((resolve, reject) => {
+            image.onload = () => resolve();
+            image.onerror = () => reject(new Error('image element decode failed'));
+            image.src = url;
+        });
+    } catch (error) {
+        URL.revokeObjectURL(url);
+        throw error;
+    }
+
+    return { source: image, release: () => URL.revokeObjectURL(url) };
+}
+
+/**
+ * `imageOrientation: 'none'` is what we want for files whose EXIF we parsed
+ * ourselves, but an unknown enum value throws on older engines — hence the
+ * retry without options.
+ */
+async function createBitmap(file: File, imageOrientation: 'none' | 'from-image', resizeWidth?: number): Promise<ImageBitmap> {
+    const options: ImageBitmapOptions = { imageOrientation };
+
+    if (resizeWidth !== undefined) {
+        options.resizeWidth = resizeWidth;
+        options.resizeQuality = 'high';
+    }
+
+    try {
+        return await createImageBitmap(file, options);
+    } catch (error) {
+        if (error instanceof TypeError) {
+            return await createImageBitmap(file);
+        }
+
+        throw error;
+    }
+}
+
+/**
+ * Whether this browser honours `imageOrientation: 'none'`, resolved once per
+ * page and remembered.
+ *
+ * This matters more than it sounds: if the browser silently straightens the
+ * photo while we also apply the EXIF rotation ourselves, every sideways phone
+ * photo comes out rotated twice. Rather than guess from user-agent strings, we
+ * decode a two-pixel-wide JPEG tagged as rotated and look at which way round it
+ * comes back.
+ */
+let orientationProbe: Promise<boolean> | null = null;
+
+function honoursOrientationNone(): Promise<boolean> {
+    orientationProbe ??= probeOrientationHandling();
+
+    return orientationProbe;
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+
+    for (let index = 0; index < binary.length; index += 1) {
+        bytes[index] = binary.charCodeAt(index);
+    }
+
+    return bytes;
+}
+
+async function probeOrientationHandling(): Promise<boolean> {
+    try {
+        const canvas = document.createElement('canvas');
+
+        canvas.width = 2;
+        canvas.height = 1;
+
+        const context = canvas.getContext('2d');
+
+        if (!context) {
+            return false;
+        }
+
+        context.fillStyle = '#808080';
+        context.fillRect(0, 0, 2, 1);
+
+        const dataUrl = canvas.toDataURL('image/jpeg', 0.5);
+        const probe = withExifOrientation(base64ToBytes(dataUrl.slice(dataUrl.indexOf(',') + 1)), 6);
+        const probeBlob = new Blob([probe.buffer as ArrayBuffer], { type: 'image/jpeg' });
+        const bitmap = await createImageBitmap(probeBlob, { imageOrientation: 'none' });
+        const untouched = bitmap.width === 2 && bitmap.height === 1;
+
+        bitmap.close?.();
+
+        return untouched;
+    } catch {
+        // Assume the browser straightens photos itself — the safe default,
+        // since we then ask it explicitly to do so.
+        return false;
+    }
+}
+
+/**
+ * Decode a picked file into a drawable source plus the metadata the rest of the
+ * tool needs. Throws `PhotoDecodeError` with a student-readable message.
+ */
+export async function decodePhotoFile(file: File): Promise<DecodedPhoto> {
+    if (file.size === 0) {
+        refuse('empty');
+    }
+
+    if (file.size > MAX_INPUT_BYTES) {
+        refuse('too-large-file');
+    }
+
+    const head = await readHead(file, 4096);
+    const fileType = sniffFileType(head);
+
+    if (fileType === 'pdf' || fileType === 'svg' || fileType === 'tiff' || fileType === 'video' || fileType === 'unknown') {
+        refuse(fileType === 'unknown' ? 'unsupported' : fileType);
+    }
+
+    if (!isRasterType(fileType)) {
+        refuse('unsupported');
+    }
+
+    // Only JPEG carries EXIF we can read here; for every other format the
+    // browser's own orientation handling is all there is.
+    const exif = fileType === 'jpeg' ? readExif(await readHead(file, EXIF_SCAN_BYTES)) : {};
+    const decoded = await decodeSource(file, fileType);
+
+    return describe(
+        decoded.source,
+        decoded.appliesOrientationItself ? 1 : (exif.orientation ?? 1),
+        exif.takenAt ?? null,
+        fileType,
+        file,
+        decoded.release,
+    );
+}
+
+interface DecodedSource {
+    source: ImageBitmap | HTMLImageElement;
+    release: () => void;
+    /** True when the decoder already straightened the image for us. */
+    appliesOrientationItself: boolean;
+}
+
+/**
+ * Try the decoders in order of fidelity: a full-size bitmap, a downscaled
+ * bitmap (the rescue for out-of-memory on huge photos), then an `<img>`
+ * element. HEIC exhausts all three on every browser but Safari, so it gets its
+ * own message rather than the generic one.
+ */
+async function decodeSource(file: File, fileType: SniffedType): Promise<DecodedSource> {
+    if (typeof createImageBitmap === 'function') {
+        const appliesOrientationItself = !(await honoursOrientationNone());
+        const orientationMode = appliesOrientationItself ? 'from-image' : 'none';
+
+        for (const resizeWidth of [undefined, RESCUE_DECODE_WIDTH]) {
+            try {
+                const bitmap = await createBitmap(file, orientationMode, resizeWidth);
+
+                return { source: bitmap, release: () => bitmap.close?.(), appliesOrientationItself };
+            } catch {
+                // Fall through to the next, cheaper decoder.
+            }
+        }
+    }
+
+    try {
+        const fallback = await decodeViaImageElement(file);
+
+        // An <img> element applies EXIF orientation itself.
+        return { source: fallback.source, release: fallback.release, appliesOrientationItself: true };
+    } catch {
+        if (fileType === 'heif') {
+            refuse('heif');
+        }
+
+        throw new PhotoDecodeError('decode-failed', 'تعذّر فتح هذه الصورة — قد يكون الملف تالفًا أو غير مكتمل. جرّب صورة أخرى.');
+    }
+}
+
+function describe(
+    source: ImageBitmap | HTMLImageElement,
+    orientation: number,
+    takenAt: Date | null,
+    fileType: SniffedType,
+    file: File,
+    release: () => void,
+): DecodedPhoto {
+    const width = source instanceof HTMLImageElement ? source.naturalWidth : source.width;
+    const height = source instanceof HTMLImageElement ? source.naturalHeight : source.height;
+
+    if (width === 0 || height === 0) {
+        release();
+
+        throw new PhotoDecodeError('decode-failed', 'الصورة فُتحت بأبعاد صفرية — الملف تالف على الأغلب. جرّب صورة أخرى.');
+    }
+
+    return { source, width, height, orientation, takenAt, fileType, fileName: file.name, fileBytes: file.size, release };
+}

--- a/resources/js/lib/studentPhoto/exif.test.ts
+++ b/resources/js/lib/studentPhoto/exif.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+import { parseExifDateString, readExif, withExifOrientation } from './exif';
+
+interface TiffEntry {
+    tag: number;
+    type: number;
+    value: number | string;
+}
+
+/**
+ * Build a minimal but valid EXIF-in-JPEG buffer: SOI, an APP1 segment holding a
+ * TIFF header with IFD0 (and optionally an Exif sub-IFD), then SOS.
+ */
+function buildJpegWithExif(options: { littleEndian?: boolean; ifd0?: TiffEntry[]; subIfd?: TiffEntry[]; corruptMagic?: boolean }): Uint8Array {
+    const littleEndian = options.littleEndian ?? true;
+    const ifd0 = [...(options.ifd0 ?? [])];
+    const subIfd = options.subIfd ?? [];
+
+    // Values longer than 4 bytes live in a heap after every IFD.
+    const heap: number[] = [];
+    const tiff: number[] = [];
+
+    const pushShort = (target: number[], value: number) => {
+        target.push(littleEndian ? value & 0xff : (value >> 8) & 0xff, littleEndian ? (value >> 8) & 0xff : value & 0xff);
+    };
+    const pushLong = (target: number[], value: number) => {
+        const octets = [value & 0xff, (value >> 8) & 0xff, (value >> 16) & 0xff, (value >>> 24) & 0xff];
+
+        target.push(...(littleEndian ? octets : octets.reverse()));
+    };
+
+    tiff.push(...(littleEndian ? [0x49, 0x49] : [0x4d, 0x4d]));
+    pushShort(tiff, options.corruptMagic ? 1234 : 42);
+    pushLong(tiff, 8);
+
+    const subIfdOffsetPlaceholders: number[] = [];
+
+    const writeIfd = (entries: TiffEntry[], nextIfdOffset = 0): void => {
+        pushShort(tiff, entries.length);
+
+        for (const entry of entries) {
+            pushShort(tiff, entry.tag);
+            pushShort(tiff, entry.type);
+
+            if (typeof entry.value === 'string') {
+                const ascii = [...entry.value].map((character) => character.charCodeAt(0));
+
+                ascii.push(0);
+                pushLong(tiff, ascii.length);
+
+                if (ascii.length <= 4) {
+                    tiff.push(...ascii, ...new Array(4 - ascii.length).fill(0));
+                } else {
+                    // Heap offsets are patched once the IFD block is sized.
+                    subIfdOffsetPlaceholders.push(tiff.length);
+                    pushLong(tiff, heap.length);
+                    heap.push(...ascii);
+                }
+            } else if (entry.type === 3) {
+                pushLong(tiff, 1);
+                pushShort(tiff, entry.value);
+                tiff.push(0, 0);
+            } else {
+                pushLong(tiff, 1);
+                pushLong(tiff, entry.value);
+            }
+        }
+
+        pushLong(tiff, nextIfdOffset);
+    };
+
+    if (subIfd.length > 0) {
+        // IFD0 gets an ExifIFDPointer whose target sits right after IFD0.
+        const ifd0Size = 2 + (ifd0.length + 1) * 12 + 4;
+
+        ifd0.push({ tag: 0x8769, type: 4, value: 8 + ifd0Size });
+    }
+
+    writeIfd(ifd0);
+
+    if (subIfd.length > 0) {
+        writeIfd(subIfd);
+    }
+
+    const heapStart = tiff.length;
+
+    for (const placeholder of subIfdOffsetPlaceholders) {
+        const current =
+            (littleEndian
+                ? tiff[placeholder] | (tiff[placeholder + 1] << 8) | (tiff[placeholder + 2] << 16) | (tiff[placeholder + 3] << 24)
+                : tiff[placeholder + 3] | (tiff[placeholder + 2] << 8) | (tiff[placeholder + 1] << 16) | (tiff[placeholder] << 24)) >>> 0;
+        const patched = [
+            (heapStart + current) & 0xff,
+            ((heapStart + current) >> 8) & 0xff,
+            ((heapStart + current) >> 16) & 0xff,
+            ((heapStart + current) >>> 24) & 0xff,
+        ];
+        const ordered = littleEndian ? patched : patched.reverse();
+
+        for (let index = 0; index < 4; index += 1) {
+            tiff[placeholder + index] = ordered[index];
+        }
+    }
+
+    tiff.push(...heap);
+
+    const app1Payload = [0x45, 0x78, 0x69, 0x66, 0x00, 0x00, ...tiff];
+    const segmentLength = app1Payload.length + 2;
+
+    return new Uint8Array([0xff, 0xd8, 0xff, 0xe1, (segmentLength >> 8) & 0xff, segmentLength & 0xff, ...app1Payload, 0xff, 0xda, 0x00, 0x02]);
+}
+
+describe('parseExifDateString', () => {
+    it('parses the EXIF date format', () => {
+        const date = parseExifDateString('2026:02:14 09:31:07');
+
+        expect(date?.getFullYear()).toBe(2026);
+        expect(date?.getMonth()).toBe(1);
+        expect(date?.getDate()).toBe(14);
+        expect(date?.getHours()).toBe(9);
+    });
+
+    it('accepts the ISO-ish separator some cameras write', () => {
+        expect(parseExifDateString('2026:02:14T09:31:07')).not.toBeNull();
+    });
+
+    it('rejects placeholder and impossible dates', () => {
+        expect(parseExifDateString('0000:00:00 00:00:00')).toBeNull();
+        expect(parseExifDateString('2026:02:31 09:31:07')).toBeNull();
+        expect(parseExifDateString('not a date')).toBeNull();
+        expect(parseExifDateString('')).toBeNull();
+    });
+});
+
+describe('readExif', () => {
+    it('reads orientation from a little-endian JPEG', () => {
+        const jpeg = buildJpegWithExif({ ifd0: [{ tag: 0x0112, type: 3, value: 6 }] });
+
+        expect(readExif(jpeg).orientation).toBe(6);
+    });
+
+    it('reads orientation from a big-endian JPEG', () => {
+        const jpeg = buildJpegWithExif({ littleEndian: false, ifd0: [{ tag: 0x0112, type: 3, value: 8 }] });
+
+        expect(readExif(jpeg).orientation).toBe(8);
+    });
+
+    it('reads the capture date out of the Exif sub-IFD', () => {
+        const jpeg = buildJpegWithExif({
+            ifd0: [{ tag: 0x0112, type: 3, value: 1 }],
+            subIfd: [{ tag: 0x9003, type: 2, value: '2026:02:14 09:31:07' }],
+        });
+        const exif = readExif(jpeg);
+
+        expect(exif.orientation).toBe(1);
+        expect(exif.takenAt?.getFullYear()).toBe(2026);
+        expect(exif.takenAt?.getMonth()).toBe(1);
+    });
+
+    it('falls back to the IFD0 DateTime when no original date exists', () => {
+        const jpeg = buildJpegWithExif({ ifd0: [{ tag: 0x0132, type: 2, value: '2025:12:01 12:00:00' }] });
+
+        expect(readExif(jpeg).takenAt?.getFullYear()).toBe(2025);
+    });
+
+    it('prefers DateTimeOriginal over the digitised and file dates', () => {
+        const jpeg = buildJpegWithExif({
+            ifd0: [{ tag: 0x0132, type: 2, value: '2020:01:01 12:00:00' }],
+            subIfd: [
+                { tag: 0x9003, type: 2, value: '2026:02:14 09:31:07' },
+                { tag: 0x9004, type: 2, value: '2023:05:05 09:31:07' },
+            ],
+        });
+
+        expect(readExif(jpeg).takenAt?.getFullYear()).toBe(2026);
+    });
+
+    it('ignores an out-of-range orientation value', () => {
+        const jpeg = buildJpegWithExif({ ifd0: [{ tag: 0x0112, type: 3, value: 17 }] });
+
+        expect(readExif(jpeg).orientation).toBeUndefined();
+    });
+
+    it('returns nothing for a JPEG with no EXIF segment', () => {
+        expect(readExif(new Uint8Array([0xff, 0xd8, 0xff, 0xda, 0x00, 0x02, 0x01, 0x02]))).toEqual({});
+    });
+
+    it('returns nothing for a corrupt TIFF header', () => {
+        expect(readExif(buildJpegWithExif({ corruptMagic: true, ifd0: [{ tag: 0x0112, type: 3, value: 6 }] }))).toEqual({});
+    });
+
+    it('returns nothing for non-EXIF formats and truncated buffers', () => {
+        expect(readExif(new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))).toEqual({});
+        expect(readExif(new Uint8Array([0xff, 0xd8]))).toEqual({});
+        expect(readExif(new Uint8Array())).toEqual({});
+    });
+
+    it('survives a truncated EXIF segment instead of throwing', () => {
+        const jpeg = buildJpegWithExif({ ifd0: [{ tag: 0x0112, type: 3, value: 6 }] });
+
+        expect(() => readExif(jpeg.slice(0, 14))).not.toThrow();
+    });
+
+    it('reads a bare TIFF buffer', () => {
+        const jpeg = buildJpegWithExif({ ifd0: [{ tag: 0x0112, type: 3, value: 3 }] });
+        const tiff = jpeg.slice(12, jpeg.length - 4);
+
+        expect(readExif(tiff).orientation).toBe(3);
+    });
+
+    it('accepts an ArrayBuffer as well as a view', () => {
+        const jpeg = buildJpegWithExif({ ifd0: [{ tag: 0x0112, type: 3, value: 6 }] });
+        const copy = new Uint8Array(jpeg);
+
+        expect(readExif(copy.buffer).orientation).toBe(6);
+    });
+});
+
+describe('withExifOrientation', () => {
+    /** A JPEG header/footer is enough: the reader only walks the segments. */
+    const bareJpeg = new Uint8Array([0xff, 0xd8, 0xff, 0xda, 0x00, 0x02, 0x11, 0x22]);
+
+    it('round-trips every orientation through the reader', () => {
+        for (const orientation of [1, 2, 3, 4, 5, 6, 7, 8]) {
+            expect(readExif(withExifOrientation(bareJpeg, orientation)).orientation).toBe(orientation);
+        }
+    });
+
+    it('keeps the original image data after the inserted segment', () => {
+        const tagged = withExifOrientation(bareJpeg, 6);
+
+        expect(tagged.length).toBe(bareJpeg.length + 36);
+        expect([...tagged.subarray(tagged.length - 6)]).toEqual([0xff, 0xda, 0x00, 0x02, 0x11, 0x22]);
+    });
+
+    it('leaves a non-JPEG buffer untouched', () => {
+        const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+        expect(withExifOrientation(png, 6)).toBe(png);
+        expect(withExifOrientation(new Uint8Array(), 6).length).toBe(0);
+    });
+});

--- a/resources/js/lib/studentPhoto/exif.ts
+++ b/resources/js/lib/studentPhoto/exif.ts
@@ -1,0 +1,271 @@
+/**
+ * A minimal, dependency-free EXIF reader for the two fields this tool needs:
+ * orientation (so a sideways phone photo is straightened before cropping) and
+ * the capture date (so a photo older than six months is caught before the
+ * student uploads it).
+ *
+ * Every read is bounds-checked and the whole parse is failure-tolerant: a
+ * truncated or malformed EXIF block yields an empty result rather than an
+ * error, because a photo with unreadable metadata is still a usable photo.
+ */
+
+export interface ExifData {
+    /** EXIF orientation 1–8, when present and valid. */
+    orientation?: number;
+    /** DateTimeOriginal, falling back to DateTimeDigitized then the IFD0 DateTime. */
+    takenAt?: Date;
+}
+
+const TAG_ORIENTATION = 0x0112;
+const TAG_DATE_TIME = 0x0132;
+const TAG_EXIF_IFD_POINTER = 0x8769;
+const TAG_DATE_TIME_ORIGINAL = 0x9003;
+const TAG_DATE_TIME_DIGITIZED = 0x9004;
+
+const TYPE_BYTE_SIZES: Record<number, number> = { 1: 1, 2: 1, 3: 2, 4: 4, 5: 8, 7: 1, 9: 4, 10: 8 };
+
+/** "2026:02:14 09:31:07" → a local Date; anything else → null. */
+export function parseExifDateString(value: string): Date | null {
+    const match = /^(\d{4}):(\d{2}):(\d{2})[ T](\d{2}):(\d{2}):(\d{2})/.exec(value.trim());
+
+    if (!match) {
+        return null;
+    }
+
+    const [, year, month, day, hour, minute, second] = match.map(Number) as unknown as number[];
+    const date = new Date(year, month - 1, day, hour, minute, second);
+
+    const isConsistent = date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
+
+    return isConsistent ? date : null;
+}
+
+interface IfdEntryValues {
+    orientation?: number;
+    dateTime?: string;
+    dateTimeOriginal?: string;
+    dateTimeDigitized?: string;
+    exifIfdOffset?: number;
+}
+
+function readAscii(view: DataView, offset: number, length: number): string {
+    let out = '';
+
+    for (let index = 0; index < length; index += 1) {
+        const position = offset + index;
+
+        if (position >= view.byteLength) {
+            break;
+        }
+
+        const code = view.getUint8(position);
+
+        if (code === 0) {
+            break;
+        }
+
+        out += String.fromCharCode(code);
+    }
+
+    return out;
+}
+
+function readIfd(view: DataView, tiffStart: number, ifdOffset: number, littleEndian: boolean, into: IfdEntryValues): void {
+    const entriesStart = tiffStart + ifdOffset;
+
+    if (entriesStart + 2 > view.byteLength) {
+        return;
+    }
+
+    const entryCount = view.getUint16(entriesStart, littleEndian);
+
+    for (let index = 0; index < entryCount; index += 1) {
+        const entry = entriesStart + 2 + index * 12;
+
+        if (entry + 12 > view.byteLength) {
+            return;
+        }
+
+        const tag = view.getUint16(entry, littleEndian);
+        const type = view.getUint16(entry + 2, littleEndian);
+        const count = view.getUint32(entry + 4, littleEndian);
+        const componentSize = TYPE_BYTE_SIZES[type] ?? 0;
+
+        if (componentSize === 0 || count > 0xffff) {
+            continue;
+        }
+
+        const totalSize = componentSize * count;
+        const valueOffset = totalSize <= 4 ? entry + 8 : tiffStart + view.getUint32(entry + 8, littleEndian);
+
+        if (valueOffset < 0 || valueOffset >= view.byteLength) {
+            continue;
+        }
+
+        switch (tag) {
+            case TAG_ORIENTATION:
+                if (type === 3) {
+                    into.orientation = view.getUint16(valueOffset, littleEndian);
+                }
+                break;
+            case TAG_DATE_TIME:
+                into.dateTime = readAscii(view, valueOffset, totalSize);
+                break;
+            case TAG_DATE_TIME_ORIGINAL:
+                into.dateTimeOriginal = readAscii(view, valueOffset, totalSize);
+                break;
+            case TAG_DATE_TIME_DIGITIZED:
+                into.dateTimeDigitized = readAscii(view, valueOffset, totalSize);
+                break;
+            case TAG_EXIF_IFD_POINTER:
+                if (type === 4) {
+                    into.exifIfdOffset = view.getUint32(valueOffset, littleEndian);
+                }
+                break;
+        }
+    }
+}
+
+function readTiff(view: DataView, tiffStart: number): ExifData {
+    if (tiffStart + 8 > view.byteLength) {
+        return {};
+    }
+
+    const byteOrder = view.getUint16(tiffStart, false);
+
+    if (byteOrder !== 0x4949 && byteOrder !== 0x4d4d) {
+        return {};
+    }
+
+    const littleEndian = byteOrder === 0x4949;
+
+    if (view.getUint16(tiffStart + 2, littleEndian) !== 42) {
+        return {};
+    }
+
+    const values: IfdEntryValues = {};
+
+    readIfd(view, tiffStart, view.getUint32(tiffStart + 4, littleEndian), littleEndian, values);
+
+    if (values.exifIfdOffset !== undefined) {
+        readIfd(view, tiffStart, values.exifIfdOffset, littleEndian, values);
+    }
+
+    const result: ExifData = {};
+
+    if (values.orientation !== undefined && values.orientation >= 1 && values.orientation <= 8) {
+        result.orientation = values.orientation;
+    }
+
+    const rawDate = values.dateTimeOriginal || values.dateTimeDigitized || values.dateTime;
+    const parsed = rawDate ? parseExifDateString(rawDate) : null;
+
+    if (parsed) {
+        result.takenAt = parsed;
+    }
+
+    return result;
+}
+
+/** Locate the EXIF TIFF header inside a JPEG's APP1 segment, if there is one. */
+function findJpegExifStart(view: DataView): number | null {
+    let offset = 2;
+
+    while (offset + 4 <= view.byteLength) {
+        if (view.getUint8(offset) !== 0xff) {
+            return null;
+        }
+
+        const marker = view.getUint8(offset + 1);
+
+        // Standalone markers carry no length payload.
+        if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd9)) {
+            offset += 2;
+            continue;
+        }
+
+        // Start of scan: image data begins, no metadata past this point.
+        if (marker === 0xda) {
+            return null;
+        }
+
+        const segmentLength = view.getUint16(offset + 2, false);
+
+        if (segmentLength < 2) {
+            return null;
+        }
+
+        if (marker === 0xe1 && readAscii(view, offset + 4, 4) === 'Exif') {
+            return offset + 10;
+        }
+
+        offset += 2 + segmentLength;
+    }
+
+    return null;
+}
+
+/**
+ * Read orientation and capture date from a JPEG (APP1) or raw TIFF buffer.
+ * Formats without EXIF (PNG, WebP, BMP…) simply return an empty object.
+ */
+export function readExif(buffer: ArrayBuffer | Uint8Array): ExifData {
+    try {
+        const view = buffer instanceof Uint8Array ? new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength) : new DataView(buffer);
+
+        if (view.byteLength < 8) {
+            return {};
+        }
+
+        const leadingBytes = view.getUint16(0, false);
+
+        if (leadingBytes === 0xffd8) {
+            const exifStart = findJpegExifStart(view);
+
+            return exifStart === null ? {} : readTiff(view, exifStart);
+        }
+
+        if (leadingBytes === 0x4949 || leadingBytes === 0x4d4d) {
+            return readTiff(view, 0);
+        }
+
+        return {};
+    } catch {
+        return {};
+    }
+}
+
+/**
+ * A minimal EXIF block declaring nothing but an orientation: little-endian
+ * TIFF header, one IFD entry, no sub-IFD. Byte 28 holds the orientation value.
+ */
+const MINIMAL_EXIF_SEGMENT: number[] = [
+    0xff, 0xe1, 0x00, 0x22, 0x45, 0x78, 0x69, 0x66, 0x00, 0x00, 0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x12,
+    0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+];
+
+const ORIENTATION_VALUE_OFFSET = 28;
+
+/**
+ * Return a copy of a JPEG with an EXIF orientation tag spliced in after the SOI
+ * marker. Used to build the probe image that tells us whether this browser
+ * honours `imageOrientation: 'none'`; a buffer that is not a JPEG comes back
+ * untouched.
+ */
+export function withExifOrientation(jpeg: Uint8Array, orientation: number): Uint8Array {
+    if (jpeg.length < 2 || jpeg[0] !== 0xff || jpeg[1] !== 0xd8) {
+        return jpeg;
+    }
+
+    const segment = [...MINIMAL_EXIF_SEGMENT];
+
+    segment[ORIENTATION_VALUE_OFFSET] = orientation & 0xff;
+
+    const out = new Uint8Array(jpeg.length + segment.length);
+
+    out.set(jpeg.subarray(0, 2), 0);
+    out.set(segment, 2);
+    out.set(jpeg.subarray(2), 2 + segment.length);
+
+    return out;
+}

--- a/resources/js/lib/studentPhoto/geometry.test.ts
+++ b/resources/js/lib/studentPhoto/geometry.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+import {
+    clampView,
+    cropFromView,
+    defaultView,
+    isTransposedOrientation,
+    maxCropWidth,
+    maxZoom,
+    MIN_CROP_WIDTH,
+    orientationForQuarterTurns,
+    orientationTransform,
+    orientedSize,
+    panView,
+    rotateView,
+    upscaleFactor,
+    zoomView,
+    type Size,
+} from './geometry';
+
+const landscape: Size = { width: 4000, height: 3000 };
+const portrait: Size = { width: 3000, height: 4000 };
+
+/** Apply a transform the way canvas would, to assert corner mapping. */
+function mapPoint(transform: ReturnType<typeof orientationTransform>, x: number, y: number): [number, number] {
+    return [transform.a * x + transform.c * y + transform.e, transform.b * x + transform.d * y + transform.f];
+}
+
+describe('orientation', () => {
+    it('knows which orientations swap the axes', () => {
+        expect([1, 2, 3, 4].map(isTransposedOrientation)).toEqual([false, false, false, false]);
+        expect([5, 6, 7, 8].map(isTransposedOrientation)).toEqual([true, true, true, true]);
+    });
+
+    it('swaps the size only for transposed orientations', () => {
+        expect(orientedSize(landscape, 1)).toEqual(landscape);
+        expect(orientedSize(landscape, 3)).toEqual(landscape);
+        expect(orientedSize(landscape, 6)).toEqual({ width: 3000, height: 4000 });
+        expect(orientedSize(landscape, 8)).toEqual({ width: 3000, height: 4000 });
+    });
+
+    it('maps the source top-left corner where each orientation demands', () => {
+        const size: Size = { width: 100, height: 50 };
+
+        expect(mapPoint(orientationTransform(1, size), 0, 0)).toEqual([0, 0]);
+        expect(mapPoint(orientationTransform(2, size), 0, 0)).toEqual([100, 0]);
+        expect(mapPoint(orientationTransform(3, size), 0, 0)).toEqual([100, 50]);
+        expect(mapPoint(orientationTransform(4, size), 0, 0)).toEqual([0, 50]);
+        expect(mapPoint(orientationTransform(5, size), 0, 0)).toEqual([0, 0]);
+        expect(mapPoint(orientationTransform(6, size), 0, 0)).toEqual([50, 0]);
+        expect(mapPoint(orientationTransform(7, size), 0, 0)).toEqual([50, 100]);
+        expect(mapPoint(orientationTransform(8, size), 0, 0)).toEqual([0, 100]);
+    });
+
+    it('keeps every corner inside the oriented canvas for all eight orientations', () => {
+        const size: Size = { width: 100, height: 50 };
+
+        for (const orientation of [1, 2, 3, 4, 5, 6, 7, 8]) {
+            const transform = orientationTransform(orientation, size);
+            const canvas = orientedSize(size, orientation);
+
+            for (const [x, y] of [
+                [0, 0],
+                [size.width, 0],
+                [0, size.height],
+                [size.width, size.height],
+            ]) {
+                const [mappedX, mappedY] = mapPoint(transform, x, y);
+
+                expect(mappedX).toBeGreaterThanOrEqual(0);
+                expect(mappedY).toBeGreaterThanOrEqual(0);
+                expect(mappedX).toBeLessThanOrEqual(canvas.width);
+                expect(mappedY).toBeLessThanOrEqual(canvas.height);
+            }
+        }
+    });
+
+    it('falls back to identity for a nonsense orientation value', () => {
+        expect(orientationTransform(99, landscape)).toEqual({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 });
+    });
+
+    it('expresses user quarter turns as orientation codes', () => {
+        expect([0, 1, 2, 3].map(orientationForQuarterTurns)).toEqual([1, 6, 3, 8]);
+        expect(orientationForQuarterTurns(4)).toBe(1);
+        expect(orientationForQuarterTurns(-1)).toBe(8);
+    });
+});
+
+describe('crop sizing', () => {
+    it('limits the crop by width on a portrait and by height on a landscape', () => {
+        expect(maxCropWidth(landscape)).toBe(2250);
+        expect(maxCropWidth(portrait)).toBe(3000);
+    });
+
+    it('never returns a negative crop width', () => {
+        expect(maxCropWidth({ width: 0, height: 0 })).toBe(0);
+    });
+
+    it('caps zoom where the crop would shrink past the minimum', () => {
+        expect(maxZoom(portrait)).toBeCloseTo(3000 / MIN_CROP_WIDTH);
+        expect(maxZoom({ width: 30, height: 40 })).toBe(1);
+    });
+});
+
+describe('views', () => {
+    it('opens fully zoomed out and biased above centre', () => {
+        const view = defaultView(landscape);
+
+        expect(view.zoom).toBe(1);
+        expect(view.centerX).toBe(2000);
+        expect(view.centerY).toBe(1500);
+    });
+
+    it('biases the frame upward when the image is taller than the card shape', () => {
+        const tall: Size = { width: 3000, height: 6000 };
+        const view = defaultView(tall);
+
+        expect(view.centerY).toBe(6000 * 0.45);
+        expect(cropFromView(view, tall).y).toBeGreaterThanOrEqual(0);
+    });
+
+    it('centres instead of biasing when the image is exactly the card shape', () => {
+        expect(defaultView(portrait).centerY).toBe(2000);
+    });
+
+    it('clamps zoom into range', () => {
+        expect(clampView({ zoom: 0.2, centerX: 0, centerY: 0 }, portrait).zoom).toBe(1);
+        expect(clampView({ zoom: 9999, centerX: 0, centerY: 0 }, portrait).zoom).toBeCloseTo(maxZoom(portrait));
+    });
+
+    it('pulls the crop back inside the image on both axes', () => {
+        const view = clampView({ zoom: 1, centerX: -500, centerY: 99999 }, landscape);
+        const crop = cropFromView(view, landscape);
+
+        expect(crop.x).toBeCloseTo(0);
+        expect(crop.y + crop.height).toBeCloseTo(landscape.height);
+    });
+
+    it('produces a 3:4 crop at every zoom level', () => {
+        for (const zoom of [1, 1.5, 3, 12]) {
+            const crop = cropFromView({ zoom, centerX: 1500, centerY: 2000 }, portrait);
+
+            expect(crop.width / crop.height).toBeCloseTo(0.75);
+        }
+    });
+
+    it('survives a degenerate image size without producing NaN', () => {
+        const crop = cropFromView({ zoom: 2, centerX: 10, centerY: 10 }, { width: 0, height: 0 });
+
+        expect(crop).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+    });
+
+    it('pans against the drag direction in image pixels', () => {
+        const start = { zoom: 2, centerX: 1500, centerY: 2000 };
+        const panned = panView(start, 100, 50, 0.5, portrait);
+
+        expect(panned.centerX).toBe(1500 - 200);
+        expect(panned.centerY).toBe(2000 - 100);
+    });
+
+    it('ignores a pan with a nonsense scale', () => {
+        const start = { zoom: 2, centerX: 1500, centerY: 2000 };
+
+        expect(panView(start, 100, 50, 0, portrait)).toEqual(clampView(start, portrait));
+    });
+
+    it('zooms multiplicatively within the legal range', () => {
+        const zoomed = zoomView({ zoom: 2, centerX: 1500, centerY: 2000 }, 1.5, portrait);
+
+        expect(zoomed.zoom).toBe(3);
+        expect(zoomView(zoomed, 0.01, portrait).zoom).toBe(1);
+    });
+
+    it('carries the framing through a quarter turn instead of resetting it', () => {
+        const view = { zoom: 2, centerX: 1200, centerY: 1000 };
+        const rotated = rotateView(view, portrait, 1);
+
+        expect(rotated.zoom).toBe(2);
+        expect(rotated.centerX).toBe(4000 - 1000);
+        expect(rotated.centerY).toBe(1200);
+    });
+
+    it('clamps a rotated frame that would fall outside the new bounds', () => {
+        const rotated = rotateView({ zoom: 2, centerX: 600, centerY: 1000 }, portrait, 1);
+        const crop = cropFromView(rotated, { width: 4000, height: 3000 });
+
+        expect(crop.y).toBeGreaterThanOrEqual(0);
+        expect(crop.y + crop.height).toBeLessThanOrEqual(3000);
+    });
+
+    it('returns to the original framing after four quarter turns', () => {
+        const view = clampView({ zoom: 2, centerX: 600, centerY: 1000 }, portrait);
+        const rotated = rotateView(view, portrait, 4);
+
+        expect(rotated.centerX).toBeCloseTo(view.centerX);
+        expect(rotated.centerY).toBeCloseTo(view.centerY);
+    });
+});
+
+describe('upscaleFactor', () => {
+    it('is at most 1 when the crop is larger than the output', () => {
+        expect(upscaleFactor(1200, 360)).toBeCloseTo(0.3);
+    });
+
+    it('exceeds 1 when detail has to be invented', () => {
+        expect(upscaleFactor(180, 360)).toBe(2);
+    });
+
+    it('is infinite for an empty crop', () => {
+        expect(upscaleFactor(0, 360)).toBe(Number.POSITIVE_INFINITY);
+    });
+});

--- a/resources/js/lib/studentPhoto/geometry.ts
+++ b/resources/js/lib/studentPhoto/geometry.ts
@@ -1,0 +1,192 @@
+/**
+ * Crop geometry for the 3:4 card photo. Everything here is pure math on plain
+ * numbers so the interactive cropper stays a thin layer over tested behaviour:
+ * the component owns gestures, this file owns what a gesture is allowed to do.
+ */
+
+import { ASPECT_RATIO } from './requirements';
+
+export interface Size {
+    width: number;
+    height: number;
+}
+
+export interface CropRect {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+/**
+ * The cropper's state. `zoom` is relative to the largest 3:4 rectangle that
+ * fits the image (zoom 1 = as much of the photo as the shape allows), and the
+ * centre is expressed in image pixels so it survives viewport resizes.
+ */
+export interface CropView {
+    zoom: number;
+    centerX: number;
+    centerY: number;
+}
+
+/** Never let the user zoom into a region smaller than this, in source pixels. */
+export const MIN_CROP_WIDTH = 48;
+
+/** Faces sit above the middle of a portrait, so the default frame starts high. */
+export const DEFAULT_VERTICAL_BIAS = 0.45;
+
+/** A 2D affine transform in canvas `setTransform(a, b, c, d, e, f)` order. */
+export interface AffineTransform {
+    a: number;
+    b: number;
+    c: number;
+    d: number;
+    e: number;
+    f: number;
+}
+
+/** EXIF orientations 5–8 exchange the axes. */
+export function isTransposedOrientation(orientation: number): boolean {
+    return orientation >= 5 && orientation <= 8;
+}
+
+/** The size an image occupies once its EXIF orientation has been applied. */
+export function orientedSize(size: Size, orientation: number): Size {
+    return isTransposedOrientation(orientation) ? { width: size.height, height: size.width } : { width: size.width, height: size.height };
+}
+
+/**
+ * The transform that draws a `size` image into a canvas of `orientedSize`, so
+ * the result is upright regardless of how the camera was held.
+ */
+export function orientationTransform(orientation: number, size: Size): AffineTransform {
+    const { width, height } = size;
+
+    switch (orientation) {
+        case 2:
+            return { a: -1, b: 0, c: 0, d: 1, e: width, f: 0 };
+        case 3:
+            return { a: -1, b: 0, c: 0, d: -1, e: width, f: height };
+        case 4:
+            return { a: 1, b: 0, c: 0, d: -1, e: 0, f: height };
+        case 5:
+            return { a: 0, b: 1, c: 1, d: 0, e: 0, f: 0 };
+        case 6:
+            return { a: 0, b: 1, c: -1, d: 0, e: height, f: 0 };
+        case 7:
+            return { a: 0, b: -1, c: -1, d: 0, e: height, f: width };
+        case 8:
+            return { a: 0, b: -1, c: 1, d: 0, e: 0, f: width };
+        default:
+            return { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 };
+    }
+}
+
+/** Quarter turns clockwise expressed as the equivalent EXIF orientation code. */
+export function orientationForQuarterTurns(quarters: number): number {
+    return [1, 6, 3, 8][((quarters % 4) + 4) % 4];
+}
+
+/** Widest 3:4 crop the image can contain — limited by width or by height. */
+export function maxCropWidth(size: Size, ratio: number = ASPECT_RATIO): number {
+    return Math.max(0, Math.min(size.width, size.height * ratio));
+}
+
+/** How far the user may zoom in before the crop region gets uselessly small. */
+export function maxZoom(size: Size, ratio: number = ASPECT_RATIO): number {
+    const widest = maxCropWidth(size, ratio);
+
+    if (widest <= MIN_CROP_WIDTH) {
+        return 1;
+    }
+
+    return widest / MIN_CROP_WIDTH;
+}
+
+/** The opening frame: fully zoomed out, centred horizontally, biased upward. */
+export function defaultView(size: Size, ratio: number = ASPECT_RATIO): CropView {
+    return clampView({ zoom: 1, centerX: size.width / 2, centerY: size.height * DEFAULT_VERTICAL_BIAS }, size, ratio);
+}
+
+/**
+ * Force a view back into legality: zoom within range, and the crop rectangle
+ * fully inside the image. Degenerate sizes collapse to a zero-area view rather
+ * than producing NaN downstream.
+ */
+export function clampView(view: CropView, size: Size, ratio: number = ASPECT_RATIO): CropView {
+    const widest = maxCropWidth(size, ratio);
+
+    if (widest <= 0) {
+        return { zoom: 1, centerX: 0, centerY: 0 };
+    }
+
+    const zoom = Math.min(Math.max(view.zoom, 1), maxZoom(size, ratio));
+    const cropWidth = widest / zoom;
+    const cropHeight = cropWidth / ratio;
+    const halfWidth = cropWidth / 2;
+    const halfHeight = cropHeight / 2;
+
+    return {
+        zoom,
+        centerX: Math.min(Math.max(view.centerX, halfWidth), size.width - halfWidth),
+        centerY: Math.min(Math.max(view.centerY, halfHeight), size.height - halfHeight),
+    };
+}
+
+/** The crop rectangle, in image pixels, described by a view. */
+export function cropFromView(view: CropView, size: Size, ratio: number = ASPECT_RATIO): CropRect {
+    const clamped = clampView(view, size, ratio);
+    const widest = maxCropWidth(size, ratio);
+    const cropWidth = widest === 0 ? 0 : widest / clamped.zoom;
+    const cropHeight = ratio === 0 ? 0 : cropWidth / ratio;
+
+    return {
+        x: clamped.centerX - cropWidth / 2,
+        y: clamped.centerY - cropHeight / 2,
+        width: cropWidth,
+        height: cropHeight,
+    };
+}
+
+/**
+ * How much the crop must be stretched to fill the output. Above 1 means real
+ * detail is being invented, which is what the clarity warning keys off.
+ */
+export function upscaleFactor(cropWidth: number, outputWidth: number): number {
+    return cropWidth <= 0 ? Number.POSITIVE_INFINITY : outputWidth / cropWidth;
+}
+
+/** Pan by a screen-space delta, given how many screen pixels one image pixel spans. */
+export function panView(view: CropView, deltaX: number, deltaY: number, scale: number, size: Size, ratio: number = ASPECT_RATIO): CropView {
+    if (scale <= 0) {
+        return clampView(view, size, ratio);
+    }
+
+    return clampView({ zoom: view.zoom, centerX: view.centerX - deltaX / scale, centerY: view.centerY - deltaY / scale }, size, ratio);
+}
+
+/** Multiply the zoom, keeping the frame legal. */
+export function zoomView(view: CropView, factor: number, size: Size, ratio: number = ASPECT_RATIO): CropView {
+    return clampView({ ...view, zoom: view.zoom * factor }, size, ratio);
+}
+
+/**
+ * Re-anchor a view after quarter-turning the image, so rotating does not throw
+ * away the framing the student already chose.
+ */
+export function rotateView(view: CropView, size: Size, quarters: number, ratio: number = ASPECT_RATIO): CropView {
+    const turns = ((quarters % 4) + 4) % 4;
+    let current = { ...view };
+    let currentSize = { ...size };
+
+    for (let turn = 0; turn < turns; turn += 1) {
+        current = {
+            zoom: current.zoom,
+            centerX: currentSize.height - current.centerY,
+            centerY: current.centerX,
+        };
+        currentSize = { width: currentSize.height, height: currentSize.width };
+    }
+
+    return clampView(current, currentSize, ratio);
+}

--- a/resources/js/lib/studentPhoto/render.ts
+++ b/resources/js/lib/studentPhoto/render.ts
@@ -1,0 +1,228 @@
+/**
+ * Canvas work: straighten the decoded photo once, then crop-and-encode from
+ * that upright copy on every adjustment.
+ *
+ * Nothing here edits the photo's content — no retouching, no background
+ * replacement, no filters — because the university rejects composited or
+ * electronically altered photos. The only operations are the mechanical ones:
+ * rotate, crop, resize, and JPEG encoding.
+ */
+
+import { ANALYSIS_SAMPLE_WIDTH, measurePhoto, type PhotoMetrics } from './analysis';
+import type { DecodedPhoto } from './decode';
+import { orientationForQuarterTurns, orientationTransform, orientedSize, type CropRect, type Size } from './geometry';
+import { ASPECT_RATIO, MAX_OUTPUT_BYTES, OUTPUT_MIME } from './requirements';
+
+/**
+ * The upright copy is capped at this on its longest side. The output is at most
+ * 480 px tall, so this costs no visible quality and keeps an 8000 px phone
+ * photo from making every pan and zoom sluggish.
+ */
+export const MAX_WORKING_SIDE = 2400;
+
+const QUALITY_CEILING = 0.95;
+const QUALITY_FLOOR = 0.2;
+const QUALITY_PROBES = 8;
+
+export interface WorkingImage {
+    canvas: HTMLCanvasElement;
+    width: number;
+    height: number;
+}
+
+export interface RenderedPhoto {
+    blob: Blob;
+    width: number;
+    height: number;
+    bytes: number;
+    /** The JPEG quality that fit under the size ceiling, for the diagnostics line. */
+    quality: number;
+}
+
+function createCanvas(width: number, height: number): HTMLCanvasElement {
+    const canvas = document.createElement('canvas');
+
+    canvas.width = Math.max(1, Math.round(width));
+    canvas.height = Math.max(1, Math.round(height));
+
+    return canvas;
+}
+
+function context2d(canvas: HTMLCanvasElement): CanvasRenderingContext2D {
+    const context = canvas.getContext('2d', { alpha: false });
+
+    if (!context) {
+        throw new Error('canvas 2d context unavailable');
+    }
+
+    context.imageSmoothingEnabled = true;
+    context.imageSmoothingQuality = 'high';
+
+    return context;
+}
+
+/**
+ * Draw the decoded photo upright — EXIF orientation and the student's quarter
+ * turns applied, downscaled to the working cap — so all later cropping is a
+ * plain sub-rectangle of a normal top-left-origin image.
+ */
+export function buildWorkingImage(decoded: DecodedPhoto, quarterTurns = 0): WorkingImage {
+    const intrinsic: Size = { width: decoded.width, height: decoded.height };
+    const upright = orientedSize(intrinsic, decoded.orientation);
+    const scale = Math.min(1, MAX_WORKING_SIDE / Math.max(upright.width, upright.height));
+
+    const straightened = createCanvas(upright.width * scale, upright.height * scale);
+    const context = context2d(straightened);
+    const transform = orientationTransform(decoded.orientation, intrinsic);
+
+    context.setTransform(
+        transform.a * scale,
+        transform.b * scale,
+        transform.c * scale,
+        transform.d * scale,
+        transform.e * scale,
+        transform.f * scale,
+    );
+    context.drawImage(decoded.source, 0, 0);
+    context.setTransform(1, 0, 0, 1, 0, 0);
+
+    const turns = ((quarterTurns % 4) + 4) % 4;
+
+    if (turns === 0) {
+        return { canvas: straightened, width: straightened.width, height: straightened.height };
+    }
+
+    // Quarter turns are axis-aligned, so this second pass resamples nothing.
+    const code = orientationForQuarterTurns(turns);
+    const source: Size = { width: straightened.width, height: straightened.height };
+    const rotatedSize = orientedSize(source, code);
+    const rotated = createCanvas(rotatedSize.width, rotatedSize.height);
+    const rotatedContext = context2d(rotated);
+    const rotation = orientationTransform(code, source);
+
+    rotatedContext.setTransform(rotation.a, rotation.b, rotation.c, rotation.d, rotation.e, rotation.f);
+    rotatedContext.drawImage(straightened, 0, 0);
+    rotatedContext.setTransform(1, 0, 0, 1, 0, 0);
+
+    return { canvas: rotated, width: rotated.width, height: rotated.height };
+}
+
+/** Keep a crop rectangle inside the working image, whatever the caller believed. */
+function clampCropToImage(working: WorkingImage, crop: CropRect): CropRect {
+    const width = Math.min(Math.max(crop.width, 1), working.width);
+    const height = Math.min(Math.max(crop.height, 1), working.height);
+
+    return {
+        x: Math.min(Math.max(crop.x, 0), working.width - width),
+        y: Math.min(Math.max(crop.y, 0), working.height - height),
+        width,
+        height,
+    };
+}
+
+/**
+ * Measure the cropped region at a fixed sample size, so the sharpness and
+ * colour thresholds mean the same thing for every source resolution. Returns
+ * null when the browser refuses to read the pixels back.
+ */
+export function measureCrop(working: WorkingImage, crop: CropRect): PhotoMetrics | null {
+    const region = clampCropToImage(working, crop);
+
+    try {
+        const sample = createCanvas(ANALYSIS_SAMPLE_WIDTH, ANALYSIS_SAMPLE_WIDTH / ASPECT_RATIO);
+        const context = context2d(sample);
+
+        context.drawImage(working.canvas, region.x, region.y, region.width, region.height, 0, 0, sample.width, sample.height);
+
+        const { data, width, height } = context.getImageData(0, 0, sample.width, sample.height);
+
+        return measurePhoto({ data, width, height });
+    } catch {
+        return null;
+    }
+}
+
+function dataUrlToBlob(dataUrl: string): Blob {
+    const payload = dataUrl.slice(dataUrl.indexOf(',') + 1);
+    const binary = atob(payload);
+    const bytes = new Uint8Array(binary.length);
+
+    for (let index = 0; index < binary.length; index += 1) {
+        bytes[index] = binary.charCodeAt(index);
+    }
+
+    return new Blob([bytes], { type: OUTPUT_MIME });
+}
+
+/** Encode a canvas as JPEG, falling back to a data URL where `toBlob` fails. */
+async function encodeJpeg(canvas: HTMLCanvasElement, quality: number): Promise<Blob> {
+    if (typeof canvas.toBlob === 'function') {
+        const blob = await new Promise<Blob | null>((resolve) => {
+            canvas.toBlob(resolve, OUTPUT_MIME, quality);
+        });
+
+        if (blob) {
+            return blob;
+        }
+    }
+
+    return dataUrlToBlob(canvas.toDataURL(OUTPUT_MIME, quality));
+}
+
+/**
+ * Highest JPEG quality that still fits under the byte ceiling. At the sizes the
+ * university allows, the ceiling almost never binds — but a busy, noisy photo
+ * at 360 × 480 can reach it, and silently shipping an oversized file would be
+ * worse than a slightly softer one.
+ */
+async function encodeUnderLimit(canvas: HTMLCanvasElement, maxBytes: number): Promise<{ blob: Blob; quality: number }> {
+    const best = await encodeJpeg(canvas, QUALITY_CEILING);
+
+    if (best.size <= maxBytes) {
+        return { blob: best, quality: QUALITY_CEILING };
+    }
+
+    let low = QUALITY_FLOOR;
+    let high = QUALITY_CEILING;
+    let fitting: { blob: Blob; quality: number } | null = null;
+
+    for (let probe = 0; probe < QUALITY_PROBES; probe += 1) {
+        const quality = (low + high) / 2;
+        const candidate = await encodeJpeg(canvas, quality);
+
+        if (candidate.size <= maxBytes) {
+            fitting = { blob: candidate, quality };
+            low = quality;
+        } else {
+            high = quality;
+        }
+    }
+
+    // Nothing fit: hand back the smallest attempt so the size check can fail
+    // out loud and point the student at a smaller output size.
+    return fitting ?? { blob: await encodeJpeg(canvas, QUALITY_FLOOR), quality: QUALITY_FLOOR };
+}
+
+/**
+ * Render the chosen crop at the chosen output size as a JPEG under the byte
+ * ceiling. The canvas is painted white first: JPEG has no alpha, and an
+ * unflattened transparent PNG would otherwise come out with a black background.
+ */
+export async function renderCroppedJpeg(
+    working: WorkingImage,
+    crop: CropRect,
+    target: Size,
+    maxBytes: number = MAX_OUTPUT_BYTES,
+): Promise<RenderedPhoto> {
+    const region = clampCropToImage(working, crop);
+    const canvas = createCanvas(target.width, target.height);
+    const context = context2d(canvas);
+
+    context.fillStyle = '#ffffff';
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.drawImage(working.canvas, region.x, region.y, region.width, region.height, 0, 0, canvas.width, canvas.height);
+
+    const { blob, quality } = await encodeUnderLimit(canvas, maxBytes);
+
+    return { blob, width: canvas.width, height: canvas.height, bytes: blob.size, quality };
+}

--- a/resources/js/lib/studentPhoto/requirements.ts
+++ b/resources/js/lib/studentPhoto/requirements.ts
@@ -1,0 +1,140 @@
+/**
+ * The single source of truth for Umm Al-Qura's university-card photo rules.
+ *
+ * Transcribed from the university's own instruction sheet (الخدمات الإلكترونية →
+ * خدمات أكاديمية → البوابة الأكاديمية → شخصي → رفع الصورة الشخصية للبطاقة الجامعية).
+ * Every check, preset and piece of copy in the tool derives from this file — the
+ * numbers are never repeated anywhere else.
+ */
+
+/** Photo shape: 3 cm wide × 4 cm tall, i.e. height must exceed width. */
+export const ASPECT_WIDTH = 3;
+export const ASPECT_HEIGHT = 4;
+export const ASPECT_RATIO = ASPECT_WIDTH / ASPECT_HEIGHT;
+
+/** Accepted pixel envelope: width 120→360 px, height 160→480 px, kept proportional. */
+export const MIN_OUTPUT_WIDTH = 120;
+export const MAX_OUTPUT_WIDTH = 360;
+export const MIN_OUTPUT_HEIGHT = 160;
+export const MAX_OUTPUT_HEIGHT = 480;
+
+/**
+ * "300 KB" is ambiguous between 300,000 and 307,200 bytes, and the portal's own
+ * validator is a black box. We target the stricter decimal reading so a file
+ * that passes here passes either implementation.
+ */
+export const MAX_OUTPUT_BYTES = 300_000;
+
+/** The portal accepts JPG only. */
+export const OUTPUT_MIME = 'image/jpeg';
+export const OUTPUT_EXTENSION = 'jpg';
+export const OUTPUT_FILE_NAME = `student-card-photo.${OUTPUT_EXTENSION}`;
+
+/** A photo older than six months is rejected. */
+export const MAX_PHOTO_AGE_MONTHS = 6;
+
+export interface OutputSizePreset {
+    width: number;
+    height: number;
+    label: string;
+    hint: string;
+}
+
+/**
+ * Every preset is exactly 3:4 and sits inside the accepted envelope. The first
+ * one is the university's own worked example (العرض 360 / الطول 480) and the
+ * default: the largest allowed size, so quality is the best the rules permit.
+ */
+export const OUTPUT_SIZE_PRESETS: OutputSizePreset[] = [
+    { width: 360, height: 480, label: '360 × 480', hint: 'الحد الأعلى المسموح — الأوضح، وهو المقاس الذي توصي به الجامعة' },
+    { width: 300, height: 400, label: '300 × 400', hint: 'مقاس متوسط بحجم ملف أصغر' },
+    { width: 240, height: 320, label: '240 × 320', hint: 'مناسب إذا كانت صورتك الأصلية صغيرة' },
+    { width: 120, height: 160, label: '120 × 160', hint: 'الحد الأدنى المسموح — لا تستخدمه إلا للضرورة' },
+];
+
+export const DEFAULT_OUTPUT_SIZE = OUTPUT_SIZE_PRESETS[0];
+
+/**
+ * Rules no software can verify from pixels alone: the student confirms them.
+ * Each one is worded as a statement the student either can or cannot tick.
+ */
+export interface ManualRequirement {
+    id: string;
+    label: string;
+    detail: string;
+}
+
+export const MANUAL_REQUIREMENTS: ManualRequirement[] = [
+    {
+        id: 'recent',
+        label: 'الصورة حديثة ولم يمضِ على تصويرها أكثر من ٦ أشهر',
+        detail: 'صورة قديمة سبب شائع جدًا لرفض الطلب.',
+    },
+    {
+        id: 'attire',
+        label: 'الصورة بالزي الرسمي',
+        detail: 'لا ملابس رياضية أو منزلية.',
+    },
+    {
+        id: 'face',
+        label: 'الوجه ظاهر كاملًا ومقابل للكاميرا بشكل مباشر',
+        detail: 'بلا ميل للرأس، ولا شيء يغطي ملامح الوجه.',
+    },
+    {
+        id: 'no-sunglasses',
+        label: 'لا توجد نظارة شمسية في الصورة',
+        detail: 'النظارة الطبية الشفافة مقبولة، والشمسية مرفوضة.',
+    },
+    {
+        id: 'not-paper',
+        label: 'الصورة ليست ملصقة على ورق ولا صورة مأخوذة لورقة أو بطاقة',
+        detail: 'صوّر نفسك بالكاميرا، أو احفظ الملف الأصلي من الاستوديو.',
+    },
+    {
+        id: 'unedited',
+        label: 'الصورة أصلية غير مركَّبة ولا معدَّلة إلكترونيًا',
+        detail: 'الفلاتر وتغيير الملامح وتركيب الخلفية كلها أسباب رفض.',
+    },
+];
+
+/** Who is responsible for a rule: the tool fixes it, verifies it, or cannot know. */
+export type RuleResponsibility = 'fixed' | 'verified' | 'student';
+
+export interface RuleSummary {
+    text: string;
+    responsibility: RuleResponsibility;
+}
+
+export const RESPONSIBILITY_LABELS: Record<RuleResponsibility, string> = {
+    fixed: 'نضبطه لك',
+    verified: 'نتحقّق منه',
+    student: 'عليك أنت',
+};
+
+/** The university's published list, in its own order, for the teaching panel. */
+export const UNIVERSITY_RULES: RuleSummary[] = [
+    { text: 'نوع الملف JPG', responsibility: 'fixed' },
+    { text: 'حجم الملف لا يزيد عن 300 KB', responsibility: 'fixed' },
+    {
+        text: 'المقاس 3 سم عرضًا × 4 سم طولًا، والطول أكبر من العرض — بالبكسل: العرض من 120 إلى 360 والطول من 160 إلى 480 بنفس النسبة',
+        responsibility: 'fixed',
+    },
+    { text: 'الصورة واضحة جدًا وبجودة مناسبة ضمن الحجم المسموح', responsibility: 'verified' },
+    { text: 'الصورة ملوّنة', responsibility: 'verified' },
+    { text: 'الصورة حديثة ولا يزيد عمرها عن ستة (6) أشهر', responsibility: 'student' },
+    { text: 'الصورة بالزي الرسمي', responsibility: 'student' },
+    { text: 'الوجه ظاهر كاملًا، أي يقابل صاحب الصورة الكاميرا بشكل مباشر', responsibility: 'student' },
+    { text: 'الصورة غير ملصقة على أي أوراق أخرى', responsibility: 'student' },
+    { text: 'الصور بالنظارات الشمسية غير مقبولة', responsibility: 'student' },
+    { text: 'الصور المركّبة أو المعدّلة إلكترونيًا غير مقبولة', responsibility: 'student' },
+];
+
+/** The portal path the student follows after downloading the file. */
+export const UPLOAD_STEPS: string[] = [
+    'سجّل الدخول إلى موقع جامعة أم القرى',
+    'الخدمات الإلكترونية',
+    'خدمات أكاديمية',
+    'البوابة الأكاديمية',
+    'شخصي',
+    'رفع الصورة الشخصية للبطاقة الجامعية',
+];

--- a/resources/js/lib/studentPhoto/sniff.test.ts
+++ b/resources/js/lib/studentPhoto/sniff.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { isRasterType, sniffFileType } from './sniff';
+
+function bytes(...values: (number | string)[]): Uint8Array {
+    const flat: number[] = [];
+
+    for (const value of values) {
+        if (typeof value === 'number') {
+            flat.push(value);
+        } else {
+            for (const character of value) {
+                flat.push(character.charCodeAt(0));
+            }
+        }
+    }
+
+    return new Uint8Array(flat);
+}
+
+describe('sniffFileType', () => {
+    it('detects a JPEG', () => {
+        expect(sniffFileType(bytes(0xff, 0xd8, 0xff, 0xe0))).toBe('jpeg');
+    });
+
+    it('detects a PNG', () => {
+        expect(sniffFileType(bytes(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a))).toBe('png');
+    });
+
+    it('detects a GIF', () => {
+        expect(sniffFileType(bytes('GIF89a'))).toBe('gif');
+    });
+
+    it('detects a WebP but not a bare RIFF container', () => {
+        expect(sniffFileType(bytes('RIFF', 0, 0, 0, 0, 'WEBP'))).toBe('webp');
+        expect(sniffFileType(bytes('RIFF', 0, 0, 0, 0, 'WAVE'))).toBe('unknown');
+    });
+
+    it('detects HEIC/HEIF brands from the ftyp box', () => {
+        expect(sniffFileType(bytes(0, 0, 0, 0x18, 'ftyp', 'heic'))).toBe('heif');
+        expect(sniffFileType(bytes(0, 0, 0, 0x18, 'ftyp', 'mif1'))).toBe('heif');
+    });
+
+    it('detects AVIF and separates video containers', () => {
+        expect(sniffFileType(bytes(0, 0, 0, 0x18, 'ftyp', 'avif'))).toBe('avif');
+        expect(sniffFileType(bytes(0, 0, 0, 0x18, 'ftyp', 'isom'))).toBe('video');
+    });
+
+    it('detects the formats the browser cannot decode', () => {
+        expect(sniffFileType(bytes('%PDF-1.7'))).toBe('pdf');
+        expect(sniffFileType(bytes(0x49, 0x49, 0x2a, 0x00))).toBe('tiff');
+        expect(sniffFileType(bytes(0x4d, 0x4d, 0x00, 0x2a))).toBe('tiff');
+        expect(sniffFileType(bytes('<svg xmlns="http://www.w3.org/2000/svg">'))).toBe('svg');
+        expect(sniffFileType(bytes('<?xml version="1.0"?><svg>'))).toBe('svg');
+    });
+
+    it('detects a BMP', () => {
+        expect(sniffFileType(bytes('BM', 0, 0, 0, 0))).toBe('bmp');
+    });
+
+    it('treats an empty or unrecognised file as unknown', () => {
+        expect(sniffFileType(new Uint8Array())).toBe('unknown');
+        expect(sniffFileType(bytes(1, 2, 3, 4, 5, 6, 7, 8))).toBe('unknown');
+    });
+
+    it('reports which types are worth handing to the decoder', () => {
+        expect(isRasterType('jpeg')).toBe(true);
+        expect(isRasterType('heif')).toBe(true);
+        expect(isRasterType('pdf')).toBe(false);
+        expect(isRasterType('svg')).toBe(false);
+        expect(isRasterType('unknown')).toBe(false);
+    });
+});

--- a/resources/js/lib/studentPhoto/sniff.ts
+++ b/resources/js/lib/studentPhoto/sniff.ts
@@ -1,0 +1,97 @@
+/**
+ * Magic-byte file sniffing. The browser's `File.type` comes from the OS and
+ * lies often enough to matter here — an iPhone HEIC renamed to `.jpg` still
+ * arrives as `image/jpeg` — so the tool decides what it was actually handed by
+ * reading the header, and uses that to explain failures precisely.
+ */
+
+export type SniffedType = 'jpeg' | 'png' | 'gif' | 'webp' | 'bmp' | 'avif' | 'heif' | 'tiff' | 'svg' | 'pdf' | 'video' | 'unknown';
+
+/** Types the tool will hand to the browser decoder (HEIF/AVIF only decode on some browsers). */
+const RASTER_TYPES: SniffedType[] = ['jpeg', 'png', 'gif', 'webp', 'bmp', 'avif', 'heif'];
+
+export function isRasterType(type: SniffedType): boolean {
+    return RASTER_TYPES.includes(type);
+}
+
+const HEIF_BRANDS = ['heic', 'heix', 'hevc', 'hevx', 'heim', 'heis', 'hevm', 'hevs', 'mif1', 'msf1'];
+const AVIF_BRANDS = ['avif', 'avis'];
+
+function ascii(bytes: Uint8Array, start: number, length: number): string {
+    let out = '';
+
+    for (let index = start; index < start + length && index < bytes.length; index += 1) {
+        out += String.fromCharCode(bytes[index]);
+    }
+
+    return out;
+}
+
+function matches(bytes: Uint8Array, signature: number[]): boolean {
+    if (bytes.length < signature.length) {
+        return false;
+    }
+
+    return signature.every((byte, index) => bytes[index] === byte);
+}
+
+/**
+ * Identify a file from its leading bytes. Only the first ~64 bytes are read for
+ * binary formats; SVG needs a slightly wider text window because of comments
+ * and XML declarations before the root element.
+ */
+export function sniffFileType(bytes: Uint8Array): SniffedType {
+    if (bytes.length === 0) {
+        return 'unknown';
+    }
+
+    if (matches(bytes, [0xff, 0xd8, 0xff])) {
+        return 'jpeg';
+    }
+
+    if (matches(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+        return 'png';
+    }
+
+    if (ascii(bytes, 0, 4) === 'GIF8') {
+        return 'gif';
+    }
+
+    if (ascii(bytes, 0, 4) === 'RIFF' && ascii(bytes, 8, 4) === 'WEBP') {
+        return 'webp';
+    }
+
+    if (matches(bytes, [0x42, 0x4d])) {
+        return 'bmp';
+    }
+
+    if (matches(bytes, [0x49, 0x49, 0x2a, 0x00]) || matches(bytes, [0x4d, 0x4d, 0x00, 0x2a])) {
+        return 'tiff';
+    }
+
+    if (ascii(bytes, 4, 4) === 'ftyp') {
+        const brand = ascii(bytes, 8, 4).toLowerCase();
+
+        if (HEIF_BRANDS.includes(brand)) {
+            return 'heif';
+        }
+
+        if (AVIF_BRANDS.includes(brand)) {
+            return 'avif';
+        }
+
+        return 'video';
+    }
+
+    if (ascii(bytes, 0, 4) === '%PDF') {
+        return 'pdf';
+    }
+
+    const head = ascii(bytes, 0, Math.min(bytes.length, 512)).trimStart().toLowerCase();
+
+    if (head.startsWith('<svg') || (head.startsWith('<?xml') && head.includes('<svg'))) {
+        return 'svg';
+    }
+
+    return 'unknown';
+}

--- a/resources/js/pages/tools/StudentPhotoPage.vue
+++ b/resources/js/pages/tools/StudentPhotoPage.vue
@@ -1,0 +1,487 @@
+<script setup lang="ts">
+import DocsLayout from '@/components/layout/DocsLayout.vue';
+import PageHeader from '@/components/page/PageHeader.vue';
+import RichContentRenderer from '@/components/RichContentRenderer.vue';
+import SeoHead, { type SeoData } from '@/components/SeoHead.vue';
+import PhotoChecks from '@/components/tools/PhotoChecks.vue';
+import PhotoCropCanvas from '@/components/tools/PhotoCropCanvas.vue';
+import PhotoDropzone from '@/components/tools/PhotoDropzone.vue';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { formatFileSize, formatFullDate } from '@/lib/formatters';
+import type { PhotoMetrics } from '@/lib/studentPhoto/analysis';
+import { buildPhotoChecks, worstStatus, type PhotoCheck } from '@/lib/studentPhoto/checks';
+import { decodePhotoFile, PhotoDecodeError, type DecodedPhoto } from '@/lib/studentPhoto/decode';
+import { clampView, cropFromView, defaultView, maxZoom, rotateView, type CropView, type Size } from '@/lib/studentPhoto/geometry';
+import { buildWorkingImage, measureCrop, renderCroppedJpeg, type RenderedPhoto, type WorkingImage } from '@/lib/studentPhoto/render';
+import {
+    DEFAULT_OUTPUT_SIZE,
+    MANUAL_REQUIREMENTS,
+    OUTPUT_FILE_NAME,
+    OUTPUT_SIZE_PRESETS,
+    RESPONSIBILITY_LABELS,
+    UNIVERSITY_RULES,
+    UPLOAD_STEPS,
+    type OutputSizePreset,
+} from '@/lib/studentPhoto/requirements';
+import { Check, Download, RotateCcw, RotateCw, Undo2 } from 'lucide-vue-next';
+import { computed, onBeforeUnmount, ref, shallowRef, watch } from 'vue';
+import { toast } from 'vue-sonner';
+
+defineOptions({
+    layout: false,
+});
+
+interface Props {
+    page?: {
+        html_content: any;
+        title?: string;
+    };
+    hasContent?: boolean;
+    seo: SeoData;
+}
+
+withDefaults(defineProps<Props>(), {
+    hasContent: false,
+});
+
+/** Re-rendering on every pointer move would encode dozens of JPEGs a second. */
+const RENDER_DEBOUNCE_MS = 120;
+
+const decoded = shallowRef<DecodedPhoto | null>(null);
+const working = shallowRef<WorkingImage | null>(null);
+const rendered = shallowRef<RenderedPhoto | null>(null);
+const metrics = shallowRef<PhotoMetrics | null>(null);
+const view = ref<CropView | null>(null);
+const quarterTurns = ref(0);
+const outputSize = ref<OutputSizePreset>(DEFAULT_OUTPUT_SIZE);
+const previewUrl = ref<string | null>(null);
+const cropWidth = ref(0);
+const confirmed = ref<Record<string, boolean>>({});
+const showGuides = ref(true);
+const isDecoding = ref(false);
+const isRendering = ref(false);
+const errorMessage = ref<string | null>(null);
+
+/** Guards against an older render finishing after a newer one. */
+let renderToken = 0;
+let renderTimer: ReturnType<typeof setTimeout> | null = null;
+
+const workingSize = computed<Size>(() => ({ width: working.value?.width ?? 0, height: working.value?.height ?? 0 }));
+
+const checks = computed<PhotoCheck[]>(() => {
+    if (!rendered.value) {
+        return [];
+    }
+
+    return buildPhotoChecks({
+        outputWidth: rendered.value.width,
+        outputHeight: rendered.value.height,
+        outputBytes: rendered.value.bytes,
+        cropWidth: cropWidth.value,
+        metrics: metrics.value,
+        takenAt: decoded.value?.takenAt ?? null,
+        now: new Date(),
+    });
+});
+
+const summaryStatus = computed(() => worstStatus(checks.value));
+
+const failedChecks = computed(() => checks.value.filter((check) => check.status === 'fail'));
+const missingConfirmations = computed(() => MANUAL_REQUIREMENTS.filter((requirement) => confirmed.value[requirement.id] !== true));
+
+/** Null when the file is ready to download; otherwise the reason it is not. */
+const downloadBlockedReason = computed<string | null>(() => {
+    if (!rendered.value || !previewUrl.value) {
+        return 'اختر صورة أولًا.';
+    }
+
+    if (failedChecks.value.length > 0) {
+        return `لا تصلح للرفع بعد: ${failedChecks.value.map((check) => check.label).join('، ')}.`;
+    }
+
+    if (missingConfirmations.value.length > 0) {
+        return `أكّد الشروط المتبقية (${missingConfirmations.value.length}) قبل التنزيل.`;
+    }
+
+    return null;
+});
+
+const zoomCeiling = computed(() => (working.value ? maxZoom(workingSize.value) : 1));
+const canZoom = computed(() => zoomCeiling.value > 1.001);
+
+/** The slider is exponential so the low zoom levels stay controllable. */
+const zoomPercent = computed({
+    get: (): number => {
+        if (!view.value || !canZoom.value) {
+            return 0;
+        }
+
+        return Math.round((100 * Math.log(view.value.zoom)) / Math.log(zoomCeiling.value));
+    },
+    set: (percent: number): void => {
+        if (!view.value || !canZoom.value) {
+            return;
+        }
+
+        view.value = clampView({ ...view.value, zoom: zoomCeiling.value ** (percent / 100) }, workingSize.value);
+    },
+});
+
+const originalSummary = computed(() => {
+    if (!decoded.value || !working.value) {
+        return null;
+    }
+
+    return {
+        name: decoded.value.fileName,
+        dimensions: `${working.value.width} × ${working.value.height}`,
+        bytes: decoded.value.fileBytes,
+        takenAt: decoded.value.takenAt,
+        wasStraightened: decoded.value.orientation !== 1,
+    };
+});
+
+function releasePreview(): void {
+    if (previewUrl.value) {
+        URL.revokeObjectURL(previewUrl.value);
+        previewUrl.value = null;
+    }
+}
+
+function resetPhotoState(): void {
+    if (renderTimer) {
+        clearTimeout(renderTimer);
+        renderTimer = null;
+    }
+
+    renderToken += 1;
+    releasePreview();
+    decoded.value?.release();
+    decoded.value = null;
+    working.value = null;
+    rendered.value = null;
+    metrics.value = null;
+    view.value = null;
+    quarterTurns.value = 0;
+    cropWidth.value = 0;
+    confirmed.value = {};
+}
+
+async function loadFile(file: File): Promise<void> {
+    errorMessage.value = null;
+    isDecoding.value = true;
+
+    let nextPhoto: DecodedPhoto;
+
+    try {
+        nextPhoto = await decodePhotoFile(file);
+    } catch (error) {
+        // A file we could not open must not cost the student the photo they
+        // already have open and framed.
+        errorMessage.value = error instanceof PhotoDecodeError ? error.message : 'تعذّر فتح هذه الصورة. جرّب صورة أخرى بصيغة JPG أو PNG.';
+        isDecoding.value = false;
+
+        return;
+    }
+
+    try {
+        resetPhotoState();
+        decoded.value = nextPhoto;
+        working.value = buildWorkingImage(nextPhoto, 0);
+        view.value = defaultView({ width: working.value.width, height: working.value.height });
+
+        await refreshOutput();
+    } catch {
+        resetPhotoState();
+        errorMessage.value = 'تعذّر تجهيز الصورة داخل المتصفح. جرّب تحديث الصفحة أو متصفحًا آخر.';
+    } finally {
+        isDecoding.value = false;
+    }
+}
+
+async function refreshOutput(): Promise<void> {
+    if (!working.value || !view.value) {
+        return;
+    }
+
+    const token = ++renderToken;
+    const crop = cropFromView(view.value, workingSize.value);
+
+    cropWidth.value = crop.width;
+    isRendering.value = true;
+
+    try {
+        const measured = measureCrop(working.value, crop);
+        const result = await renderCroppedJpeg(working.value, crop, { width: outputSize.value.width, height: outputSize.value.height });
+
+        if (token !== renderToken) {
+            return;
+        }
+
+        releasePreview();
+        metrics.value = measured;
+        rendered.value = result;
+        previewUrl.value = URL.createObjectURL(result.blob);
+    } catch {
+        if (token === renderToken) {
+            errorMessage.value = 'تعذّر تجهيز الصورة داخل المتصفح. جرّب تحديث الصفحة أو متصفحًا آخر.';
+        }
+    } finally {
+        if (token === renderToken) {
+            isRendering.value = false;
+        }
+    }
+}
+
+function scheduleRefresh(): void {
+    if (renderTimer) {
+        clearTimeout(renderTimer);
+    }
+
+    renderTimer = setTimeout(() => {
+        renderTimer = null;
+        void refreshOutput();
+    }, RENDER_DEBOUNCE_MS);
+}
+
+function rotate(direction: 1 | -1): void {
+    if (!decoded.value || !working.value || !view.value) {
+        return;
+    }
+
+    const sizeBefore = { width: working.value.width, height: working.value.height };
+
+    quarterTurns.value = (quarterTurns.value + direction + 4) % 4;
+    working.value = buildWorkingImage(decoded.value, quarterTurns.value);
+    view.value = rotateView(view.value, sizeBefore, direction === 1 ? 1 : 3);
+
+    scheduleRefresh();
+}
+
+function resetFraming(): void {
+    if (!working.value) {
+        return;
+    }
+
+    view.value = defaultView(workingSize.value);
+    scheduleRefresh();
+}
+
+function download(): void {
+    if (!previewUrl.value || downloadBlockedReason.value) {
+        return;
+    }
+
+    const link = document.createElement('a');
+
+    link.href = previewUrl.value;
+    link.download = OUTPUT_FILE_NAME;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+
+    toast.success('نُزِّلت الصورة — ارفعها الآن من البوابة الأكاديمية');
+}
+
+function chooseSize(preset: OutputSizePreset): void {
+    outputSize.value = preset;
+    scheduleRefresh();
+}
+
+watch(view, scheduleRefresh);
+
+onBeforeUnmount(resetPhotoState);
+</script>
+
+<template>
+    <SeoHead :seo="seo" />
+    <DocsLayout>
+        <PageHeader title="صورة البطاقة الجامعية" icon="solar:camera-broken" />
+
+        <!-- Rich content from database -->
+        <div v-if="hasContent" class="typography mb-6">
+            <RichContentRenderer :content="page?.html_content" />
+        </div>
+
+        <div class="typography">
+            <Alert>
+                <AlertDescription>
+                    اضبط صورتك على شروط البطاقة الجامعية: قصّ بمقاس ٣ × ٤، وحفظ بصيغة JPG بحجم أقل من ٣٠٠ كيلوبايت. الأداة تعمل داخل متصفحك بالكامل —
+                    صورتك لا تُرفع لأي خادم — وهي تقصّ وتصغّر فقط ولا تعدّل ملامح الصورة، لأن الصور المعدّلة إلكترونيًا مرفوضة.
+                </AlertDescription>
+            </Alert>
+
+            <p v-if="errorMessage" class="!mb-4 rounded-lg bg-destructive/10 p-3 text-sm text-destructive">
+                {{ errorMessage }}
+            </p>
+
+            <!-- Empty state: teach the rules before asking for a file -->
+            <template v-if="!working">
+                <PhotoDropzone :busy="isDecoding" @select="loadFile" @reject="errorMessage = $event" />
+
+                <section class="!mt-6 space-y-3">
+                    <h2 class="!my-0 text-lg font-semibold">شروط الجامعة لصورة البطاقة</h2>
+
+                    <ul class="!my-0 space-y-2 !ps-0">
+                        <li v-for="rule in UNIVERSITY_RULES" :key="rule.text" class="flex items-start gap-2 text-sm">
+                            <Badge
+                                :variant="rule.responsibility === 'student' ? 'outline' : rule.responsibility === 'fixed' ? 'default' : 'secondary'"
+                                class="mt-0.5 shrink-0"
+                            >
+                                {{ RESPONSIBILITY_LABELS[rule.responsibility] }}
+                            </Badge>
+                            <span>{{ rule.text }}</span>
+                        </li>
+                    </ul>
+                </section>
+            </template>
+
+            <!-- Editing state -->
+            <div v-else class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+                <div class="space-y-3">
+                    <PhotoCropCanvas
+                        v-if="view"
+                        :working="working"
+                        :view="view"
+                        :show-guides="showGuides"
+                        @update:view="view = $event"
+                        @reset="resetFraming"
+                    />
+
+                    <div class="flex flex-wrap items-center gap-2">
+                        <Button type="button" variant="outline" size="sm" title="تدوير لليسار" @click="rotate(-1)">
+                            <RotateCcw class="size-4" />
+                            تدوير
+                        </Button>
+                        <Button type="button" variant="outline" size="sm" title="تدوير لليمين" @click="rotate(1)">
+                            <RotateCw class="size-4" />
+                            تدوير
+                        </Button>
+                        <Button type="button" variant="outline" size="sm" @click="resetFraming">
+                            <Undo2 class="size-4" />
+                            إعادة الضبط
+                        </Button>
+                        <Button type="button" variant="ghost" size="sm" @click="resetPhotoState">صورة أخرى</Button>
+                    </div>
+
+                    <div class="flex items-center gap-3">
+                        <Label for="zoom" class="shrink-0 text-sm">التكبير</Label>
+                        <input
+                            id="zoom"
+                            v-model.number="zoomPercent"
+                            type="range"
+                            min="0"
+                            max="100"
+                            step="1"
+                            class="h-2 w-full accent-primary"
+                            :disabled="!canZoom"
+                            :title="canZoom ? undefined : 'الصورة بالكاد تكفي للإطار، فلا مجال للتكبير'"
+                        />
+                    </div>
+
+                    <div class="flex items-center gap-2">
+                        <Switch id="guides" :model-value="showGuides" @update:model-value="showGuides = $event" />
+                        <Label for="guides" class="text-sm">إظهار دليل موضع الوجه والعينين</Label>
+                    </div>
+
+                    <p class="!my-0 text-xs text-muted-foreground">
+                        اسحب الصورة لتحريكها، وقرّب بإصبعين أو بعجلة الفأرة. من لوحة المفاتيح: الأسهم للتحريك، + و − للتكبير والتصغير، و ٠ لإعادة
+                        الضبط.
+                    </p>
+
+                    <p v-if="originalSummary" class="!my-0 text-xs text-muted-foreground">
+                        الأصل:
+                        <span dir="ltr" class="inline-block text-start">{{ originalSummary.name }}</span>
+                        — <span dir="ltr" class="inline-block tabular-nums">{{ originalSummary.dimensions }}</span> بكسل،
+                        <span dir="ltr" class="inline-block tabular-nums">{{ formatFileSize(originalSummary.bytes) }}</span>
+                        <template v-if="originalSummary.takenAt">، صُوّرت في {{ formatFullDate(originalSummary.takenAt) }}</template>
+                        <template v-if="originalSummary.wasStraightened">، وقد عُدِّل ميلانها تلقائيًا</template>
+                    </p>
+                </div>
+
+                <div class="space-y-4">
+                    <div class="space-y-2 rounded-xl border p-4">
+                        <h3 class="!my-0 text-base font-semibold">الناتج</h3>
+
+                        <div class="flex items-start gap-4">
+                            <img
+                                v-if="previewUrl"
+                                :src="previewUrl"
+                                alt="معاينة الصورة الناتجة"
+                                class="!my-0 rounded-md border bg-card"
+                                :width="Math.min(outputSize.width, 120)"
+                            />
+
+                            <div v-if="rendered" class="space-y-1 text-xs text-muted-foreground">
+                                <p class="!my-0">
+                                    <span dir="ltr" class="inline-block tabular-nums">{{ rendered.width }} × {{ rendered.height }}</span>
+                                    بكسل
+                                </p>
+                                <p class="!my-0">
+                                    <span dir="ltr" class="inline-block tabular-nums">{{ formatFileSize(rendered.bytes) }}</span>
+                                    بصيغة JPG
+                                </p>
+                                <p v-if="isRendering" class="!my-0">جارٍ التحديث…</p>
+                            </div>
+                        </div>
+
+                        <div class="space-y-1">
+                            <Label class="text-xs text-muted-foreground">مقاس الملف الناتج</Label>
+                            <div class="flex flex-wrap gap-2">
+                                <Button
+                                    v-for="preset in OUTPUT_SIZE_PRESETS"
+                                    :key="preset.label"
+                                    type="button"
+                                    size="sm"
+                                    :variant="preset.width === outputSize.width ? 'default' : 'outline'"
+                                    :title="preset.hint"
+                                    @click="chooseSize(preset)"
+                                >
+                                    <span dir="ltr" class="tabular-nums">{{ preset.label }}</span>
+                                </Button>
+                            </div>
+                        </div>
+
+                        <Button
+                            type="button"
+                            class="w-full"
+                            :disabled="downloadBlockedReason !== null"
+                            :title="downloadBlockedReason ?? 'تنزيل الصورة بصيغة JPG'"
+                            @click="download"
+                        >
+                            <Download class="size-4" />
+                            تنزيل الصورة
+                        </Button>
+
+                        <p v-if="downloadBlockedReason" class="!my-0 text-xs text-muted-foreground">{{ downloadBlockedReason }}</p>
+                        <p v-else class="!my-0 flex items-center gap-1 text-xs text-primary">
+                            <Check class="size-3.5" />
+                            جاهزة للرفع
+                        </p>
+                    </div>
+
+                    <div
+                        class="rounded-xl border p-4"
+                        :class="{
+                            'border-destructive/40': summaryStatus === 'fail',
+                            'border-amber-500/40': summaryStatus === 'warn',
+                        }"
+                    >
+                        <PhotoChecks :checks="checks" :confirmed="confirmed" @update:confirmed="confirmed = $event" />
+                    </div>
+                </div>
+            </div>
+
+            <section class="!mt-8 space-y-2">
+                <h2 class="!my-0 text-lg font-semibold">بعد التنزيل: أين ترفعها</h2>
+                <ol class="!my-0 !ps-5">
+                    <li v-for="step in UPLOAD_STEPS" :key="step">{{ step }}</li>
+                </ol>
+            </section>
+        </div>
+    </DocsLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ Route::middleware(CacheResponse::class)->group(function () {
     Route::get('/adwat/hasbh-almadl', [ToolController::class, 'gpaCalculator'])->name('tools.gpa-calculator');
     Route::get('/adwat/hasbh-altahwel', [ToolController::class, 'transferCalculator'])->name('tools.transfer-calculator');
     Route::get('/adwat/jdwal-alsawab', [ToolController::class, 'truthTable'])->name('tools.truth-table');
+    Route::get('/adwat/sorh-albtaqa', [ToolController::class, 'studentPhoto'])->name('tools.student-photo');
     Route::get('/adwat/alkhosousieen', [PrivateTutorController::class, 'index'])->name('tools.private-tutors');
 });
 

--- a/tests/Feature/PublicRoutesTest.php
+++ b/tests/Feature/PublicRoutesTest.php
@@ -104,6 +104,7 @@ it('renders each tool route with its backing page', function (string $uri, strin
     'transfer calculator' => ['/adwat/hasbh-altahwel', '/adwat/hasbh-altahwel', 'tools/TransferCalculatorPage'],
     'next reward' => ['/adwat/almkafa', '/adwat/almkafa', 'tools/NextRewardPage'],
     'truth table' => ['/adwat/jdwal-alsawab', '/adwat/jdwal-alsawab', 'tools/TruthTablePage'],
+    'student photo' => ['/adwat/sorh-albtaqa', '/adwat/sorh-albtaqa', 'tools/StudentPhotoPage'],
 ]);
 
 it('renders each tool route without a backing page using fallback seo', function (string $uri, string $component) {
@@ -122,6 +123,7 @@ it('renders each tool route without a backing page using fallback seo', function
     'transfer calculator' => ['/adwat/hasbh-altahwel', 'tools/TransferCalculatorPage'],
     'next reward' => ['/adwat/almkafa', 'tools/NextRewardPage'],
     'truth table' => ['/adwat/jdwal-alsawab', 'tools/TruthTablePage'],
+    'student photo' => ['/adwat/sorh-albtaqa', 'tools/StudentPhotoPage'],
 ]);
 
 it('renders the private tutors tool route', function () {


### PR DESCRIPTION
A new tool at `/adwat/sorh-albtaqa` that turns any photo a student has into one the academic portal accepts: cropped 3:4, JPG, under 300 KB. **Fully client-side** — the file never leaves the browser, no upload endpoint, no storage.

## The requirements, transcribed

From the university's own instruction sheet. All of them live in one place — `resources/js/lib/studentPhoto/requirements.ts` — and every preset, verdict, badge and piece of copy derives from it.

| Rule | Who handles it |
| --- | --- |
| File type JPG | tool sets it |
| ≤ 300 KB (targeted as 300,000 bytes, the stricter reading) | tool sets it |
| 3 cm × 4 cm, height > width; in pixels width 120–360, height 160–480, proportional | tool sets it |
| Very clear, good quality within the allowed size | tool verifies |
| Coloured | tool verifies |
| No older than 6 months | tool verifies when EXIF has a date, else student confirms |
| Official attire · full face to camera · no sunglasses · not pasted on paper · not composited or edited | student confirms |

## Privacy: the photo never leaves the device

This is an ID photo, so the guarantee is enforced rather than promised:

- No network API appears anywhere in the photo path. `privacy.test.ts` scans every file that touches the image for `fetch`, `XMLHttpRequest`, `sendBeacon`, `WebSocket`, `EventSource`, `axios`, the Inertia router, form submission, or an absolute URL — a call added later in an untested branch fails the suite the moment it is written.
- Verified in a real Chromium: with a photo loaded, zoomed, rotated, confirmed and downloaded, the only network activity after the file was chosen was **two `blob:` reads for the preview**. No request body anywhere, no websocket, and no request containing the file's bytes. The download arrives from a `blob:` URL as `student-card-photo.jpg`.
- The decode path reads the picked file only through `File.slice`, `createImageBitmap` and a local object URL; the render lives in an object URL that is revoked when replaced.

## What it does mechanically

Crops, rotates, resizes and encodes — nothing else. No retouching or background replacement, because electronically altered photos are rejected. Highest JPEG quality that fits under the byte ceiling (binary search on quality); the canvas is flattened to white first so a transparent PNG doesn't come out black.

## What it verifies and reports

Sharpness (Laplacian variance on a fixed-size sample, so a threshold means the same thing for an 8 MP or a 0.3 MP source), greyscale detection, exposure, whether the crop is being upscaled past the source's real resolution, and the EXIF capture date against the six-month rule. The download button stays disabled — with the reason written out — until nothing fails and every manual box is ticked.

## Robustness

- **Files identified by magic bytes**, not the OS mime type: a renamed HEIC gets the HEIC advice (iPhone → Settings → Camera → Formats → Most Compatible) instead of a generic failure. PDF, SVG, TIFF, video, empty and oversized files each get their own way out.
- **EXIF orientation applied by us, but only after probing the browser**: a two-pixel JPEG tagged as rotated reveals whether this engine honours `imageOrientation: 'none'`. That probe is what keeps a sideways phone photo from being rotated twice.
- **Decode ladder**: full bitmap → downscaled bitmap (the rescue for out-of-memory on huge photos) → `<img>` element.
- A file that fails to open no longer costs the student the photo they already have framed.
- The upright working copy is capped at 2400 px so panning stays smooth on an 8000 px photo; renders are debounced and token-guarded so a stale encode can't overwrite a newer one.

## Adjusting

A fixed 3:4 frame with the photo moving behind it: drag, wheel, two-finger pinch, zoom slider, quarter-turn rotation that carries the existing framing over, and keyboard arrows / `+` `−` / `0`. Passport-style head-and-eye-line guides on by default. Empty state teaches the rules before asking for a file; the portal path to upload it is listed after download.

## Tests and gates

- 98 new vitest cases: crop geometry and all eight orientations, EXIF read plus a write/read round-trip, pixel metrics, verdict rules, magic-byte sniffing, and the privacy scan. Full suite 238 passing.
- The new route joins the existing public-route matrix in `PublicRoutesTest` (13 passing).
- `vue-tsc` clean, eslint/prettier clean, `pint` clean, `npm run build:ssr` green.
- Driven in a real Chromium against the running app: landscape, 100 px-wide, greyscale and transparent-PNG sources plus a fake PDF, with no page errors — greyscale fails the colour rule, the tiny source raises the upscale warning, and the PDF is refused with guidance. Dark, light and 390 px layouts all checked.

The pre-existing 27 failures elsewhere in `php artisan test` (MCP admin, quiz date fixtures, welcome page) reproduce identically on an untouched checkout — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9TnP5fb53scAdFRry12xs