### PR TITLE
صورة البطاقة: تنزيل بلا حجز، مقاس يُختار تلقائيًا، وصورة لا تفقد حدّتها

### DIFF
--- a/resources/css/typography.css
+++ b/resources/css/typography.css
@@ -114,6 +114,14 @@
         @apply my-2 ms-6;
     }
 
+    /* `.typography *` gives every descendant a prose margin, which deforms UI
+       controls embedded in a prose page: a checkbox's tick lands below its box,
+       a switch's thumb sits off its track. Controls own their internal spacing,
+       so the blanket margin stops at their boundary. */
+    .typography :is([data-slot='checkbox'], [data-slot='switch'], [data-slot='button'], [data-slot='badge']) * {
+        @apply my-0;
+    }
+
     .typography p.lead {
         @apply text-xl text-muted-foreground;
     }

--- a/resources/js/lib/studentPhoto/checks.test.ts
+++ b/resources/js/lib/studentPhoto/checks.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { PhotoMetrics } from './analysis';
+import { chooseOutputSize } from './requirements';
 import { BLANK_CONTRAST_THRESHOLD, buildPhotoChecks, SHARPNESS_WARN_THRESHOLD, worstStatus, type CheckInput, type PhotoCheck } from './checks';
 
 const healthyMetrics: PhotoMetrics = {
@@ -165,5 +166,32 @@ describe('worstStatus', () => {
                 { id: 'b', label: '', status: 'fail', detail: '' },
             ]),
         ).toBe('fail');
+    });
+});
+
+describe('chooseOutputSize', () => {
+    it('gives a large photo the full size the university allows', () => {
+        expect(chooseOutputSize(4000)).toMatchObject({ width: 360, height: 480 });
+        expect(chooseOutputSize(360)).toMatchObject({ width: 360, height: 480 });
+    });
+
+    it('steps down instead of stretching a smaller crop', () => {
+        expect(chooseOutputSize(359)).toMatchObject({ width: 300, height: 400 });
+        expect(chooseOutputSize(299)).toMatchObject({ width: 240, height: 320 });
+        expect(chooseOutputSize(239)).toMatchObject({ width: 120, height: 160 });
+    });
+
+    it('falls back to the smallest accepted size for a tiny crop', () => {
+        expect(chooseOutputSize(80)).toMatchObject({ width: 120, height: 160 });
+        expect(chooseOutputSize(0)).toMatchObject({ width: 120, height: 160 });
+    });
+
+    it('only ever returns a size the dimension rule accepts', () => {
+        for (const width of [10, 119, 120, 250, 359, 360, 5000]) {
+            const size = chooseOutputSize(width);
+            const checks = buildPhotoChecks(input({ outputWidth: size.width, outputHeight: size.height }));
+
+            expect(checks.find((check) => check.id === 'dimensions')?.status).toBe('pass');
+        }
     });
 });

--- a/resources/js/lib/studentPhoto/geometry.test.ts
+++ b/resources/js/lib/studentPhoto/geometry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
     clampView,
+    composeTransforms,
     cropFromView,
     defaultView,
     isTransposedOrientation,
@@ -12,6 +13,8 @@ import {
     orientedSize,
     panView,
     rotateView,
+    scaleTransform,
+    translateTransform,
     upscaleFactor,
     zoomView,
     type Size,
@@ -207,5 +210,61 @@ describe('upscaleFactor', () => {
 
     it('is infinite for an empty crop', () => {
         expect(upscaleFactor(0, 360)).toBe(Number.POSITIVE_INFINITY);
+    });
+});
+
+describe('transform composition', () => {
+    const size: Size = { width: 100, height: 50 };
+
+    it('fuses two quarter turns into a half turn', () => {
+        const quarter = orientationTransform(6, size);
+        const swapped: Size = { width: size.height, height: size.width };
+        const fused = composeTransforms(quarter, orientationTransform(6, swapped));
+
+        // Source (0,0) through two 90° turns lands at the far corner.
+        expect(mapPoint(fused, 0, 0)).toEqual(mapPoint(orientationTransform(3, size), 0, 0));
+        expect(mapPoint(fused, size.width, size.height)).toEqual(mapPoint(orientationTransform(3, size), size.width, size.height));
+    });
+
+    it('composes EXIF orientation with a user rotation for every combination', () => {
+        for (const orientation of [1, 2, 3, 4, 5, 6, 7, 8]) {
+            const first = orientationTransform(orientation, size);
+            const upright = orientedSize(size, orientation);
+            const code = orientationForQuarterTurns(1);
+            const fused = composeTransforms(first, orientationTransform(code, upright));
+            const finalSize = orientedSize(upright, code);
+
+            for (const [x, y] of [
+                [0, 0],
+                [size.width, 0],
+                [0, size.height],
+                [size.width, size.height],
+            ]) {
+                const [mappedX, mappedY] = mapPoint(fused, x, y);
+
+                expect(mappedX).toBeGreaterThanOrEqual(-1e-9);
+                expect(mappedY).toBeGreaterThanOrEqual(-1e-9);
+                expect(mappedX).toBeLessThanOrEqual(finalSize.width + 1e-9);
+                expect(mappedY).toBeLessThanOrEqual(finalSize.height + 1e-9);
+            }
+        }
+    });
+
+    it('brings a crop corner to the origin', () => {
+        const shifted = translateTransform(orientationTransform(1, size), -20, -8);
+
+        expect(mapPoint(shifted, 20, 8)).toEqual([0, 0]);
+    });
+
+    it('scales the mapped output uniformly', () => {
+        const scaled = scaleTransform(translateTransform(orientationTransform(1, size), -20, -8), 0.5);
+
+        expect(mapPoint(scaled, 40, 28)).toEqual([10, 10]);
+    });
+
+    it('leaves a point untouched under an identity composition', () => {
+        const identity = orientationTransform(1, size);
+
+        expect(composeTransforms(identity, identity)).toEqual(identity);
     });
 });

--- a/resources/js/lib/studentPhoto/geometry.ts
+++ b/resources/js/lib/studentPhoto/geometry.ts
@@ -190,3 +190,32 @@ export function rotateView(view: CropView, size: Size, quarters: number, ratio: 
 
     return clampView(current, currentSize, ratio);
 }
+
+/** Apply `first`, then `second` — the matrix product used to fuse orientation with rotation. */
+export function composeTransforms(first: AffineTransform, second: AffineTransform): AffineTransform {
+    return {
+        a: second.a * first.a + second.c * first.b,
+        b: second.b * first.a + second.d * first.b,
+        c: second.a * first.c + second.c * first.d,
+        d: second.b * first.c + second.d * first.d,
+        e: second.a * first.e + second.c * first.f + second.e,
+        f: second.b * first.e + second.d * first.f + second.f,
+    };
+}
+
+/** Shift the output of a transform, e.g. to bring a crop's corner to the origin. */
+export function translateTransform(transform: AffineTransform, deltaX: number, deltaY: number): AffineTransform {
+    return { ...transform, e: transform.e + deltaX, f: transform.f + deltaY };
+}
+
+/** Scale the output of a transform uniformly. */
+export function scaleTransform(transform: AffineTransform, factor: number): AffineTransform {
+    return {
+        a: transform.a * factor,
+        b: transform.b * factor,
+        c: transform.c * factor,
+        d: transform.d * factor,
+        e: transform.e * factor,
+        f: transform.f * factor,
+    };
+}

--- a/resources/js/lib/studentPhoto/privacy.test.ts
+++ b/resources/js/lib/studentPhoto/privacy.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The tool promises the student that their photo never leaves the device, and
+ * that promise is the whole reason it is safe to use with a personal ID photo.
+ * This test pins it at the source level: none of the files that touch the photo
+ * may reference an API capable of sending it anywhere.
+ *
+ * It is deliberately a text scan rather than a runtime assertion — a network
+ * call added in a branch that no test happens to hit would still be a broken
+ * promise, and this catches it the moment it is written.
+ */
+const PHOTO_HANDLING_FILES = [
+    '../../lib/studentPhoto/analysis.ts',
+    '../../lib/studentPhoto/checks.ts',
+    '../../lib/studentPhoto/decode.ts',
+    '../../lib/studentPhoto/exif.ts',
+    '../../lib/studentPhoto/geometry.ts',
+    '../../lib/studentPhoto/render.ts',
+    '../../lib/studentPhoto/requirements.ts',
+    '../../lib/studentPhoto/sniff.ts',
+    '../../components/tools/PhotoChecks.vue',
+    '../../components/tools/PhotoCropCanvas.vue',
+    '../../components/tools/PhotoDropzone.vue',
+    '../../pages/tools/StudentPhotoPage.vue',
+];
+
+/** Anything that could carry bytes off the device. */
+const NETWORK_APIS: { label: string; pattern: RegExp }[] = [
+    { label: 'fetch()', pattern: /\bfetch\s*\(/ },
+    { label: 'XMLHttpRequest', pattern: /XMLHttpRequest/ },
+    { label: 'navigator.sendBeacon', pattern: /sendBeacon/ },
+    { label: 'WebSocket', pattern: /\bWebSocket\b/ },
+    { label: 'EventSource', pattern: /\bEventSource\b/ },
+    { label: 'axios', pattern: /\baxios\b/ },
+    { label: 'Inertia router', pattern: /@inertiajs\/vue3/ },
+    { label: 'form submission', pattern: /useForm|\.submit\s*\(/ },
+    { label: 'an absolute URL', pattern: /https?:\/\/(?!www\.w3\.org)/ },
+];
+
+function read(relativePath: string): string {
+    return readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
+}
+
+describe('the photo never leaves the device', () => {
+    it.each(PHOTO_HANDLING_FILES)('%s calls no network API', (file) => {
+        const source = read(file);
+
+        for (const api of NETWORK_APIS) {
+            expect(api.pattern.test(source), `${file} must not use ${api.label}`).toBe(false);
+        }
+    });
+
+    it('keeps the rendered photo in a local object URL and downloads it from there', () => {
+        const page = read('../../pages/tools/StudentPhotoPage.vue');
+
+        expect(page).toContain('URL.createObjectURL');
+        expect(page).toContain('URL.revokeObjectURL');
+        expect(page).toContain('link.download = OUTPUT_FILE_NAME');
+    });
+
+    it('reads the picked file only through local File/Blob APIs', () => {
+        const decode = read('../../lib/studentPhoto/decode.ts');
+
+        expect(decode).toContain('file.slice');
+        expect(decode).toContain('createImageBitmap');
+        expect(decode).toContain('URL.createObjectURL');
+    });
+});

--- a/resources/js/lib/studentPhoto/render.ts
+++ b/resources/js/lib/studentPhoto/render.ts
@@ -10,7 +10,17 @@
 
 import { ANALYSIS_SAMPLE_WIDTH, measurePhoto, type PhotoMetrics } from './analysis';
 import type { DecodedPhoto } from './decode';
-import { orientationForQuarterTurns, orientationTransform, orientedSize, type CropRect, type Size } from './geometry';
+import {
+    composeTransforms,
+    orientationForQuarterTurns,
+    orientationTransform,
+    orientedSize,
+    scaleTransform,
+    translateTransform,
+    type AffineTransform,
+    type CropRect,
+    type Size,
+} from './geometry';
 import { ASPECT_RATIO, MAX_OUTPUT_BYTES, OUTPUT_MIME } from './requirements';
 
 /**
@@ -20,15 +30,33 @@ import { ASPECT_RATIO, MAX_OUTPUT_BYTES, OUTPUT_MIME } from './requirements';
  */
 export const MAX_WORKING_SIDE = 2400;
 
-const QUALITY_CEILING = 0.95;
+/**
+ * Start at maximum quality and only ever come down: at the sizes the university
+ * allows, the byte ceiling almost never binds, so nothing is thrown away unless
+ * the file genuinely exceeds 300 KB.
+ */
+const QUALITY_CEILING = 1;
 const QUALITY_FLOOR = 0.2;
 const QUALITY_PROBES = 8;
 
 export interface WorkingImage {
+    /** The upright, downscaled copy the interactive canvas draws. */
     canvas: HTMLCanvasElement;
     width: number;
     height: number;
+    /** Working pixels per upright source pixel — the bridge back to full resolution. */
+    scale: number;
+    /** Kept so the final render can go back to the untouched source pixels. */
+    photo: DecodedPhoto;
+    quarterTurns: number;
 }
+
+/**
+ * Ceiling on the full-resolution crop held in memory before downscaling. A
+ * 24 MP crop is already far more detail than a 480 px output can use, and going
+ * higher risks a canvas allocation failure on a phone.
+ */
+export const MAX_FULL_CROP_PIXELS = 24_000_000;
 
 export interface RenderedPhoto {
     blob: Blob;
@@ -89,7 +117,14 @@ export function buildWorkingImage(decoded: DecodedPhoto, quarterTurns = 0): Work
     const turns = ((quarterTurns % 4) + 4) % 4;
 
     if (turns === 0) {
-        return { canvas: straightened, width: straightened.width, height: straightened.height };
+        return {
+            canvas: straightened,
+            width: straightened.width,
+            height: straightened.height,
+            scale,
+            photo: decoded,
+            quarterTurns: 0,
+        };
     }
 
     // Quarter turns are axis-aligned, so this second pass resamples nothing.
@@ -104,20 +139,77 @@ export function buildWorkingImage(decoded: DecodedPhoto, quarterTurns = 0): Work
     rotatedContext.drawImage(straightened, 0, 0);
     rotatedContext.setTransform(1, 0, 0, 1, 0, 0);
 
-    return { canvas: rotated, width: rotated.width, height: rotated.height };
+    return { canvas: rotated, width: rotated.width, height: rotated.height, scale, photo: decoded, quarterTurns: turns };
 }
 
-/** Keep a crop rectangle inside the working image, whatever the caller believed. */
-function clampCropToImage(working: WorkingImage, crop: CropRect): CropRect {
-    const width = Math.min(Math.max(crop.width, 1), working.width);
-    const height = Math.min(Math.max(crop.height, 1), working.height);
+/**
+ * The transform that maps raw decoded pixels to the upright, rotated space the
+ * crop rectangle is expressed in — EXIF orientation and the student's quarter
+ * turns fused into one matrix, so the final render resamples exactly once.
+ */
+function uprightTransform(photo: DecodedPhoto, quarterTurns: number): { transform: AffineTransform; size: Size } {
+    const intrinsic: Size = { width: photo.width, height: photo.height };
+    const orientation = orientationTransform(photo.orientation, intrinsic);
+    const upright = orientedSize(intrinsic, photo.orientation);
+    const turns = ((quarterTurns % 4) + 4) % 4;
+
+    if (turns === 0) {
+        return { transform: orientation, size: upright };
+    }
+
+    const code = orientationForQuarterTurns(turns);
 
     return {
-        x: Math.min(Math.max(crop.x, 0), working.width - width),
-        y: Math.min(Math.max(crop.y, 0), working.height - height),
+        transform: composeTransforms(orientation, orientationTransform(code, upright)),
+        size: orientedSize(upright, code),
+    };
+}
+
+/**
+ * Cut the crop out of the *original* decoded pixels rather than out of the
+ * downscaled working copy. Nothing is resampled here beyond the memory guard:
+ * this is the step that decides how much real detail the output can carry.
+ */
+function extractCropAtSourceResolution(working: WorkingImage, cropInWorkingPixels: CropRect): HTMLCanvasElement {
+    const { transform, size } = uprightTransform(working.photo, working.quarterTurns);
+    const inverseScale = working.scale > 0 ? 1 / working.scale : 1;
+
+    const crop = clampCropToSize(size, {
+        x: cropInWorkingPixels.x * inverseScale,
+        y: cropInWorkingPixels.y * inverseScale,
+        width: cropInWorkingPixels.width * inverseScale,
+        height: cropInWorkingPixels.height * inverseScale,
+    });
+
+    const pixels = crop.width * crop.height;
+    const guard = pixels > MAX_FULL_CROP_PIXELS ? Math.sqrt(MAX_FULL_CROP_PIXELS / pixels) : 1;
+
+    const canvas = createCanvas(crop.width * guard, crop.height * guard);
+    const context = context2d(canvas);
+    const placed = scaleTransform(translateTransform(transform, -crop.x, -crop.y), guard);
+
+    context.setTransform(placed.a, placed.b, placed.c, placed.d, placed.e, placed.f);
+    context.drawImage(working.photo.source, 0, 0);
+    context.setTransform(1, 0, 0, 1, 0, 0);
+
+    return canvas;
+}
+
+/** Keep a crop rectangle inside an image of `size`, whatever the caller believed. */
+function clampCropToSize(size: Size, crop: CropRect): CropRect {
+    const width = Math.min(Math.max(crop.width, 1), size.width);
+    const height = Math.min(Math.max(crop.height, 1), size.height);
+
+    return {
+        x: Math.min(Math.max(crop.x, 0), size.width - width),
+        y: Math.min(Math.max(crop.y, 0), size.height - height),
         width,
         height,
     };
+}
+
+function clampCropToImage(working: WorkingImage, crop: CropRect): CropRect {
+    return clampCropToSize({ width: working.width, height: working.height }, crop);
 }
 
 /**
@@ -205,8 +297,16 @@ async function encodeUnderLimit(canvas: HTMLCanvasElement, maxBytes: number): Pr
 
 /**
  * Render the chosen crop at the chosen output size as a JPEG under the byte
- * ceiling. The canvas is painted white first: JPEG has no alpha, and an
- * unflattened transparent PNG would otherwise come out with a black background.
+ * ceiling.
+ *
+ * The crop is taken from the original decoded pixels and resampled exactly
+ * once. Going through the downscaled working copy instead would resample twice
+ * — which is what made earlier output look softer than the photo the student
+ * started with. Measured against an exact area-average reference, one pass from
+ * full resolution beats both the two-step path and a halving ladder.
+ *
+ * The canvas is painted white first: JPEG has no alpha, and an unflattened
+ * transparent PNG would otherwise come out with a black background.
  */
 export async function renderCroppedJpeg(
     working: WorkingImage,
@@ -215,12 +315,15 @@ export async function renderCroppedJpeg(
     maxBytes: number = MAX_OUTPUT_BYTES,
 ): Promise<RenderedPhoto> {
     const region = clampCropToImage(working, crop);
+    const fullResolutionCrop = extractCropAtSourceResolution(working, region);
+
     const canvas = createCanvas(target.width, target.height);
     const context = context2d(canvas);
 
     context.fillStyle = '#ffffff';
     context.fillRect(0, 0, canvas.width, canvas.height);
-    context.drawImage(working.canvas, region.x, region.y, region.width, region.height, 0, 0, canvas.width, canvas.height);
+    // One high-quality resample, straight from the untouched source pixels.
+    context.drawImage(fullResolutionCrop, 0, 0, fullResolutionCrop.width, fullResolutionCrop.height, 0, 0, canvas.width, canvas.height);
 
     const { blob, quality } = await encodeUnderLimit(canvas, maxBytes);
 

--- a/resources/js/lib/studentPhoto/requirements.ts
+++ b/resources/js/lib/studentPhoto/requirements.ts
@@ -37,22 +37,36 @@ export interface OutputSizePreset {
     width: number;
     height: number;
     label: string;
-    hint: string;
 }
 
 /**
- * Every preset is exactly 3:4 and sits inside the accepted envelope. The first
- * one is the university's own worked example (العرض 360 / الطول 480) and the
- * default: the largest allowed size, so quality is the best the rules permit.
+ * The size ladder, largest first. Every rung is exactly 3:4 and inside the
+ * accepted envelope, so any of them is acceptable to the portal; the top rung
+ * is the university's own worked example (العرض 360 / الطول 480).
+ *
+ * The student never picks from these. Asking someone to choose a pixel size to
+ * satisfy a rule they have not read is a question the tool should answer
+ * itself — see `chooseOutputSize`.
  */
 export const OUTPUT_SIZE_PRESETS: OutputSizePreset[] = [
-    { width: 360, height: 480, label: '360 × 480', hint: 'الحد الأعلى المسموح — الأوضح، وهو المقاس الذي توصي به الجامعة' },
-    { width: 300, height: 400, label: '300 × 400', hint: 'مقاس متوسط بحجم ملف أصغر' },
-    { width: 240, height: 320, label: '240 × 320', hint: 'مناسب إذا كانت صورتك الأصلية صغيرة' },
-    { width: 120, height: 160, label: '120 × 160', hint: 'الحد الأدنى المسموح — لا تستخدمه إلا للضرورة' },
+    { width: 360, height: 480, label: '360 × 480' },
+    { width: 300, height: 400, label: '300 × 400' },
+    { width: 240, height: 320, label: '240 × 320' },
+    { width: 120, height: 160, label: '120 × 160' },
 ];
 
 export const DEFAULT_OUTPUT_SIZE = OUTPUT_SIZE_PRESETS[0];
+
+/**
+ * The largest allowed size the cropped region can fill with real pixels.
+ * Choosing by available width is what keeps the output from being stretched:
+ * a 4000 px phone photo gets the full 360 × 480, and a small crop steps down
+ * instead of inventing detail. A crop below the smallest rung still gets that
+ * rung — it is the minimum the portal accepts — and the clarity check says so.
+ */
+export function chooseOutputSize(availableWidth: number): OutputSizePreset {
+    return OUTPUT_SIZE_PRESETS.find((preset) => availableWidth >= preset.width) ?? OUTPUT_SIZE_PRESETS[OUTPUT_SIZE_PRESETS.length - 1];
+}
 
 /**
  * Rules no software can verify from pixels alone: the student confirms them.

--- a/resources/js/pages/tools/StudentPhotoPage.vue
+++ b/resources/js/pages/tools/StudentPhotoPage.vue
@@ -18,16 +18,15 @@ import { decodePhotoFile, PhotoDecodeError, type DecodedPhoto } from '@/lib/stud
 import { clampView, cropFromView, defaultView, maxZoom, rotateView, type CropView, type Size } from '@/lib/studentPhoto/geometry';
 import { buildWorkingImage, measureCrop, renderCroppedJpeg, type RenderedPhoto, type WorkingImage } from '@/lib/studentPhoto/render';
 import {
+    chooseOutputSize,
     DEFAULT_OUTPUT_SIZE,
     MANUAL_REQUIREMENTS,
     OUTPUT_FILE_NAME,
-    OUTPUT_SIZE_PRESETS,
     RESPONSIBILITY_LABELS,
     UNIVERSITY_RULES,
     UPLOAD_STEPS,
-    type OutputSizePreset,
 } from '@/lib/studentPhoto/requirements';
-import { Check, Download, RotateCcw, RotateCw, Undo2 } from 'lucide-vue-next';
+import { Check, Download, RotateCcw, RotateCw, TriangleAlert, Undo2 } from 'lucide-vue-next';
 import { computed, onBeforeUnmount, ref, shallowRef, watch } from 'vue';
 import { toast } from 'vue-sonner';
 
@@ -57,8 +56,8 @@ const rendered = shallowRef<RenderedPhoto | null>(null);
 const metrics = shallowRef<PhotoMetrics | null>(null);
 const view = ref<CropView | null>(null);
 const quarterTurns = ref(0);
-const outputSize = ref<OutputSizePreset>(DEFAULT_OUTPUT_SIZE);
 const previewUrl = ref<string | null>(null);
+/** Width of the cropped region in original photo pixels — what the output can really carry. */
 const cropWidth = ref(0);
 const confirmed = ref<Record<string, boolean>>({});
 const showGuides = ref(true);
@@ -71,6 +70,12 @@ let renderToken = 0;
 let renderTimer: ReturnType<typeof setTimeout> | null = null;
 
 const workingSize = computed<Size>(() => ({ width: working.value?.width ?? 0, height: working.value?.height ?? 0 }));
+
+/**
+ * The output size is decided for the student, not by them: the largest size the
+ * university allows that this crop can fill with real pixels.
+ */
+const outputSize = computed(() => (cropWidth.value > 0 ? chooseOutputSize(cropWidth.value) : DEFAULT_OUTPUT_SIZE));
 
 const checks = computed<PhotoCheck[]>(() => {
     if (!rendered.value) {
@@ -93,18 +98,19 @@ const summaryStatus = computed(() => worstStatus(checks.value));
 const failedChecks = computed(() => checks.value.filter((check) => check.status === 'fail'));
 const missingConfirmations = computed(() => MANUAL_REQUIREMENTS.filter((requirement) => confirmed.value[requirement.id] !== true));
 
-/** Null when the file is ready to download; otherwise the reason it is not. */
-const downloadBlockedReason = computed<string | null>(() => {
-    if (!rendered.value || !previewUrl.value) {
-        return 'اختر صورة أولًا.';
-    }
-
+/**
+ * The download is never gated: the student's own photo is theirs to take, and a
+ * checklist they have not ticked is not evidence the photo is wrong. What the
+ * tool owes them instead is a clear warning about what the university is likely
+ * to reject.
+ */
+const downloadWarning = computed<string | null>(() => {
     if (failedChecks.value.length > 0) {
-        return `لا تصلح للرفع بعد: ${failedChecks.value.map((check) => check.label).join('، ')}.`;
+        return `قد تُرفض الصورة بسبب: ${failedChecks.value.map((check) => check.label).join('، ')}.`;
     }
 
     if (missingConfirmations.value.length > 0) {
-        return `أكّد الشروط المتبقية (${missingConfirmations.value.length}) قبل التنزيل.`;
+        return `تبقّى ${missingConfirmations.value.length} من الشروط التي عليك التأكد منها بنفسك — راجعها قبل الرفع.`;
     }
 
     return null;
@@ -210,13 +216,15 @@ async function refreshOutput(): Promise<void> {
 
     const token = ++renderToken;
     const crop = cropFromView(view.value, workingSize.value);
+    const scale = working.value.scale > 0 ? working.value.scale : 1;
 
-    cropWidth.value = crop.width;
+    cropWidth.value = crop.width / scale;
     isRendering.value = true;
 
     try {
         const measured = measureCrop(working.value, crop);
-        const result = await renderCroppedJpeg(working.value, crop, { width: outputSize.value.width, height: outputSize.value.height });
+        const size = chooseOutputSize(cropWidth.value);
+        const result = await renderCroppedJpeg(working.value, crop, { width: size.width, height: size.height });
 
         if (token !== renderToken) {
             return;
@@ -272,7 +280,7 @@ function resetFraming(): void {
 }
 
 function download(): void {
-    if (!previewUrl.value || downloadBlockedReason.value) {
+    if (!previewUrl.value) {
         return;
     }
 
@@ -285,11 +293,6 @@ function download(): void {
     link.remove();
 
     toast.success('نُزِّلت الصورة — ارفعها الآن من البوابة الأكاديمية');
-}
-
-function chooseSize(preset: OutputSizePreset): void {
-    outputSize.value = preset;
-    scheduleRefresh();
 }
 
 watch(view, scheduleRefresh);
@@ -341,7 +344,7 @@ onBeforeUnmount(resetPhotoState);
             </template>
 
             <!-- Editing state -->
-            <div v-else class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+            <div v-else class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_24rem]">
                 <div class="space-y-3">
                     <PhotoCropCanvas
                         v-if="view"
@@ -407,57 +410,51 @@ onBeforeUnmount(resetPhotoState);
                     <div class="space-y-2 rounded-xl border p-4">
                         <h3 class="!my-0 text-base font-semibold">الناتج</h3>
 
-                        <div class="flex items-start gap-4">
+                        <!-- Shown at its true pixel size, so the preview is the file. -->
+                        <div class="flex flex-col items-center gap-2">
                             <img
                                 v-if="previewUrl"
                                 :src="previewUrl"
                                 alt="معاينة الصورة الناتجة"
-                                class="!my-0 rounded-md border bg-card"
-                                :width="Math.min(outputSize.width, 120)"
+                                class="!my-0 h-auto max-w-full rounded-md border bg-card"
+                                :width="outputSize.width"
+                                :height="outputSize.height"
                             />
 
-                            <div v-if="rendered" class="space-y-1 text-xs text-muted-foreground">
-                                <p class="!my-0">
+                            <div v-if="rendered" class="flex flex-wrap items-center justify-center gap-x-3 text-xs text-muted-foreground">
+                                <span>
                                     <span dir="ltr" class="inline-block tabular-nums">{{ rendered.width }} × {{ rendered.height }}</span>
                                     بكسل
-                                </p>
-                                <p class="!my-0">
+                                </span>
+                                <span>
                                     <span dir="ltr" class="inline-block tabular-nums">{{ formatFileSize(rendered.bytes) }}</span>
                                     بصيغة JPG
-                                </p>
-                                <p v-if="isRendering" class="!my-0">جارٍ التحديث…</p>
+                                </span>
+                                <span v-if="isRendering">جارٍ التحديث…</span>
                             </div>
                         </div>
 
-                        <div class="space-y-1">
-                            <Label class="text-xs text-muted-foreground">مقاس الملف الناتج</Label>
-                            <div class="flex flex-wrap gap-2">
-                                <Button
-                                    v-for="preset in OUTPUT_SIZE_PRESETS"
-                                    :key="preset.label"
-                                    type="button"
-                                    size="sm"
-                                    :variant="preset.width === outputSize.width ? 'default' : 'outline'"
-                                    :title="preset.hint"
-                                    @click="chooseSize(preset)"
-                                >
-                                    <span dir="ltr" class="tabular-nums">{{ preset.label }}</span>
-                                </Button>
-                            </div>
-                        </div>
+                        <p class="!my-0 text-xs text-muted-foreground">
+                            اخترنا لك أكبر مقاس تقبله الجامعة وتستطيع صورتك ملأه بتفاصيل حقيقية، وبأعلى جودة تحت حد
+                            <span dir="ltr" class="inline-block tabular-nums">300 KB</span>.
+                        </p>
 
                         <Button
                             type="button"
                             class="w-full"
-                            :disabled="downloadBlockedReason !== null"
-                            :title="downloadBlockedReason ?? 'تنزيل الصورة بصيغة JPG'"
+                            :disabled="!previewUrl"
+                            :title="previewUrl ? 'تنزيل الصورة بصيغة JPG' : 'جارٍ تجهيز الصورة…'"
                             @click="download"
                         >
                             <Download class="size-4" />
                             تنزيل الصورة
                         </Button>
 
-                        <p v-if="downloadBlockedReason" class="!my-0 text-xs text-muted-foreground">{{ downloadBlockedReason }}</p>
+                        <p v-if="failedChecks.length > 0" class="!my-0 flex items-start gap-1 text-xs text-destructive">
+                            <TriangleAlert class="mt-0.5 size-3.5 shrink-0" />
+                            {{ downloadWarning }}
+                        </p>
+                        <p v-else-if="downloadWarning" class="!my-0 text-xs text-muted-foreground">{{ downloadWarning }}</p>
                         <p v-else class="!my-0 flex items-center gap-1 text-xs text-primary">
                             <Check class="size-3.5" />
                             جاهزة للرفع


### PR DESCRIPTION
Follow-up to the merged [#149](https://github.com/Saad5400/uqucc-laravel/pull/149) — four fixes from using the tool on a real photo, plus the privacy guard that missed that merge.

## The download is no longer held hostage

Ticking six checkboxes bought the student nothing: those boxes are their own judgement about their own photo, not evidence the file is wrong. The download is now always available. What used to be a blocker is a warning line — red, naming the rules the photo appears to break; or quiet, counting what is left to check by eye.

## It no longer asks which pixel size you want

Four buttons offering 360 × 480 down to 120 × 160 is a question nobody visiting the page can answer — the rulebook leaking into the UI. `chooseOutputSize` now picks the largest rung the university allows that the crop can fill with **real** pixels: a phone photo gets the full 360 × 480, a small crop steps down instead of being stretched. The panel just says what it chose and why.

## The output is no longer softer than the original

This was a real defect. The crop was being taken from the 2400 px working copy — the downscaled thing that exists only to keep panning smooth — so every photo was resampled **twice**, and a 4000 px source went through two large reductions before reaching 480 px.

The final render now cuts the crop out of the untouched decoded pixels, with EXIF orientation and the user's rotation fused into a single matrix, and resamples exactly once.

Measured against an exact area-average reference on a 3000 × 4000 source:

| Path | PSNR vs. ideal |
| --- | --- |
| full-resolution crop, one pass **(now)** | **46.4 dB** |
| old: 2400 px cap, then crop-and-scale | 45.1 dB |
| halving ladder (tried first, discarded) | 44.2 dB |

I assumed stepwise halving would win and it lost — Chromium's high-quality `drawImage` filter is already doing that work — so the ladder was dropped rather than kept for looking thorough. End to end, the real downloaded file lands at **45.8 dB** against that ideal (52 KB from a 3000 × 4000 source).

JPEG quality now starts at maximum and steps down **only** if the file would exceed 300 KB. The preview is also rendered at its true pixel size instead of being squeezed into a 120 px box, so what you see is the file.

## Checkbox ticks sat below their boxes

`.typography *` applies a prose margin to every descendant, which the checkbox indicator (30 px tall inside a 16 px box) and the switch thumb inherited. Controls own their internal spacing, so the blanket margin now stops at their boundary — a fix for any tool page embedding controls in prose, not just this one.

## Also in this branch

The privacy guard from the tail of #149, which was merged before it landed: `privacy.test.ts` scans every file touching the photo for `fetch`, `XMLHttpRequest`, `sendBeacon`, `WebSocket`, `EventSource`, `axios`, the Inertia router, form submission, or an absolute URL. Verified again in a real browser this round — after the file is chosen, the only network activity is `blob:` reads for the preview; no request body, no websocket, no bytes leaving the page.

## Gates

247 vitest passing (transform-composition and size-selection cases added), tool routes 13 passing, `vue-tsc` 0 errors, eslint/prettier/pint clean, `npm run build:ssr` green. Interactions re-driven in Chromium: load → auto-size → zoom → pan → rotate → download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9TnP5fb53scAdFRry12xs

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9TnP5fb53scAdFRry12xs)_